### PR TITLE
Cache build artifacts on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: '*'
   pull_request:
     branches: [ main ]
 
@@ -25,6 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: cache-build-artifacts
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: cargo-bpf-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          cargo-bpf-${{ hashFiles('Cargo.lock') }}
+          cargo-bpf
+
     - name: Solana contract test
       run: |
         cd program
@@ -37,8 +47,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: cache-build-artifacts
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: cargo-clippy-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          cargo-clippy-${{ hashFiles('Cargo.lock') }}
+          cargo-clippy
+
     - name: install-clippy
       run: rustup component add clippy
+
     - name: run-clippy
       run: |
         sudo apt-get install -y libudev-dev


### PR DESCRIPTION
Solana and dependencies pull in more than 500 crates. Rebuilding all of those twice for every CI run is a bit wasteful, instead we can cache them to reduce build time at the expense of some storage space and bandwidth.

This reduces the build time for the `build` step from ~9.5 minutes to ~4 minutes, and build time for the `clippy` step from ~5.5 minutes to ~2 minutes, and thereby the wall clock build time from ~9.5 minutes to ~4.5 minutes.