### PR TITLE
Adds the option to load the config file from environment variables.

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -24,7 +24,7 @@ pub fn get_option_from_config<T: FromStr>(
     }
 }
 
-pub fn get_option_from_env<'a, T: FromStr>(str_key: &'a str) -> Option<T> {
+pub fn get_option_from_env<T: FromStr>(str_key: &str) -> Option<T> {
     let env_var = (std::env::var(str_key)).ok()?;
     match T::from_str(&env_var) {
         Ok(t) => Some(t),


### PR DESCRIPTION
Modifies the `cli_opt_struct` macro to also search for environment variables in the order: program arguments, config file, environment variable.

Closes #261