### PR TITLE
Set a safe minimum stake account balance to avoid stake merging footgun

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -33,3 +33,39 @@ pub fn find_authority_program_address(
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[&lido_address.to_bytes(), authority], program_id)
 }
+
+/// The minimum amount to put in a stake account (1 SOL).
+///
+/// For stake accounts, there is a minimum balance for the account to be
+/// rent-exempt, that depends on the size of the stake program's stake state
+/// struct. But aside from this minimum, in order to merge two stake accounts,
+/// their `credits_observed` must match. If the rewards received is less than a
+/// single Lamport, then `credits_observed` will not be updated, and then the
+/// stake account cannot be merged into a different stake account. Because we
+/// need to be able to merge stake accounts, we also need to make sure that they
+/// contain enough stake that they will earn at least one lamport per epoch.
+/// 1 SOL should be sufficient for that.
+pub const MINIMUM_STAKE_ACCOUNT_BALANCE: token::Lamports = token::Lamports(1_000_000_000);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn minimum_stake_account_balance_is_at_least_rent_exempt() {
+        use crate::token::Lamports;
+        use solana_program::rent::Rent;
+        use spl_stake_pool::stake_program::StakeState;
+
+        let rent = Rent::default();
+        let minimum_rent_exempt_balance =
+            Lamports(rent.minimum_balance(std::mem::size_of::<StakeState>()));
+
+        // Sanity check that the default rent instance is not for free. In theory
+        // the rent could change dynamically on the network, but in practice,
+        // it has been hard-coded since forever, and it is unlikely to suddenly
+        // change, because half the Solana ecosystem would break.
+        assert!(minimum_rent_exempt_balance > Lamports(0));
+        assert!(MINIMUM_STAKE_ACCOUNT_BALANCE > minimum_rent_exempt_balance);
+    }
+}

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -21,7 +21,7 @@ use crate::{
         LIDO_VERSION,
     },
     token::{Lamports, StLamports},
-    DEPOSIT_AUTHORITY, RESERVE_AUTHORITY, VALIDATOR_STAKE_ACCOUNT,
+    DEPOSIT_AUTHORITY, MINIMUM_STAKE_ACCOUNT_BALANCE, RESERVE_AUTHORITY, VALIDATOR_STAKE_ACCOUNT,
 };
 
 use {
@@ -160,13 +160,11 @@ pub fn process_stake_deposit(
     let mut lido = deserialize_lido(program_id, accounts.lido)?;
     lido.check_maintainer(accounts.maintainer)?;
 
-    let minimum_stake_balance =
-        Lamports(rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>()));
-    if amount < minimum_stake_balance {
-        msg!("Trying to stake less than the minimum balance of a stake account.");
+    if amount < MINIMUM_STAKE_ACCOUNT_BALANCE {
+        msg!("Trying to stake less than the minimum stake account balance.");
         msg!(
             "Need as least {} but got {}.",
-            minimum_stake_balance,
+            MINIMUM_STAKE_ACCOUNT_BALANCE,
             amount
         );
         return Err(LidoError::InvalidAmount.into());


### PR DESCRIPTION
I just learned that there is an idiosyncrasy in Solana stake accounts, that may prevent them from being merged. To avoid this footgun, we need to make sure that a stake account contains sufficient balance, which is supposedly more than the minimum rent-exempt balance. The exact minimum safe value is not known, but supposedly 1 SOL is sufficient (this is what the stake pool uses).