### PR TITLE
Extend the opts macro to the general options.

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -79,7 +79,7 @@ pub fn get_option_from_env<T: FromStr>(str_key: &str) -> Option<T> {
 /// }
 ///
 /// impl FooOpts {
-///     pub fn merge_with_config(&mut self, config_file: &Option<ConfigFile>);
+///     pub fn merge_with_config_and_environment(&mut self, config_file: &Option<ConfigFile>);
 /// }
 /// ```
 /// When `merge_with_config(config_file)` is called, it will set the fields of
@@ -120,7 +120,7 @@ macro_rules! cli_opt_struct {
             /// present in the config file. When failing, prints all the missing
             /// fields.
             #[allow(dead_code)]
-            pub fn merge_with_config(&mut self, config_file: Option<&ConfigFile>) {
+            pub fn merge_with_config_and_environment(&mut self, config_file: Option<&ConfigFile>) {
                 let mut failed = false;
                 $(
                     let from_cli = self.$field.take();

--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -43,15 +43,21 @@ pub struct MultisigOpts {
 }
 
 impl MultisigOpts {
-    pub fn merge_with_config(&mut self, config_file: Option<&ConfigFile>) {
+    pub fn merge_with_config_and_environment(&mut self, config_file: Option<&ConfigFile>) {
         match &mut self.subcommand {
-            SubCommand::CreateMultisig(opts) => opts.merge_with_config(config_file),
-            SubCommand::ShowMultisig(opts) => opts.merge_with_config(config_file),
-            SubCommand::ShowTransaction(opts) => opts.merge_with_config(config_file),
-            SubCommand::ProposeUpgrade(opts) => opts.merge_with_config(config_file),
-            SubCommand::ProposeChangeMultisig(opts) => opts.merge_with_config(config_file),
-            SubCommand::Approve(opts) => opts.merge_with_config(config_file),
-            SubCommand::ExecuteTransaction(opts) => opts.merge_with_config(config_file),
+            SubCommand::CreateMultisig(opts) => opts.merge_with_config_and_environment(config_file),
+            SubCommand::ShowMultisig(opts) => opts.merge_with_config_and_environment(config_file),
+            SubCommand::ShowTransaction(opts) => {
+                opts.merge_with_config_and_environment(config_file)
+            }
+            SubCommand::ProposeUpgrade(opts) => opts.merge_with_config_and_environment(config_file),
+            SubCommand::ProposeChangeMultisig(opts) => {
+                opts.merge_with_config_and_environment(config_file)
+            }
+            SubCommand::Approve(opts) => opts.merge_with_config_and_environment(config_file),
+            SubCommand::ExecuteTransaction(opts) => {
+                opts.merge_with_config_and_environment(config_file)
+            }
         }
     }
 }


### PR DESCRIPTION
This allows us to set in the config file:
- keypair_path.
- cluster.
- output_mode.