### PR TITLE
Fix bug where bot could try to stake less than the minimum amount

### DIFF
--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -453,5 +453,11 @@ mod test {
             None,
             "Should not try to stake, this is not enough for a rent-exempt stake account.",
         );
+
+        // If we add a bit more, then we can fund two stake accounts, and that
+        // should be enough to trigger a StakeDeposit.
+        state.reserve_account.lamports += minimum_stake_account_balance.0 + 1;
+
+        assert!(state.try_stake_deposit().is_some());
     }
 }


### PR DESCRIPTION
Fixes #215.

We should check that the amount to deposit is at least the rent-exempt reserve of a stake account *after* determining the amount to deposit. That the reserve contains enough, is the wrong check, because we may want to split that over multiple validators.

Also add a regression test, and simplify the types a bit while I’m at it.