### PR TITLE
Use Clap 3 for the command line interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,12 +3734,14 @@ dependencies = [
 name = "solido-cli"
 version = "0.1.0"
 dependencies = [
+ "anchor-client",
  "bincode",
  "borsh 0.8.2",
  "bs58 0.4.0",
- "clap 2.33.3",
+ "clap 3.0.0-beta.2",
  "lazy_static",
  "lido",
+ "serde",
  "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,13 +6,15 @@ name = "solido-cli"
 version = "0.1.0"
 
 [dependencies]
+anchor-client = "0.4.4"
 bincode = "1.3.1"
 borsh = "0.8"
 bs58 = "0.4.0"
-clap = "2.33.3"
+clap = "3.0.0-beta.2"
 lazy_static = "1.4.0"
 lido = {path = "../program", features = ["no-entrypoint"]}
-serde_json = "1.0.62"
+serde = "1.0"
+serde_json = "1.0"
 solana-account-decoder = "1.6.6"
 solana-clap-utils = "1.6.6"
 solana-cli-config = "1.6.6"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,16 +1,12 @@
-use std::process::exit;
+use std::fmt;
+use std::path::PathBuf;
 
-use clap::{
-    crate_description, crate_name, crate_version, value_t, value_t_or_exit, App, AppSettings, Arg,
-    SubCommand,
-};
-
-use solana_clap_utils::{
-    input_validators::{is_keypair, is_parsable, is_pubkey, is_url},
-    keypair::signer_from_path,
-};
+use anchor_client::Cluster;
+use clap::Clap;
+use serde::Serialize;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::signature::{read_keypair_file, Keypair};
 
 use crate::helpers::{command_create_solido, CreateSolidoOpts};
 
@@ -21,195 +17,92 @@ mod helpers;
 mod stake_pool_helpers;
 type Error = Box<dyn std::error::Error>;
 
+/// Solido -- Interact with Lido for Solana.
+#[derive(Clap, Debug)]
+struct Opts {
+    /// The keypair to sign and pay with. [default: ~/.config/solana/id.json]
+    #[clap(long)]
+    keypair_path: Option<PathBuf>,
+
+    /// Cluster to connect to (mainnet, testnet, devnet, localnet, or url).
+    #[clap(long, default_value = "localnet")]
+    // Although we don't use Anchor here, we use it’s `Cluster` type because
+    // it has a convenient `FromStr` implementation.
+    cluster: Cluster,
+
+    /// Output json instead of text to stdout.
+    #[clap(long)]
+    output_json: bool,
+
+    #[clap(subcommand)]
+    subcommand: SubCommand,
+}
+
+#[derive(Clap, Debug)]
+enum SubCommand {
+    /// Create a new Lido for Solana instance.
+    CreateSolido(CreateSolidoOpts),
+}
+
 /// Determines which network to connect to, and who pays the fees.
-pub struct Config {
+pub struct Config<'a> {
     rpc_client: RpcClient,
-    manager: Box<dyn Signer>,
-    staker: Box<dyn Signer>,
-    fee_payer: Box<dyn Signer>,
+    manager: &'a Keypair,
+    staker: &'a Keypair,
+    fee_payer: &'a Keypair,
     dry_run: bool,
 }
 
+/// Resolve ~/.config/solana/id.json.
+fn get_default_keypair_path() -> PathBuf {
+    let home = std::env::var("HOME").expect("Expected $HOME to be set.");
+    let mut path = PathBuf::from(home);
+    path.push(".config/solana/id.json");
+    path
+}
+
+fn print_output<Output: fmt::Display + Serialize>(as_json: bool, output: &Output) {
+    if as_json {
+        let json_string =
+            serde_json::to_string_pretty(output).expect("Failed to serialize output as json.");
+        println!("{}", json_string);
+    } else {
+        println!("{}", output);
+    }
+}
+
 fn main() {
+    let opts = Opts::parse();
     solana_logger::setup_with_default("solana=info");
 
-    let matches = App::new(crate_name!())
-        .about(crate_description!())
-        .version(crate_version!())
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .arg({
-            let arg = Arg::with_name("config_file")
-                .short("C")
-                .long("config")
-                .value_name("PATH")
-                .takes_value(true)
-                .global(true)
-                .help("Configuration file to use");
-            if let Some(ref config_file) = *solana_cli_config::CONFIG_FILE {
-                arg.default_value(&config_file)
-            } else {
-                arg
-            }
-        })
-        .arg(
-            Arg::with_name("dry_run")
-                .long("dry-run")
-                .takes_value(false)
-                .global(true)
-                .help("Simulate transaction instead of executing"),
-        )
-        .arg(
-            Arg::with_name("json_rpc_url")
-                .long("url")
-                .value_name("URL")
-                .takes_value(true)
-                .validator(is_url)
-                .help("JSON RPC URL for the cluster.  Default from the configuration file."),
-        )
-        .arg(
-            Arg::with_name("staker")
-                .long("staker")
-                .value_name("KEYPAIR")
-                .validator(is_keypair)
-                .takes_value(true)
-                .help(
-                    "Specify the stake pool staker. \
-                     This may be a keypair file, the ASK keyword. \
-                     Defaults to the client keypair.",
-                ),
-        )
-        .arg(
-            Arg::with_name("manager")
-                .long("manager")
-                .value_name("KEYPAIR")
-                .validator(is_keypair)
-                .takes_value(true)
-                .help(
-                    "Specify the stake pool manager. \
-                     This may be a keypair file, the ASK keyword. \
-                     Defaults to the client keypair.",
-                ),
-        )
-        .arg(
-            Arg::with_name("fee_payer")
-                .long("fee-payer")
-                .value_name("KEYPAIR")
-                .validator(is_keypair)
-                .takes_value(true)
-                .help(
-                    "Specify the fee-payer account. \
-                     This may be a keypair file, the ASK keyword. \
-                     Defaults to the client keypair.",
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("create")
-                .about("Create a new lido")
-                .arg(
-                    Arg::with_name("stake-pool")
-                        .long("stake-pool")
-                        .short("s")
-                        .validator(is_pubkey)
-                        .value_name("STAKE-POOL")
-                        .takes_value(true)
-                        .help("Specifies a stake pool. If none is specified, one is created."),
-                )
-                .arg(
-                    Arg::with_name("fee-numerator")
-                        .long("fee-numerator")
-                        .validator(is_parsable::<u64>)
-                        .value_name("NUMBER")
-                        .takes_value(true)
-                        .help("Fee numerator, fee amount is numerator divided by denominator."),
-                )
-                .arg(
-                    Arg::with_name("fee-denominator")
-                        .long("fee-denominator")
-                        .validator(is_parsable::<u64>)
-                        .value_name("NUMBER")
-                        .takes_value(true)
-                        .help("Fee denominator, fee amount is numerator divided by denominator."),
-                )
-                .arg(
-                    Arg::with_name("max-validators")
-                        .long("max-validators")
-                        .validator(is_parsable::<u64>)
-                        .value_name("NUMBER")
-                        .takes_value(true)
-                        .help("Max number of validators included in the stake pool"),
-                ),
-        )
-        .subcommand(SubCommand::with_name("deposit").about("Deposits to lido"))
-        .get_matches();
+    let payer_keypair_path = match opts.keypair_path {
+        Some(path) => path,
+        None => get_default_keypair_path(),
+    };
+    let keypair = read_keypair_file(&payer_keypair_path).expect(&format!(
+        "Failed to read key pair from {:?}.",
+        payer_keypair_path
+    ));
 
-    let mut wallet_manager = None;
-    let mut config = {
-        let cli_config = if let Some(config_file) = matches.value_of("config_file") {
-            solana_cli_config::Config::load(config_file).unwrap_or_default()
-        } else {
-            solana_cli_config::Config::default()
-        };
-        let json_rpc_url = value_t!(matches, "json_rpc_url", String)
-            .unwrap_or_else(|_| cli_config.json_rpc_url.clone());
-
-        let staker = signer_from_path(
-            &matches,
-            &cli_config.keypair_path,
-            "staker",
-            &mut wallet_manager,
-        )
-        .unwrap_or_else(|e| {
-            eprintln!("error: {}", e);
-            exit(1);
-        });
-        let manager = signer_from_path(
-            &matches,
-            &cli_config.keypair_path,
-            "manager",
-            &mut wallet_manager,
-        )
-        .unwrap_or_else(|e| {
-            eprintln!("error: {}", e);
-            exit(1);
-        });
-        let fee_payer = signer_from_path(
-            &matches,
-            &cli_config.keypair_path,
-            "fee_payer",
-            &mut wallet_manager,
-        )
-        .unwrap_or_else(|e| {
-            eprintln!("error: {}", e);
-            exit(1);
-        });
-        let dry_run = matches.is_present("dry_run");
-
-        Config {
-            rpc_client: RpcClient::new_with_commitment(json_rpc_url, CommitmentConfig::confirmed()),
-            manager,
-            staker,
-            fee_payer,
-            dry_run,
-        }
+    let config = Config {
+        rpc_client: RpcClient::new_with_commitment(
+            opts.cluster.url().to_string(),
+            CommitmentConfig::confirmed(),
+        ),
+        // For now, we'll assume that the provided key pair fulfils all of these
+        // roles. We need a better way to configure keys in the future.
+        manager: &keypair,
+        staker: &keypair,
+        fee_payer: &keypair,
+        // TODO: Do we want a dry-run option in the MVP at all?
+        dry_run: false,
     };
 
-    let _ = match matches.subcommand() {
-        ("create", Some(arg_matches)) => {
-            let numerator = value_t_or_exit!(arg_matches, "fee-numerator", u64);
-            let denominator = value_t_or_exit!(arg_matches, "fee-denominator", u64);
-            let max_validators = value_t_or_exit!(arg_matches, "max-validators", u32);
-            let opts = CreateSolidoOpts {
-                fee_numerator: numerator,
-                fee_denominator: denominator,
-                max_validators: max_validators,
-            };
-            command_create_solido(&mut config, opts)
+    match opts.subcommand {
+        SubCommand::CreateSolido(cmd_opts) => {
+            let output = command_create_solido(&config, cmd_opts)
+                .expect("Failed to create Solido instance.");
+            print_output(opts.output_json, &output);
         }
-
-        _ => unreachable!(),
     }
-    .map_err(|err| {
-        eprintln!("{}", err);
-        exit(1);
-    });
 }

--- a/cli/src/stake_pool_helpers.rs
+++ b/cli/src/stake_pool_helpers.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use {
     crate::helpers::{check_fee_payer_balance, send_transaction},
     crate::Config,
+    serde::Serialize,
     solana_program::{borsh::get_packed_len, program_pack::Pack, pubkey::Pubkey},
     solana_sdk::{
         signature::{Keypair, Signer},
@@ -20,6 +21,7 @@ use {
 
 const STAKE_STATE_LEN: usize = 200;
 
+#[derive(Serialize)]
 pub struct CreatePoolOutput {
     /// Account that holds the stake pool data structure.
     pub stake_pool_address: Pubkey,
@@ -67,7 +69,7 @@ impl fmt::Display for CreatePoolOutput {
 }
 
 pub fn command_create_pool(
-    config: &mut Config,
+    config: &Config,
     deposit_authority: &Pubkey,
     fee: Fee,
     max_validators: u32,
@@ -212,7 +214,7 @@ pub fn command_create_pool(
             + fee_calculator.calculate_fee(&initialize_transaction.message()),
     )?;
     let setup_signers = vec![
-        config.fee_payer.as_ref(),
+        config.fee_payer,
         &mint_keypair,
         &pool_fee_account,
         &reserve_stake,
@@ -221,10 +223,10 @@ pub fn command_create_pool(
     send_transaction(&config, setup_transaction)?;
 
     let initialize_signers = vec![
-        config.fee_payer.as_ref(),
+        config.fee_payer,
         &stake_pool_keypair,
         &validator_list,
-        config.manager.as_ref(),
+        config.manager,
     ];
     initialize_transaction.sign(&initialize_signers, recent_blockhash);
     send_transaction(&config, initialize_transaction)?;


### PR DESCRIPTION
This is a follow-up to #65, and a step towards merging the `multisig` and `solido` CLIs.

This simplifies the CLI by using a `#[derive(Clap)]` struct, instead of the more verbose parsing in Clap 2. We also make the output structs derive `serde::Serialize`, so we get an `--output-json` mode, just like we do for the multisig CLI. (The pubkey types would need to be wrapped to get useful output — it would be nice if we can avoid that somehow.)

Aside from replacing the CLI parser, this also drops the config file that configured the different key pairs for the manager, staker, and fee payer; they are always the same key pair for now (this was the default previously anyway). I expect we will need to split them up again later, but to get something going this will do. We need to figure out a convenient way to manage so many key pairs later, a config file seems appropriate.

Some small functions were copied from `multisig-cli/src/main.rs`; we can de-duplicate this later when we merge them into a single program.