### PR TITLE
Add more safe wrappers for token types, use them everywhere

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -12,7 +12,8 @@ use solana_program::{
 use spl_stake_pool::{instruction::StakePoolInstruction, stake_program, state::Fee};
 
 use crate::{
-    error::LidoError, state::FeeDistribution,
+    error::LidoError,
+    state::FeeDistribution,
     token::{Lamports, StLamports},
 };
 
@@ -61,11 +62,11 @@ pub enum LidoInstruction {
     RemoveMaintainer,
     IncreaseValidatorStake {
         #[allow(dead_code)] // but it's not
-        lamports: u64,
+        lamports: Lamports,
     },
     DecreaseValidatorStake {
         #[allow(dead_code)] // but it's not
-        lamports: u64,
+        lamports: Lamports,
     },
 }
 
@@ -1014,7 +1015,7 @@ accounts_struct! {
 
 pub fn increase_validator_stake(
     program_id: &Pubkey,
-    lamports: u64,
+    lamports: Lamports,
     accounts: &IncreaseValidatorStakeMeta,
 ) -> Result<Instruction, ProgramError> {
     Ok(Instruction {
@@ -1071,7 +1072,7 @@ accounts_struct! {
 
 pub fn decrease_validator_stake(
     program_id: &Pubkey,
-    lamports: u64,
+    lamports: Lamports,
     accounts: &DecreaseValidatorStakeMeta,
 ) -> Result<Instruction, ProgramError> {
     Ok(Instruction {

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -4,11 +4,11 @@ use solana_program::pubkey::Pubkey;
 pub mod entrypoint;
 pub mod error;
 pub mod instruction;
-pub mod token;
 pub(crate) mod logic;
 pub(crate) mod process_management;
 pub mod processor;
 pub mod state;
+pub mod token;
 
 /// Seed for reserve authority in SOL
 pub const RESERVE_AUTHORITY: &[u8] = b"reserve_authority";

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -1,9 +1,14 @@
+use crate::{
+    error::LidoError,
+    state::Lido,
+    token::{Lamports, Rational, StLamports},
+    RESERVE_AUTHORITY,
+};
 use solana_program::{
     account_info::AccountInfo, borsh::try_from_slice_unchecked, msg, program::invoke_signed,
     program_error::ProgramError, pubkey::Pubkey, rent::Rent,
 };
 use spl_stake_pool::state::StakePool;
-use crate::{error::LidoError, token::{Lamports, Rational, StLamports}, RESERVE_AUTHORITY, state::Lido};
 use std::fmt::Display;
 
 pub(crate) fn rent_exemption(
@@ -58,10 +63,11 @@ pub fn calc_stakepool_lamports(
     if stake_pool.pool_token_supply == 0 {
         Some(Lamports(0))
     } else {
-        Lamports(stake_pool.total_stake_lamports) * Rational {
-            numerator: pool_to_token_account.amount,
-            denominator: stake_pool.pool_token_supply,
-        }
+        Lamports(stake_pool.total_stake_lamports)
+            * Rational {
+                numerator: pool_to_token_account.amount,
+                denominator: stake_pool.pool_token_supply,
+            }
     }
     .ok_or(LidoError::CalculationFailure)
 }

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -20,10 +20,8 @@ use crate::{
         IncreaseValidatorStakeInfo, RemoveMaintainerInfo, RemoveValidatorInfo,
     },
     logic::{deserialize_lido, token_mint_to, transfer_to},
-    state::{
-        distribute_fees, FeeDistribution, Lido, ValidatorCredit,
-    },
-    token::{StLamports, StakePoolTokenLamports},
+    state::{distribute_fees, FeeDistribution, Lido, ValidatorCredit},
+    token::{Lamports, StLamports, StakePoolTokenLamports},
     FEE_MANAGER_AUTHORITY, RESERVE_AUTHORITY, STAKE_POOL_AUTHORITY,
 };
 
@@ -382,7 +380,7 @@ pub fn process_remove_maintainer(
 /// Increases a validator's stake. This function is called by maintainers
 pub fn process_increase_validator_stake(
     program_id: &Pubkey,
-    lamports: u64,
+    lamports: Lamports,
     accounts_raw: &[AccountInfo],
 ) -> ProgramResult {
     let accounts = IncreaseValidatorStakeInfo::try_from_slice(accounts_raw)?;
@@ -400,7 +398,7 @@ pub fn process_increase_validator_stake(
             accounts.stake_pool_reserve_stake.key,
             accounts.transient_stake.key,
             accounts.validator_vote.key,
-            lamports,
+            lamports.0,
         ),
         &[
             accounts.stake_pool_program.clone(),
@@ -429,7 +427,7 @@ pub fn process_increase_validator_stake(
 /// Removes a maintainer to the list of maintainers
 pub fn process_decrease_validator_stake(
     program_id: &Pubkey,
-    lamports: u64,
+    lamports: Lamports,
     accounts_raw: &[AccountInfo],
 ) -> ProgramResult {
     let accounts = DecreaseValidatorStakeInfo::try_from_slice(accounts_raw)?;
@@ -446,7 +444,7 @@ pub fn process_decrease_validator_stake(
             accounts.stake_pool_validator_list.key,
             accounts.validator_stake.key,
             accounts.transient_stake.key,
-            lamports,
+            lamports.0,
         ),
         &[
             accounts.stake_pool_program.clone(),

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -276,7 +276,8 @@ pub fn process_stake_deposit(
         return Err(LidoError::InvalidReserveAuthority.into());
     }
 
-    let minium_stake_balance = Lamports(rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>()));
+    let minium_stake_balance =
+        Lamports(rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>()));
     if amount < minium_stake_balance {
         return Err(LidoError::InvalidAmount.into());
     }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -9,8 +9,7 @@ use solana_program::{
 };
 
 use crate::error::LidoError;
-use crate::token::{Rational, Lamports, StLamports, StakePoolTokenLamports};
-
+use crate::token::{Lamports, Rational, StLamports, StakePoolTokenLamports};
 
 /// Constant size of header size = 5 public keys, 1 u64, 4 u8
 pub const LIDO_CONSTANT_HEADER_SIZE: usize = 5 * 32 + 8 + 4;
@@ -400,7 +399,8 @@ mod test_lido {
     fn test_pool_tokens_when_st_sol_total_shares_is_default() {
         let lido = Lido::default();
 
-        let pool_tokens_for_deposit = lido.calc_pool_tokens_for_deposit(Lamports(200), Lamports(100));
+        let pool_tokens_for_deposit =
+            lido.calc_pool_tokens_for_deposit(Lamports(200), Lamports(100));
 
         assert_eq!(pool_tokens_for_deposit, Some(StLamports(0)));
     }
@@ -410,7 +410,8 @@ mod test_lido {
         let mut lido = Lido::default();
         lido.st_sol_total_shares = StLamports(120);
 
-        let pool_tokens_for_deposit = lido.calc_pool_tokens_for_deposit(Lamports(200), Lamports(40));
+        let pool_tokens_for_deposit =
+            lido.calc_pool_tokens_for_deposit(Lamports(200), Lamports(40));
 
         assert_eq!(pool_tokens_for_deposit, Some(StLamports(600)));
     }

--- a/program/src/token.rs
+++ b/program/src/token.rs
@@ -28,7 +28,6 @@ pub struct Rational {
 /// only used for `Debug` and `Display` printing.
 macro_rules! impl_token {
     ($TokenLamports:ident, $symbol:expr) => {
-
         #[derive(
             Copy,
             Clone,
@@ -99,7 +98,7 @@ macro_rules! impl_token {
                 Some($TokenLamports(self.0.checked_add(other.0)?))
             }
         }
-    }
+    };
 }
 
 impl_token!(Lamports, "SOL");

--- a/program/tests/fee_distribution.rs
+++ b/program/tests/fee_distribution.rs
@@ -13,7 +13,7 @@ use solana_program_test::{tokio, ProgramTestContext};
 use solana_sdk::signature::Signer;
 use spl_stake_pool::state::StakePool;
 
-use lido::state::{StLamports, StakePoolTokenLamports};
+use lido::token::{Lamports, StLamports, StakePoolTokenLamports};
 
 async fn setup() -> (ProgramTestContext, LidoAccounts, Vec<ValidatorStakeAccount>) {
     let mut context = program_test().start_with_context().await;
@@ -42,8 +42,8 @@ async fn setup() -> (ProgramTestContext, LidoAccounts, Vec<ValidatorStakeAccount
     (context, lido_accounts, stake_accounts)
 }
 const NUMBER_VALIDATORS: u64 = 4;
-const TEST_DEPOSIT_AMOUNT: u64 = 100_000_000_000;
-const EXTRA_STAKE_AMOUNT: u64 = 50_000_000_000;
+const TEST_DEPOSIT_AMOUNT: Lamports = Lamports(100_000_000_000);
+const EXTRA_STAKE_AMOUNT: Lamports = Lamports(50_000_000_000);
 
 #[tokio::test]
 async fn test_successful_fee_distribution() {
@@ -110,10 +110,11 @@ async fn test_successful_fee_distribution() {
     let stake_pool = StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
 
     // The total reward is the the sum of what each stake account received.
-    let reward_lamports = NUMBER_VALIDATORS * EXTRA_STAKE_AMOUNT;
+    let reward_lamports = (EXTRA_STAKE_AMOUNT * NUMBER_VALIDATORS).unwrap();
 
     // Of that reward, Lido claims a fraction as fee.
-    let fee_stake_pool_tokens_expected = stake_pool.calc_fee_amount(reward_lamports).unwrap();
+    let fee_stake_pool_tokens_expected =
+        StakePoolTokenLamports(stake_pool.calc_fee_amount(reward_lamports.0).unwrap());
 
     // Now we are going to warp to the next epoch and actually update the pool
     // balance, which should cause rewards to be minted and deposited into the
@@ -135,13 +136,15 @@ async fn test_successful_fee_distribution() {
         .await;
     assert!(error.is_none());
 
-    let fee_in_stake_pool_tokens = get_token_balance(
-        &mut context.banks_client,
-        &lido_accounts.stake_pool_accounts.pool_fee_account.pubkey(),
-    )
-    .await;
+    let fee_in_stake_pool_tokens = StakePoolTokenLamports(
+        get_token_balance(
+            &mut context.banks_client,
+            &lido_accounts.stake_pool_accounts.pool_fee_account.pubkey(),
+        )
+        .await,
+    );
 
-    assert_eq!(fee_in_stake_pool_tokens, fee_stake_pool_tokens_expected,);
+    assert_eq!(fee_in_stake_pool_tokens, fee_stake_pool_tokens_expected);
 
     let fee_error = lido_accounts
         .distribute_fees(
@@ -171,7 +174,7 @@ async fn test_successful_fee_distribution() {
     let calculated_fee_distribution = lido::state::distribute_fees(
         &lido_accounts.fee_distribution,
         NUMBER_VALIDATORS,
-        StakePoolTokenLamports(fee_stake_pool_tokens_expected),
+        fee_stake_pool_tokens_expected,
     )
     .unwrap();
 


### PR DESCRIPTION
We already had the `StLamports` type, and a `StakePoolTokenLamports` type. However, lamports were still represented as a bare `u64` in all places, and stake pool tokens were in some. Also, for rebalaning I need to do some arithmetic with lamports, and I’d like to have a safe type for that. So as a first step, use these wrapper types for token amounts whenever possible.

* Move the `StLamports` type into the new `lido::token` module.
* Generate it with a macro so we can generate three structurally identical but nominally different types: one for SOL, one for stSOL, and one for stake pool tokens.
* Use it everywhere, simplify arithmetic if possible.