### PR TITLE
Use clearer names for staking instructions

### DIFF
--- a/program/tests/fee_distribution.rs
+++ b/program/tests/fee_distribution.rs
@@ -61,7 +61,7 @@ async fn test_successful_fee_distribution() {
     // Delegate the deposit
     let validator_account = stake_accounts.get(0).unwrap();
     let validator_stake = lido_accounts
-        .delegate_deposit(
+        .stake_deposit(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -71,7 +71,7 @@ async fn test_successful_fee_distribution() {
         .await;
 
     lido_accounts
-        .delegate_stakepool_deposit(
+        .deposit_active_stake_to_pool(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,

--- a/program/tests/helpers/mod.rs
+++ b/program/tests/helpers/mod.rs
@@ -275,7 +275,7 @@ impl LidoAccounts {
         recipient
     }
 
-    pub async fn delegate_deposit(
+    pub async fn stake_deposit(
         &self,
         banks_client: &mut BanksClient,
         payer: &Keypair,
@@ -287,9 +287,9 @@ impl LidoAccounts {
             Pubkey::find_program_address(&[&validator.vote.pubkey().to_bytes()[..32]], &id());
 
         let mut transaction = Transaction::new_with_payer(
-            &[instruction::delegate_deposit(
+            &[instruction::stake_deposit(
                 &id(),
-                &instruction::DelegateDepositAccountsMeta {
+                &instruction::StakeDepositAccountsMeta {
                     lido: self.lido.pubkey(),
                     validator: validator.vote.pubkey(),
                     reserve: self.reserve_authority,
@@ -306,7 +306,7 @@ impl LidoAccounts {
         stake_account
     }
 
-    pub async fn delegate_stakepool_deposit(
+    pub async fn deposit_active_stake_to_pool(
         &self,
         banks_client: &mut BanksClient,
         payer: &Keypair,
@@ -315,9 +315,9 @@ impl LidoAccounts {
         stake_account: &Pubkey,
     ) {
         let mut transaction = Transaction::new_with_payer(
-            &[instruction::stake_pool_delegate(
+            &[instruction::deposit_active_stake_to_pool(
                 &id(),
-                &instruction::StakePoolDelegateAccountsMeta {
+                &instruction::DepositActiveStakeToPoolAccountsMeta {
                     lido: self.lido.pubkey(),
                     validator: validator.vote.pubkey(),
                     stake: *stake_account,

--- a/program/tests/stake_deposit.rs
+++ b/program/tests/stake_deposit.rs
@@ -44,10 +44,10 @@ async fn setup() -> (
     )
 }
 pub const TEST_DEPOSIT_AMOUNT: u64 = 100_000_000_000;
-pub const TEST_DELEGATE_DEPOSIT_AMOUNT: u64 = 10_000_000_000;
+pub const TEST_STAKE_DEPOSIT_AMOUNT: u64 = 10_000_000_000;
 
 #[tokio::test]
-async fn test_successful_delegate_deposit_stake_pool_deposit() {
+async fn test_successful_stake_deposit_stake_pool_deposit() {
     let (mut banks_client, payer, recent_blockhash, lido_accounts, stake_accounts) = setup().await;
     lido_accounts
         .deposit(
@@ -61,12 +61,12 @@ async fn test_successful_delegate_deposit_stake_pool_deposit() {
     // Delegate the deposit
     let validator_account = stake_accounts.get(0).unwrap();
     let stake_account = lido_accounts
-        .delegate_deposit(
+        .stake_deposit(
             &mut banks_client,
             &payer,
             &recent_blockhash,
             validator_account,
-            TEST_DELEGATE_DEPOSIT_AMOUNT,
+            TEST_STAKE_DEPOSIT_AMOUNT,
         )
         .await;
 
@@ -90,7 +90,7 @@ async fn test_successful_delegate_deposit_stake_pool_deposit() {
         .unwrap();
 
     lido_accounts
-        .delegate_stakepool_deposit(
+        .deposit_active_stake_to_pool(
             &mut banks_client,
             &payer,
             &recent_blockhash,
@@ -108,17 +108,17 @@ async fn test_successful_delegate_deposit_stake_pool_deposit() {
     let stake_pool = StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
     assert_eq!(
         stake_pool.total_stake_lamports,
-        stake_pool_before.total_stake_lamports + TEST_DELEGATE_DEPOSIT_AMOUNT
+        stake_pool_before.total_stake_lamports + TEST_STAKE_DEPOSIT_AMOUNT
     );
     assert_eq!(
         stake_pool.pool_token_supply,
-        stake_pool_before.pool_token_supply + TEST_DELEGATE_DEPOSIT_AMOUNT
+        stake_pool_before.pool_token_supply + TEST_STAKE_DEPOSIT_AMOUNT
     );
 
     // Check minted tokens
     let lido_token_balance =
         get_token_balance(&mut banks_client, &lido_accounts.pool_token_to.pubkey()).await;
-    assert_eq!(lido_token_balance, TEST_DELEGATE_DEPOSIT_AMOUNT);
+    assert_eq!(lido_token_balance, TEST_STAKE_DEPOSIT_AMOUNT);
 
     // Check balances in validator stake account list storage
     let validator_list = get_account(
@@ -133,7 +133,7 @@ async fn test_successful_delegate_deposit_stake_pool_deposit() {
         .unwrap();
     assert_eq!(
         validator_stake_item.stake_lamports,
-        validator_stake_item_before.stake_lamports + TEST_DELEGATE_DEPOSIT_AMOUNT
+        validator_stake_item_before.stake_lamports + TEST_STAKE_DEPOSIT_AMOUNT
     );
 
     // Check validator stake account actual SOL balance
@@ -149,4 +149,4 @@ async fn test_successful_delegate_deposit_stake_pool_deposit() {
 }
 
 #[tokio::test]
-async fn test_stake_exists_delegate_deposit() {} // TODO
+async fn test_stake_exists_stake_deposit() {} // TODO

--- a/program/tests/update_balances.rs
+++ b/program/tests/update_balances.rs
@@ -62,7 +62,7 @@ async fn test_successful_update_balance() {
     // Create a stake account from the now-funded Lido reserve.
     let validator_account = stake_accounts.get(0).unwrap();
     let validator_stake = lido_accounts
-        .delegate_deposit(
+        .stake_deposit(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -73,7 +73,7 @@ async fn test_successful_update_balance() {
 
     // Delegate the newly created stake account to Lido's stake pool.
     lido_accounts
-        .delegate_stakepool_deposit(
+        .deposit_active_stake_to_pool(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,


### PR DESCRIPTION
There are two phases for moving SOL deposited into Solido into the stake pool:

 * Stake the SOL into a new stake account, and delegate (=activate) it.
 * Once the stake is active, merge ("deposit") the activated stake account into the stake pool.

Previously they were called “DelegateDeposit” and “StakePoolDelegate”. I propose to call them “StakeDeposit” and “DepositActiveStakeToPool” to make them a bit more descriptive.