### PR TITLE
Rename "mint program" to "stSOL mint"

### DIFF
--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -322,7 +322,7 @@ pub fn command_create_solido(
         &lido::instruction::InitializeAccountsMeta {
             lido: lido_keypair.pubkey(),
             stake_pool: stake_pool.stake_pool_address.0,
-            mint_program: st_sol_mint_keypair.pubkey(),
+            st_sol_mint: st_sol_mint_keypair.pubkey(),
             stake_pool_token_holder: stake_pool_token_holder_keypair.pubkey(),
             fee_token: stake_pool.fee_address.0,
             manager,
@@ -549,7 +549,7 @@ impl fmt::Display for ShowSolidoOutput {
         writeln!(
             f,
             "Minter:                      {}",
-            self.solido.st_sol_mint_program
+            self.solido.st_sol_mint
         )?;
         writeln!(
             f,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -333,7 +333,7 @@ accounts_struct! {
             is_signer: false,
             is_writable: false,
         },
-        pub mint_program {
+        pub st_sol_mint {
             is_signer: false,
             is_writable: false,
         },
@@ -408,7 +408,7 @@ accounts_struct! {
             is_signer: false,
             is_writable: true,
         },
-        pub mint_program {
+        pub st_sol_mint {
             is_signer: false,
             is_writable: true,
         },
@@ -797,7 +797,7 @@ accounts_struct! {
             is_signer: false,
             is_writable: true,
         },
-        pub mint_program {
+        pub st_sol_mint {
             is_signer: false,
             is_writable: true,
         },
@@ -902,7 +902,7 @@ accounts_struct! {
             is_signer: false,
             is_writable: true,
         },
-        pub mint_program {
+        pub st_sol_mint {
             is_signer: false,
             is_writable: true,
         },

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -94,8 +94,8 @@ pub fn process_change_fee_spec(
     let mut lido = deserialize_lido(program_id, accounts.lido)?;
     lido.check_manager(accounts.manager)?;
 
-    Lido::check_valid_minter_program(&lido.st_sol_mint_program, accounts.treasury_account)?;
-    Lido::check_valid_minter_program(&lido.st_sol_mint_program, accounts.developer_account)?;
+    Lido::check_valid_minter_program(&lido.st_sol_mint, accounts.treasury_account)?;
+    Lido::check_valid_minter_program(&lido.st_sol_mint, accounts.developer_account)?;
 
     lido.fee_distribution = new_fee_distribution;
     lido.fee_recipients.treasury_account = *accounts.treasury_account.key;
@@ -113,11 +113,11 @@ pub fn process_add_validator(program_id: &Pubkey, accounts_raw: &[AccountInfo]) 
     let validator_fee_st_sol_account = spl_token::state::Account::unpack_from_slice(
         &accounts.validator_fee_st_sol_account.data.borrow(),
     )?;
-    if lido.st_sol_mint_program != validator_fee_st_sol_account.mint {
+    if lido.st_sol_mint != validator_fee_st_sol_account.mint {
         msg!("Validator fee account minter should be the same as Lido minter.");
         msg!(
             "Expected {}, got {}.",
-            lido.st_sol_mint_program,
+            lido.st_sol_mint,
             validator_fee_st_sol_account.mint
         );
         return Err(LidoError::InvalidTokenMinter.into());
@@ -177,7 +177,7 @@ pub fn process_claim_validator_fee(
     token_mint_to(
         accounts.lido.key,
         accounts.spl_token.clone(),
-        accounts.mint_program.clone(),
+        accounts.st_sol_mint.clone(),
         accounts.validator_fee_st_sol_account.clone(),
         accounts.reserve_authority.clone(),
         RESERVE_AUTHORITY,
@@ -227,7 +227,7 @@ pub fn process_distribute_fees(program_id: &Pubkey, accounts_raw: &[AccountInfo]
     token_mint_to(
         accounts.lido.key,
         accounts.spl_token.clone(),
-        accounts.mint_program.clone(),
+        accounts.st_sol_mint.clone(),
         accounts.treasury_account.clone(),
         accounts.reserve_authority.clone(),
         RESERVE_AUTHORITY,
@@ -238,7 +238,7 @@ pub fn process_distribute_fees(program_id: &Pubkey, accounts_raw: &[AccountInfo]
     token_mint_to(
         accounts.lido.key,
         accounts.spl_token.clone(),
-        accounts.mint_program.clone(),
+        accounts.st_sol_mint.clone(),
         accounts.developer_account.clone(),
         accounts.reserve_authority.clone(),
         RESERVE_AUTHORITY,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -68,8 +68,8 @@ pub fn process_initialize(
     }
 
     // Check if fee structure is valid
-    Lido::check_valid_minter_program(&accounts.mint_program.key, accounts.treasury_account)?;
-    Lido::check_valid_minter_program(&accounts.mint_program.key, accounts.developer_account)?;
+    Lido::check_valid_minter_program(&accounts.st_sol_mint.key, accounts.treasury_account)?;
+    Lido::check_valid_minter_program(&accounts.st_sol_mint.key, accounts.developer_account)?;
 
     // Bytes required for maintainers
     let bytes_for_maintainers = Maintainers::required_bytes(max_maintainers as usize);
@@ -149,7 +149,7 @@ pub fn process_initialize(
     lido.maintainers = Maintainers::new(max_maintainers);
     lido.stake_pool_account = *accounts.stake_pool.key;
     lido.manager = *accounts.manager.key;
-    lido.st_sol_mint_program = *accounts.mint_program.key;
+    lido.st_sol_mint = *accounts.st_sol_mint.key;
     lido.stake_pool_token_holder = *accounts.stake_pool_token_holder.key;
     lido.token_program_id = *accounts.spl_token.key;
     lido.sol_reserve_authority_bump_seed = reserve_bump_seed;
@@ -180,7 +180,7 @@ pub fn process_deposit(
     lido.check_lido_for_deposit(
         accounts.manager.key,
         accounts.stake_pool.key,
-        accounts.mint_program.key,
+        accounts.st_sol_mint.key,
     )?;
     lido.check_token_program_id(accounts.spl_token.key)?;
     lido.check_reserve_authority(program_id, accounts.lido.key, accounts.reserve_account)?;
@@ -217,7 +217,7 @@ pub fn process_deposit(
     token_mint_to(
         accounts.lido.key,
         accounts.spl_token.clone(),
-        accounts.mint_program.clone(),
+        accounts.st_sol_mint.clone(),
         accounts.recipient.clone(),
         accounts.reserve_account.clone(),
         RESERVE_AUTHORITY,

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -35,17 +35,22 @@ pub struct Lido {
     /// Stake pool account associated with Lido
     #[serde(serialize_with = "serialize_b58")]
     pub stake_pool_account: Pubkey,
+
     /// Manager of the Lido program, able to execute administrative functions
     #[serde(serialize_with = "serialize_b58")]
     pub manager: Pubkey,
-    /// Program in charge of minting Lido tokens
+
+    /// The SPL Token mint address for stSOL.
     #[serde(serialize_with = "serialize_b58")]
-    pub st_sol_mint_program: Pubkey,
+    pub st_sol_mint: Pubkey,
+
     /// Total Lido tokens in circulation
     pub st_sol_total_shares: StLamports,
+
     /// Holder of tokens in Lido's underlying stake pool
     #[serde(serialize_with = "serialize_b58")]
     pub stake_pool_token_holder: Pubkey,
+
     /// Token program id associated with Lido's token
     #[serde(serialize_with = "serialize_b58")]
     pub token_program_id: Pubkey,
@@ -122,7 +127,7 @@ impl Lido {
             return Err(LidoError::InvalidStakePool.into());
         }
 
-        if &self.st_sol_mint_program != st_sol_mint_key {
+        if &self.st_sol_mint != st_sol_mint_key {
             return Err(LidoError::InvalidTokenMinter.into());
         }
         Ok(())
@@ -418,7 +423,7 @@ mod test_lido {
         let lido = Lido {
             stake_pool_account: Pubkey::new_unique(),
             manager: Pubkey::new_unique(),
-            st_sol_mint_program: Pubkey::new_unique(),
+            st_sol_mint: Pubkey::new_unique(),
             st_sol_total_shares: StLamports(1000),
             stake_pool_token_holder: Pubkey::new_unique(),
             token_program_id: Pubkey::new_unique(),
@@ -517,7 +522,7 @@ mod test_lido {
         let err = lido.check_lido_for_deposit(
             &other_owner.pubkey(),
             &lido.stake_pool_account,
-            &lido.st_sol_mint_program,
+            &lido.st_sol_mint,
         );
 
         let expect: ProgramError = LidoError::InvalidOwner.into();
@@ -532,7 +537,7 @@ mod test_lido {
         let err = lido.check_lido_for_deposit(
             &lido.manager,
             &other_stakepool.pubkey(),
-            &lido.st_sol_mint_program,
+            &lido.st_sol_mint,
         );
 
         let expect: ProgramError = LidoError::InvalidStakePool.into();
@@ -540,7 +545,7 @@ mod test_lido {
     }
 
     #[test]
-    fn test_lido_for_deposit_wrong_mint_program() {
+    fn test_lido_for_deposit_wrong_mint() {
         let lido = Lido::default();
         let other_mint = Keypair::new();
 

--- a/program/tests/change_fee.rs
+++ b/program/tests/change_fee.rs
@@ -64,7 +64,7 @@ async fn test_successful_change_fee() {
             &payer,
             &recent_blockhash,
             &k,
-            &lido_accounts.mint_program.pubkey(),
+            &lido_accounts.st_sol_mint.pubkey(),
             &payer.pubkey(),
         )
         .await
@@ -111,12 +111,12 @@ async fn test_change_fee_wrong_minter() {
     let fee_recipient_keys = [Keypair::new(), Keypair::new()];
     let mut rng = thread_rng();
     let n: usize = rng.gen_range(0..fee_recipient_keys.len());
-    let wrong_mint_program = Keypair::new();
+    let wrong_mint = Keypair::new();
     create_mint(
         &mut banks_client,
         &payer,
         &recent_blockhash,
-        &wrong_mint_program,
+        &wrong_mint,
         &payer.pubkey(),
     )
     .await
@@ -125,9 +125,9 @@ async fn test_change_fee_wrong_minter() {
     for (i, k) in fee_recipient_keys.iter().enumerate() {
         let minter;
         if i == n {
-            minter = wrong_mint_program.pubkey();
+            minter = wrong_mint.pubkey();
         } else {
-            minter = lido_accounts.mint_program.pubkey();
+            minter = lido_accounts.st_sol_mint.pubkey();
         }
         create_token_account(
             &mut banks_client,

--- a/program/tests/deposit.rs
+++ b/program/tests/deposit.rs
@@ -44,7 +44,7 @@ async fn test_successful_deposit() {
         &payer,
         &recent_blockhash,
         &recipient,
-        &lido_accounts.mint_program.pubkey(),
+        &lido_accounts.st_sol_mint.pubkey(),
         &user.pubkey(),
     )
     .await
@@ -69,7 +69,7 @@ async fn test_successful_deposit() {
                 manager: lido_accounts.manager.pubkey(),
                 user: user.pubkey(),
                 recipient: recipient.pubkey(),
-                mint_program: lido_accounts.mint_program.pubkey(),
+                st_sol_mint: lido_accounts.st_sol_mint.pubkey(),
                 reserve_account: lido_accounts.reserve_authority,
             },
             TEST_DEPOSIT_AMOUNT,

--- a/program/tests/helpers/mod.rs
+++ b/program/tests/helpers/mod.rs
@@ -47,7 +47,7 @@ pub fn program_test() -> ProgramTest {
 pub struct LidoAccounts {
     pub manager: Keypair,
     pub lido: Keypair,
-    pub mint_program: Keypair,
+    pub st_sol_mint: Keypair,
     pub stake_pool_token_holder: Keypair,
     pub maintainer: Keypair,
 
@@ -67,7 +67,7 @@ impl LidoAccounts {
     pub fn new() -> Self {
         let manager = Keypair::new();
         let lido = Keypair::new();
-        let mint_program = Keypair::new();
+        let st_sol_mint = Keypair::new();
         let stake_pool_token_holder = Keypair::new();
         let maintainer = Keypair::new();
 
@@ -105,7 +105,7 @@ impl LidoAccounts {
         Self {
             manager,
             lido,
-            mint_program,
+            st_sol_mint,
             stake_pool_token_holder,
             maintainer,
             treasury_account,
@@ -142,7 +142,7 @@ impl LidoAccounts {
             banks_client,
             payer,
             recent_blockhash,
-            &self.mint_program,
+            &self.st_sol_mint,
             &self.reserve_authority,
         )
         .await?;
@@ -163,7 +163,7 @@ impl LidoAccounts {
             payer,
             recent_blockhash,
             &self.treasury_account,
-            &self.mint_program.pubkey(),
+            &self.st_sol_mint.pubkey(),
             &self.treasury_account.pubkey(),
         )
         .await
@@ -173,7 +173,7 @@ impl LidoAccounts {
             payer,
             recent_blockhash,
             &self.developer_account,
-            &self.mint_program.pubkey(),
+            &self.st_sol_mint.pubkey(),
             &self.developer_account.pubkey(),
         )
         .await
@@ -206,7 +206,7 @@ impl LidoAccounts {
                         lido: self.lido.pubkey(),
                         stake_pool: self.stake_pool_accounts.stake_pool.pubkey(),
                         manager: self.manager.pubkey(),
-                        mint_program: self.mint_program.pubkey(),
+                        st_sol_mint: self.st_sol_mint.pubkey(),
                         stake_pool_token_holder: self.stake_pool_token_holder.pubkey(),
                         fee_token: self.stake_pool_accounts.pool_fee_account.pubkey(),
                         treasury_account: self.treasury_account.pubkey(),
@@ -248,7 +248,7 @@ impl LidoAccounts {
             payer,
             recent_blockhash,
             &recipient,
-            &self.mint_program.pubkey(),
+            &self.st_sol_mint.pubkey(),
             &user.pubkey(),
         )
         .await
@@ -273,7 +273,7 @@ impl LidoAccounts {
                     manager: self.manager.pubkey(),
                     user: user.pubkey(),
                     recipient: recipient.pubkey(),
-                    mint_program: self.mint_program.pubkey(),
+                    st_sol_mint: self.st_sol_mint.pubkey(),
                     reserve_account: self.reserve_authority,
                 },
                 deposit_amount,
@@ -472,7 +472,7 @@ impl LidoAccounts {
                     lido: self.lido.pubkey(),
                     maintainer: self.maintainer.pubkey(),
                     token_holder_stake_pool: self.stake_pool_token_holder.pubkey(),
-                    mint_program: self.mint_program.pubkey(),
+                    st_sol_mint: self.st_sol_mint.pubkey(),
                     reserve_authority: self.reserve_authority,
                     treasury_account: self.treasury_account.pubkey(),
                     developer_account: self.developer_account.pubkey(),
@@ -501,7 +501,7 @@ impl LidoAccounts {
                 &id(),
                 &lido::instruction::ClaimValidatorFeeMeta {
                     lido: self.lido.pubkey(),
-                    mint_program: self.mint_program.pubkey(),
+                    st_sol_mint: self.st_sol_mint.pubkey(),
                     reserve_authority: self.reserve_authority,
                     validator_token: *validator_token,
                 },
@@ -638,7 +638,7 @@ pub async fn simple_add_validator_to_pool(
         payer,
         recent_blockhash,
         &validator_stake.validator_token_account,
-        &lido_accounts.mint_program.pubkey(),
+        &lido_accounts.st_sol_mint.pubkey(),
         &validator_stake.validator_token_account.pubkey(),
     )
     .await


### PR DESCRIPTION
What used to be called the "mint program" was not actually a program id. The address does not hold a Solana program. It holds data for and SPL token mint. This was very confusing, rename it.