### PR TITLE
fix: removed spurious termination character from build file

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -39,7 +39,7 @@ RUN cd $SOLIDOBUILDPATH \
 # Hash on-chain programs
 RUN cd $SOLIDORELEASEPATH/deploy \
     && sha256sum lido.so >> lido.hash \
-    && sha256sum multisig.so >> multisig.hash \
+    && sha256sum multisig.so >> multisig.hash
 
 
 # Hash CLI


### PR DESCRIPTION
The extra character was causing the build to break