### PR TITLE
Airdrop more SOL in nightly test against testnet

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,26 +44,27 @@ jobs:
     - name: Build CLI client
       run: cargo build --bin solido
 
-    - name: Run Solido integration test against testnet
+    - name: Run Solido integration test against devnet
       run: |
         export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
 
         solana-keygen new --no-bip39-passphrase --silent
-        solana config set --url https://api.testnet.solana.com
-        # Loop airdrop as devnet doesn't seem to support large drops
-        for i in {1..20}; do solana airdrop 1.0; sleep 30;  done
+        solana config set --url https://api.devnet.solana.com
 
-        NETWORK='https://api.testnet.solana.com' tests/test_solido.py
+        # Loop airdrop as devnet allows at most 10 SOL at a time.
+        for i in {1..4}; do solana airdrop 10.0; sleep 20;  done
 
-    - name: Run Multisig integration test against testnet
+        NETWORK='https://api.devnet.solana.com' tests/test_solido.py
+
+    - name: Run Multisig integration test against devnet
       run: |
         export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
 
         # We don't need to run keygen/setup again, the private key and state
         # should still be there from the previous run.
 
-        # Loop airdrop as devnet doesn't seem to support large drops
-        for i in {1..20}; do solana airdrop 1.0; sleep 30;  done
+        # Loop airdrop as devnet allows at most 10 SOL at a time.
+        for i in {1..4}; do solana airdrop 10.0; sleep 20;  done
 
-        NETWORK='https://api.testnet.solana.com' tests/test_multisig.py
+        NETWORK='https://api.devnet.solana.com' tests/test_multisig.py
 


### PR DESCRIPTION
`solana program deploy` fails in nightly, and I suspect it's because of insufficient funds.