### PR TITLE
Replace `.unwrap()` in http thread with user-friendly error

### DIFF
--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -244,7 +244,18 @@ fn start_http_server(
     opts: &RunMaintainerOpts,
     snapshot_mutex: Arc<SnapshotMutex>,
 ) -> Vec<JoinHandle<()>> {
-    let server = Arc::new(Server::http(opts.listen().clone()).unwrap());
+    let server = match Server::http(opts.listen().clone()) {
+        Ok(server) => Arc::new(server),
+        Err(err) => {
+            eprintln!(
+                "Error: {}\nFailed to start http server on {}. Is the daemon already running?",
+                err,
+                opts.listen(),
+            );
+            std::process::exit(1);
+        }
+    };
+
     println!("Http server listening on {}", opts.listen());
 
     // Spawn a number of http handler threads, so we can handle requests in


### PR DESCRIPTION
When starting the http server and the port is already in use, print a frienly message, instead of the `.unwrap()` panic message.

Relates to #292.