### PR TITLE
Improve CLI help for `solido create-solido`

### DIFF
--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -66,45 +66,44 @@ pub fn sign_and_send_transaction<T: Signers>(
 #[derive(Clap, Debug)]
 pub struct CreateSolidoOpts {
     /// Address of the Solido program.
-    #[clap(long)]
+    #[clap(long, value_name = "address")]
     pub solido_program_id: Pubkey,
 
     /// Numerator of the fee fraction.
-    #[clap(long)]
+    #[clap(long, value_name = "int")]
     pub fee_numerator: u64,
 
     /// Denominator of the fee fraction.
-    #[clap(long)]
+    #[clap(long, value_name = "int")]
     pub fee_denominator: u64,
 
     /// The maximum number of validators that this Solido instance will support.
-    #[clap(long)]
+    #[clap(long, value_name = "int")]
     pub max_validators: u32,
 
-    /// Fees are divided proportionally to the sum of all specified fees, for instance,
-    /// if all the fees are the same value, they will be divided equally.
-
-    /// Insurance fee proportion
-    #[clap(long)]
+    // Fees are divided proportionally to the sum of all specified fees, for instance,
+    // if all the fees are the same value, they will be divided equally.
+    /// Insurance fee share
+    #[clap(long, value_name = "int")]
     pub insurance_fee: u32,
-    /// Treasury fee proportion
-    #[clap(long)]
+    /// Treasury fee share
+    #[clap(long, value_name = "int")]
     pub treasury_fee: u32,
-    /// Validation fee proportion, to be divided equally among validators
-    #[clap(long)]
+    /// Validation fee share, to be divided equally among validators
+    #[clap(long, value_name = "int")]
     pub validation_fee: u32,
-    /// Manager fee
-    #[clap(long)]
+    /// Manager fee share
+    #[clap(long, value_name = "int")]
     pub manager_fee: u32,
 
     /// Account who will own the stSOL SPL token account that receives insurance fees.
-    #[clap(long)]
+    #[clap(long, value_name = "address")]
     pub insurance_account_owner: Pubkey,
     /// Account who will own the stSOL SPL token account that receives treasury fees.
-    #[clap(long)]
+    #[clap(long, value_name = "address")]
     pub treasury_account_owner: Pubkey,
     /// Account who will own the stSOL SPL token account that receives the manager fees.
-    #[clap(long)]
+    #[clap(long, value_name = "address")]
     pub manager_fee_account_owner: Pubkey,
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -68,6 +68,32 @@ struct Opts {
 #[derive(Clap, Debug)]
 enum SubCommand {
     /// Create a new Lido for Solana instance.
+    #[clap(after_help = r"ACCOUNTS:
+
+    This sets up a few things:
+
+    * An SPL token mint for stake pool tokens.
+    * An SPL token mint for stSOL.
+    * stSOL-denominated SPL token accounts for fee receivers.
+    * The stake pool managed by this Solido instance.
+    * The Solido instance itself.
+
+FEES:
+
+    Of the validation rewards that the stake pool receives, a fraction
+    «fee-numerator» / «fee-denominator» gets paid out as fees. The remaining
+    rewards get distributed implicitly to stSOL holders because they now own
+    a share of a larger pool of SOL.
+
+    The fees are distributed among the insurance, treasury, validators, and the
+    manager, according to the ratio
+
+    «insurance-fee» : «treasury-fee» : «validation-fee» : «manager-fee»
+
+    For example, if all fees are set to 1, then the four parties would each
+    receive 25% of the fees. Subsequently, the validation fee is divided equally
+    among all validators.
+    ")]
     CreateSolido(CreateSolidoOpts),
 
     /// Interact with a deployed Multisig program for governance tasks.


### PR DESCRIPTION
This makes the output of `solido create-solido --help` a bit more readable and helpful.

@glottologist we should also document the fee structure in the hosted docs later, is there a place where I can add that?