### PR TITLE
Improve validator startup on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,9 +71,6 @@ jobs:
         # Perform initial Solana setup.
         solana-keygen new --no-bip39-passphrase --silent
         solana config set --url http://127.0.0.1:8899
-        # TODO: It *should* be online, that's what the start script enforces ...
-        # but still, let's see if a sleep fixes this.
-        sleep 5.0
         solana airdrop 500.0
 
         tests/test_solido.py
@@ -85,9 +82,7 @@ jobs:
         validator=$(tests/start_test_validator.py)
 
         # We don't need to run keygen/setup again, the private key and state
-        # should still be there from the previous run. Do wait for the validator
-        # to have started.
-        sleep 5.0
+        # should still be there from the previous run.
 
         tests/test_multisig.py
         kill $validator

--- a/tests/start_test_validator.py
+++ b/tests/start_test_validator.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import time
 
+from typing import Optional
+
 # Start the validator, pipe its stdout to /dev/null.
 test_validator = subprocess.Popen(
     [
@@ -18,22 +20,33 @@ test_validator = subprocess.Popen(
     stdout=subprocess.DEVNULL,
 )
 
-# Wait up to 5 seconds for the validator to be running. We check this by running
-# "solana cluster-version". If it does not fail, the RPC is responding.
-is_rpc_online = False
+# Wait up to 5 seconds for the validator to be running and processing blocks. We
+# check this by running "solana block-height", and observing at least one
+# increase. If that is the case, the RPC is available, and the validator must be
+# producing blocks. Previously we only checked "solana cluster-version", but
+# this can return a response before the validator is ready to accept
+# transactions.
+last_observed_block_height: Optional[int] = None
 
 for _ in range(50):
     result = subprocess.run(
-        ['solana', 'cluster-version'],
-        stdout=subprocess.DEVNULL,
+        ['solana', 'block-height'],
+        stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     )
     if result.returncode == 0:
-        is_rpc_online = True
-        break
+        current_block_height = int(result.stdout)
+        if (
+            last_observed_block_height is not None
+            and current_block_height > last_observed_block_height
+        ):
+            break
+        last_observed_block_height = current_block_height
 
     sleep_seconds = 0.1
     time.sleep(sleep_seconds)
+
+is_rpc_online = last_observed_block_height is not None
 
 if is_rpc_online and test_validator.poll() is None:
     # The RPC is online, and the process is still running.


### PR DESCRIPTION
I previously added this script that starts the test validator and then polls until its RPC is available, before continuing, but subsequent operations could *still* fail on CI, so I added a sleep, but this is a bit of a hack.

I think I figured out why the sleep was needed: the RPC can be available before the test validator accepts transactions. Previously we only waited for the RPC, but then subsequent operations could still fail, because the validator was still initializing.

Fix this by not only waiting for the RPC to be available, but also waiting until the validator has produced one block, which demonstrates that it is validating, and therefore done initializing.