### PR TITLE
Fix caches.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
           multisig/target
         key: cargo-bpf-1.7.3-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
-          cargo-bpf-1.7.3-${{ hashFiles('Cargo.lock') }}
           cargo-bpf-1.7.3
 
     - name: Build on-chain BPF programs
@@ -115,7 +114,6 @@ jobs:
         path: target
         key: cargo-clippy-1.7.3-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
-          cargo-clippy-1.7.3-${{ hashFiles('Cargo.lock') }}
           cargo-clippy-1.7.3
 
     - name: Install linters
@@ -154,7 +152,6 @@ jobs:
           path: target
           key: cargo-tarpaulin-1.7.3-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            cargo-tarpaulin-1.7.3-${{ hashFiles('Cargo.lock') }}
             cargo-tarpaulin-1.7.3
 
       - name: Generate code coverage

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,6 @@ jobs:
           multisig/target
         key: cargo-bpf-1.7.3-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
-          cargo-bpf-1.7.3-${{ hashFiles('Cargo.lock') }}
           cargo-bpf-1.7.3
 
     - name: Build on-chain BPF programs


### PR DESCRIPTION
When we change the Solana toolkit, there are some issues that can lead to reusing invalid caches. This commit appends the cache keys with the Solana toolkit version.