### PR TITLE
fix:  small fix to not use uncoupled literals to aid overriding paths

### DIFF
--- a/tests/prepare_test_environment.py
+++ b/tests/prepare_test_environment.py
@@ -18,14 +18,15 @@ from util import (
     solana,
     solido,
     multisig,
+    get_solido_program_path,
 )
 
 print('\nUploading Solido program ...')
-solido_program_id = solana_program_deploy('target/deploy/lido.so')
+solido_program_id = solana_program_deploy(get_solido_program_path() + '/lido.so')
 print(f'> Solido program id is {solido_program_id}')
 
 print('\nUploading Multisig program ...')
-multisig_program_id = solana_program_deploy('target/deploy/multisig.so')
+multisig_program_id = solana_program_deploy(get_solido_program_path() + '/multisig.so')
 print(f'> Multisig program id is {multisig_program_id}')
 
 os.makedirs('tests/.keys', exist_ok=True)


### PR DESCRIPTION
I ran into this when trying to deploy the devnet version of v0.2.0. Small fix to enable these to be overridden