### PR TITLE
Exclude 100%-commission validator in test setup

### DIFF
--- a/tests/prepare_test_environment.py
+++ b/tests/prepare_test_environment.py
@@ -158,8 +158,14 @@ current_validators = json.loads(solana('validators', '--output', 'json'))
 
 # Filter out the validators that are actually voting. On a local testnet, this
 # will only contain the test validator, but on devnet or testnet, there can be
-# more validators.
-active_validators = [v for v in current_validators['validators'] if not v['delinquent']]
+# more validators. Only include validators with less than 50% commission. On the
+# devnet there are a few 100%-commission validators, but these are not
+# interesting to include for testing, because they don't generate rewards for us.
+active_validators = [
+    v
+    for v in current_validators['validators']
+    if (not v['delinquent']) and v['commission'] < 50
+]
 
 # Add up to 5 of the active validators. Locally there will only be one, but on
 # the devnet or testnet there can be more, and we don't want to add *all* of them.


### PR DESCRIPTION
When we prepare an instance for devnet, we include some real validators, but previously we did not look at the commission. If we include a 100%-commission validator, that's not interesting to test with, because it will not generate any rewards for Lido.