### PR TITLE
Add tests for `AccountMap`

### DIFF
--- a/program/src/account_map.rs
+++ b/program/src/account_map.rs
@@ -91,14 +91,14 @@ impl<T: Default + EntryConstantSize> AccountMap<T> {
         self.entries
             .iter()
             .find(|pe| &pe.pubkey == address)
-            .ok_or_else(|| LidoError::InvalidAccountMember)
+            .ok_or(LidoError::InvalidAccountMember)
     }
 
     pub fn get_mut(&mut self, address: &Pubkey) -> Result<&mut PubkeyAndEntry<T>, LidoError> {
         self.entries
             .iter_mut()
             .find(|pe| &pe.pubkey == address)
-            .ok_or_else(|| LidoError::InvalidAccountMember)
+            .ok_or(LidoError::InvalidAccountMember)
     }
 
     /// Return how many bytes are needed to serialize an instance holding `max_entries`.


### PR DESCRIPTION
I was going over the coverage results of #238, and one of the things missing test coverage in `program/` were the error cases of `AccountMap`, so add a few basic tests.