### PR TITLE
Run "apt update" for nightly build as well

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,16 +27,19 @@ jobs:
         restore-keys: |
           cargo-bpf-1.7.3
 
-    - name: Build on-chain BPF programs
+    - name: Install dependencies
       run: |
+        sudo apt update
         sudo apt-get install -y libudev-dev
         sh -c "$(curl -sSfL https://release.solana.com/v1.7.3/install)"
+
+    - name: Build on-chain BPF programs
+      run: |
         export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
 
-        # Build all BPF programs in the workspace, including the SPL stake pool,
+        # Build all BPF programs in the workspace, including the multisig program,
         # because we will need them later to test Solido.
         cargo build-bpf
-
 
     - name: Build CLI client
       run: cargo build --bin solido


### PR DESCRIPTION
This is analogous to #211, [this build ran last night](https://github.com/ChorusOne/solido/actions/runs/959158963), but failed due to the same problem that that PR fixed for the push build.

Also rename the workflow to "nightly" so we can tell them apart from the push builds on the Actions page.