### PR TITLE
Restore serialization without intermediate buffer

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -202,15 +202,11 @@ impl Lido {
     }
 
     pub fn save(&self, account: &AccountInfo) -> ProgramResult {
-        // For some reason, calling self.serialize(&mut *account.data.borrow_mut())
-        // stopped working; it leaves the data with size zero. As a workaround
-        // serialize to an intermediate buffer first, and then overwrite the
-        // data in the account. ¯\_(ツ)_/¯
-        // Also, we don't use Vec::with_capacity here, because the account may
-        // be so large that the program goes out of memory.
-        let mut buf = Vec::new();
-        BorshSerialize::serialize(self, &mut buf)?;
-        account.data.borrow_mut()[..buf.len()].copy_from_slice(&buf[..]);
+        // NOTE: If you ended up here because the tests are failing because the
+        // runtime complained that an account's size was modified by a program
+        // that wasn't its owner, double check that the name passed to
+        // ProgramTest matches the name of the crate.
+        BorshSerialize::serialize(self, &mut *account.data.borrow_mut())?;
         Ok(())
     }
 }


### PR DESCRIPTION
[I promised to still fix this](https://github.com/ChorusOne/solido/pull/225#discussion_r657223408) after #225.