### PR TITLE
Run `UpdateExchangeRate` from maintenance bot

### DIFF
--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -35,7 +35,6 @@ struct MaintenanceMetrics {
 
     /// Number of times we performed `UpdateExchangeRate`.
     transactions_update_exchange_rate: u64,
-
     // TODO(#96#issuecomment-859388866): Track how much the daemon spends on transaction fees,
     // so we know how much SOL it costs to operate.
     // spent_lamports_total: u64


### PR DESCRIPTION
This is a follow-up to #233. After adding the instruction to update the exchange rate, we need to call it once per epoch.