### PR TITLE
Restructure `solido` output to use structs

### DIFF
--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -8,10 +8,14 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use spl_stake_pool::state::Fee;
+use std::fmt;
 
-use crate::{stake_pool_helpers::command_create_pool, CommandResult, Config, Error};
+use crate::{
+    stake_pool_helpers::{command_create_pool, CreatePoolOutput},
+    Config, Error,
+};
 
-pub(crate) fn check_fee_payer_balance(config: &Config, required_balance: u64) -> Result<(), Error> {
+pub fn check_fee_payer_balance(config: &Config, required_balance: u64) -> Result<(), Error> {
     let balance = config.rpc_client.get_balance(&config.fee_payer.pubkey())?;
     if balance < required_balance {
         Err(format!(
@@ -26,39 +30,74 @@ pub(crate) fn check_fee_payer_balance(config: &Config, required_balance: u64) ->
     }
 }
 
-pub(crate) fn send_transaction(
+pub fn send_transaction(
     config: &Config,
     transaction: Transaction,
 ) -> solana_client::client_error::Result<()> {
     if config.dry_run {
-        let result = config.rpc_client.simulate_transaction(&transaction)?;
-        println!("Simulate result: {:?}", result);
+        config.rpc_client.simulate_transaction(&transaction)?;
     } else {
-        let signature = config
+        let _signature = config
             .rpc_client
             .send_and_confirm_transaction_with_spinner(&transaction)?;
-        println!("Signature: {}", signature);
     }
     Ok(())
 }
 
-pub(crate) struct NewStakePoolArgs {
-    pub(crate) keypair: Keypair,
-    pub(crate) numerator: u64,
-    pub(crate) denominator: u64,
-    pub(crate) max_validators: u32,
-}
-pub(crate) enum StakePoolArgs {
-    New(NewStakePoolArgs),
-    Existing(Pubkey),
+#[derive(Debug)]
+pub struct CreateSolidoOpts {
+    /// Numerator of the fee fraction.
+    pub fee_numerator: u64,
+
+    /// Denominator of the fee fraction.
+    pub fee_denominator: u64,
+
+    /// The maximum number of validators that this Solido instance will support.
+    pub max_validators: u32,
 }
 
-pub(crate) fn command_create_solido(
-    config: &Config,
-    stake_pool_args: StakePoolArgs,
-) -> CommandResult {
+pub struct CreateSolidoOutput {
+    /// Account that stores the data for this Solido instance.
+    pub solido_address: Pubkey,
+
+    /// TODO(fynn): What is the role of the reserve authority?
+    pub reserve_authority: Pubkey,
+
+    /// TODO(fynn): What is the role of the fee authority?
+    pub fee_authority: Pubkey,
+
+    /// TODO(fynn): What does the fee account do?
+    pub fee_address: Pubkey,
+
+    /// SPL token mint account for LSOL tokens.
+    pub mint_address: Pubkey,
+
+    /// TODO(fynn): What is the role of this account?
+    pub pool_token_to: Pubkey,
+
+    /// Details of the stake pool managed by Solido.
+    pub stake_pool: CreatePoolOutput,
+}
+
+impl fmt::Display for CreateSolidoOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Solido details:")?;
+        writeln!(f, "  Solido address:         {}", self.solido_address)?;
+        writeln!(f, "  Reserve authority:      {}", self.reserve_authority)?;
+        writeln!(f, "  Fee authority:          {}", self.fee_authority)?;
+        writeln!(f, "  Fee address:            {}", self.fee_address)?;
+        writeln!(f, "  stSOL mint:             {}", self.mint_address)?;
+        writeln!(f, "  Solido's pool account:  {}", self.pool_token_to)?;
+        writeln!(f, "Stake pool details:\n{}", self.stake_pool)?;
+        Ok(())
+    }
+}
+
+pub fn command_create_solido(
+    config: &mut Config,
+    opts: CreateSolidoOpts,
+) -> Result<CreateSolidoOutput, crate::Error> {
     let lido_keypair = Keypair::new();
-    println!("Creating lido {}", lido_keypair.pubkey());
 
     let (reserve_authority, _) = lido::find_authority_program_address(
         &lido::id(),
@@ -72,45 +111,25 @@ pub(crate) fn command_create_solido(
         FEE_MANAGER_AUTHORITY,
     );
 
-    let stake_pool_pubkey = match stake_pool_args {
-        StakePoolArgs::New(NewStakePoolArgs {
-            keypair,
-            numerator,
-            denominator,
-            max_validators,
-        }) => {
-            let (deposit_authority, _) = lido::find_authority_program_address(
-                &lido::id(),
-                &lido_keypair.pubkey(),
-                DEPOSIT_AUTHORITY_ID,
-            );
-            let stake_pool_public_key = keypair.pubkey();
-            command_create_pool(
-                &config,
-                &deposit_authority,
-                Fee {
-                    denominator,
-                    numerator,
-                },
-                max_validators,
-                Some(keypair),
-                None,
-            )?;
-            stake_pool_public_key
-        }
-        StakePoolArgs::Existing(stake_pool_pubkey) => stake_pool_pubkey,
-    };
+    let (deposit_authority, _) = lido::find_authority_program_address(
+        &lido::id(),
+        &lido_keypair.pubkey(),
+        DEPOSIT_AUTHORITY_ID,
+    );
+
+    let stake_pool = command_create_pool(
+        config,
+        &deposit_authority,
+        Fee {
+            numerator: opts.fee_numerator,
+            denominator: opts.fee_denominator,
+        },
+        opts.max_validators,
+    )?;
 
     let mint_keypair = Keypair::new();
-    println!("Creating mint {}", mint_keypair.pubkey());
     let fee_keypair = Keypair::new();
-    println!("Creating fee account {}", fee_keypair.pubkey());
-
     let pool_token_to = Keypair::new();
-    println!(
-        "Creating lido's account in stake pool: {}",
-        pool_token_to.pubkey()
-    );
 
     let mint_account_balance = config
         .rpc_client
@@ -174,7 +193,7 @@ pub(crate) fn command_create_solido(
                 &lido::id(),
                 &lido::instruction::InitializeAccountsMeta {
                     lido: lido_keypair.pubkey(),
-                    stake_pool: stake_pool_pubkey,
+                    stake_pool: stake_pool.stake_pool_address,
                     owner: config.staker.pubkey(),
                     mint_program: mint_keypair.pubkey(),
                     pool_token_to: pool_token_to.pubkey(), // to define
@@ -194,5 +213,14 @@ pub(crate) fn command_create_solido(
     lido_transaction.sign(&signers, recent_blockhash);
     send_transaction(&config, lido_transaction)?;
 
-    Ok(())
+    let result = CreateSolidoOutput {
+        solido_address: lido_keypair.pubkey(),
+        reserve_authority: reserve_authority,
+        fee_authority: fee_authority,
+        mint_address: mint_keypair.pubkey(),
+        fee_address: fee_keypair.pubkey(),
+        pool_token_to: pool_token_to.pubkey(),
+        stake_pool: stake_pool,
+    };
+    Ok(result)
 }

--- a/cli/src/stake_pool_helpers.rs
+++ b/cli/src/stake_pool_helpers.rs
@@ -1,8 +1,8 @@
 use solana_program::sysvar;
-
+use std::fmt;
 use {
     crate::helpers::{check_fee_payer_balance, send_transaction},
-    crate::{CommandResult, Config},
+    crate::Config,
     solana_program::{borsh::get_packed_len, program_pack::Pack, pubkey::Pubkey},
     solana_sdk::{
         signature::{Keypair, Signer},
@@ -20,31 +20,62 @@ use {
 
 const STAKE_STATE_LEN: usize = 200;
 
-pub(crate) fn command_create_pool(
-    config: &Config,
+pub struct CreatePoolOutput {
+    /// Account that holds the stake pool data structure.
+    pub stake_pool_address: Pubkey,
+
+    /// TODO(fynn): What's the reserve stake?
+    pub reserve_stake_address: Pubkey,
+
+    /// SPL token mint account for stake pool tokens.
+    pub mint_address: Pubkey,
+
+    /// Account that collected fees get deposited into.
+    pub fee_address: Pubkey,
+
+    /// Account that stores the validator list data structure.
+    pub validator_list_address: Pubkey,
+
+    /// Program-derived account that can mint stake pool tokens.
+    pub withdraw_authority: Pubkey,
+}
+
+impl fmt::Display for CreatePoolOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // All output is indented by two spaces because we expect to call this
+        // from `CreateSolidoOutput::fmt`.
+        writeln!(f, "  Stake pool address:     {}", self.stake_pool_address)?;
+        writeln!(
+            f,
+            "  Reserve stake address:  {}",
+            self.reserve_stake_address
+        )?;
+        writeln!(
+            f,
+            "  Stake pool token mint:  {}",
+            self.reserve_stake_address
+        )?;
+        writeln!(f, "  Fee deposit address:    {}", self.fee_address)?;
+        writeln!(
+            f,
+            "  Validator list address: {}",
+            self.validator_list_address
+        )?;
+        writeln!(f, "  Withdraw authority:     {}", self.withdraw_authority)?;
+        Ok(())
+    }
+}
+
+pub fn command_create_pool(
+    config: &mut Config,
     deposit_authority: &Pubkey,
     fee: Fee,
     max_validators: u32,
-    stake_pool_keypair: Option<Keypair>,
-    mint_keypair: Option<Keypair>,
-) -> CommandResult {
+) -> Result<CreatePoolOutput, crate::Error> {
     let reserve_stake = Keypair::new();
-    println!(
-        "Creating stake pool reserve stake {}",
-        reserve_stake.pubkey()
-    );
-
-    let mint_keypair = mint_keypair.unwrap_or_else(Keypair::new);
-    println!("Creating stake pool mint {}", mint_keypair.pubkey());
-
+    let mint_keypair = Keypair::new();
     let pool_fee_account = Keypair::new();
-    println!(
-        "Creating stake pool fee collection account {}",
-        pool_fee_account.pubkey()
-    );
-
-    let stake_pool_keypair = stake_pool_keypair.unwrap_or_else(Keypair::new);
-
+    let stake_pool_keypair = Keypair::new();
     let validator_list = Keypair::new();
 
     let reserve_stake_balance = config
@@ -78,10 +109,6 @@ pub(crate) fn command_create_pool(
         &spl_stake_pool::id(),
         &stake_pool_keypair.pubkey(),
     );
-
-    if config.verbose {
-        println!("Stake pool withdraw authority {}", withdraw_authority);
-    }
 
     let mut setup_transaction = Transaction::new_with_payer(
         &[
@@ -201,5 +228,14 @@ pub(crate) fn command_create_pool(
     ];
     initialize_transaction.sign(&initialize_signers, recent_blockhash);
     send_transaction(&config, initialize_transaction)?;
-    Ok(())
+
+    let result = CreatePoolOutput {
+        stake_pool_address: stake_pool_keypair.pubkey(),
+        reserve_stake_address: reserve_stake.pubkey(),
+        mint_address: mint_keypair.pubkey(),
+        fee_address: pool_fee_account.pubkey(),
+        validator_list_address: validator_list.pubkey(),
+        withdraw_authority: withdraw_authority,
+    };
+    Ok(result)
 }


### PR DESCRIPTION
We want to unify the `solido` CLI utility with the `multisig` utility, and at the same time make the `solido` utility use Clap 3 like `multisig` does, because it is a bit less verbose. I initially started with the `upgrade-clap` branch, but rather than moving everything into the `multisig` crate, I think a better first step would be to make them have roughly the same setup, and then we can merge `multisig` into `solido` later.

This is a first step towards bringing the CLI utility in line with the multisig CLI utility: make them handle IO in the same way, with one struct for options, and another for output.

The next steps will be to use Clap 3 for parsing the options, and to use serde_json to provide an --output-json option. But as a first step, replace all raw prints with structs, and restructure the input options a bit.