### PR TITLE
Simplify `LidoInstruction` serialization

### DIFF
--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -184,7 +184,7 @@ pub fn command_create_solido(
             developer_account: developer_keypair.pubkey(),
             reserve_account,
         },
-    )?);
+    ));
 
     config.sign_and_send_transaction(&instructions[..], &[config.signer, &lido_keypair])?;
     eprintln!("Did send Lido init.");
@@ -217,7 +217,7 @@ pub fn command_add_validator(
             validator_vote_account: *opts.validator_vote_account(),
             validator_fee_st_sol_account: *opts.validator_fee_account(),
         },
-    )?;
+    );
     propose_instruction(
         config,
         opts.multisig_program_id(),
@@ -240,7 +240,7 @@ pub fn command_add_maintainer(
             manager: multisig_address,
             maintainer: *opts.maintainer_address(),
         },
-    )?;
+    );
     propose_instruction(
         config,
         opts.multisig_program_id(),
@@ -263,7 +263,7 @@ pub fn command_remove_maintainer(
             manager: multisig_address,
             maintainer: *opts.maintainer_address(),
         },
-    )?;
+    );
     propose_instruction(
         config,
         opts.multisig_program_id(),
@@ -553,7 +553,7 @@ pub fn command_deposit(
                 reserve_account: reserve,
             },
             *opts.amount_sol(),
-        )?;
+        );
 
         config.sign_and_send_transaction(&[instr], &[config.signer])?;
 

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -378,8 +378,7 @@ impl SolidoState {
                 stake_authority: self.get_stake_authority(),
             },
             amount_to_deposit,
-        )
-        .expect("Failed to construct StakeDeposit instruction.");
+        );
         let task = MaintenanceOutput::StakeDeposit {
             validator_vote_account: validator.pubkey,
             amount: amount_to_deposit,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -72,6 +72,17 @@ pub enum LidoInstruction {
     MergeStake,
 }
 
+impl LidoInstruction {
+    pub fn to_vec(&self) -> Vec<u8> {
+        // `BorshSerialize::try_to_vec` returns a Result, because it uses
+        // `Borsh::serialize`, which takes an arbitrary writer, and which can
+        // therefore return an IoError. But when serializing to a vec, there
+        // is no IO, so for this particular writer, it should never fail.
+        self.try_to_vec()
+            .expect("Serializing an Instruction to Vec<u8> does not fail.")
+    }
+}
+
 accounts_struct! {
     InitializeAccountsMeta, InitializeAccountsInfo {
         pub lido {
@@ -109,18 +120,17 @@ pub fn initialize(
     max_validators: u32,
     max_maintainers: u32,
     accounts: &InitializeAccountsMeta,
-) -> Result<Instruction, ProgramError> {
-    let init_data = LidoInstruction::Initialize {
+) -> Instruction {
+    let data = LidoInstruction::Initialize {
         reward_distribution,
         max_validators,
         max_maintainers,
     };
-    let data = init_data.try_to_vec()?;
-    Ok(Instruction {
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data,
-    })
+        data: data.to_vec(),
+    }
 }
 
 accounts_struct! {
@@ -159,14 +169,13 @@ pub fn deposit(
     program_id: &Pubkey,
     accounts: &DepositAccountsMeta,
     amount: Lamports,
-) -> Result<Instruction, ProgramError> {
-    let init_data = LidoInstruction::Deposit { amount };
-    let data = init_data.try_to_vec()?;
-    Ok(Instruction {
+) -> Instruction {
+    let data = LidoInstruction::Deposit { amount };
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data,
-    })
+        data: data.to_vec(),
+    }
 }
 
 accounts_struct! {
@@ -220,14 +229,13 @@ pub fn stake_deposit(
     program_id: &Pubkey,
     accounts: &StakeDepositAccountsMeta,
     amount: Lamports,
-) -> Result<Instruction, ProgramError> {
-    let init_data = LidoInstruction::StakeDeposit { amount };
-    let data = init_data.try_to_vec()?;
-    Ok(Instruction {
+) -> Instruction {
+    let data = LidoInstruction::StakeDeposit { amount };
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data,
-    })
+        data: data.to_vec(),
+    }
 }
 
 accounts_struct! {
@@ -253,12 +261,10 @@ pub fn update_exchange_rate(
     program_id: &Pubkey,
     accounts: &UpdateExchangeRateAccountsMeta,
 ) -> Instruction {
-    // There is no reason why `try_to_vec` should fail here.
-    let data = LidoInstruction::UpdateExchangeRate.try_to_vec().unwrap();
     Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data,
+        data: LidoInstruction::UpdateExchangeRate.to_vec(),
     }
 }
 
@@ -315,12 +321,10 @@ pub fn withdraw_inactive_stake(
     program_id: &Pubkey,
     accounts: &WithdrawInactiveStakeMeta,
 ) -> Instruction {
-    // There is no reason why `try_to_vec` should fail here.
-    let data = LidoInstruction::WithdrawInactiveStake.try_to_vec().unwrap();
     Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data,
+        data: LidoInstruction::WithdrawInactiveStake.to_vec(),
     }
 }
 
@@ -391,12 +395,10 @@ pub fn collect_validator_fee(
     program_id: &Pubkey,
     accounts: &CollectValidatorFeeMeta,
 ) -> Instruction {
-    // There is no reason why `try_to_vec` should fail here.
-    let data = LidoInstruction::CollectValidatorFee.try_to_vec().unwrap();
     Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data,
+        data: LidoInstruction::CollectValidatorFee.to_vec(),
     }
 }
 
@@ -469,12 +471,13 @@ pub fn add_validator(
     program_id: &Pubkey,
     weight: Weight,
     accounts: &AddValidatorMeta,
-) -> Result<Instruction, ProgramError> {
-    Ok(Instruction {
+) -> Instruction {
+    let data = LidoInstruction::AddValidator { weight };
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data: LidoInstruction::AddValidator { weight }.try_to_vec()?,
-    })
+        data: data.to_vec(),
+    }
 }
 
 accounts_struct! {
@@ -496,15 +499,12 @@ accounts_struct! {
     }
 }
 
-pub fn remove_validator(
-    program_id: &Pubkey,
-    accounts: &RemoveValidatorMeta,
-) -> Result<Instruction, ProgramError> {
-    Ok(Instruction {
+pub fn remove_validator(program_id: &Pubkey, accounts: &RemoveValidatorMeta) -> Instruction {
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data: LidoInstruction::RemoveValidator.try_to_vec()?,
-    })
+        data: LidoInstruction::RemoveValidator.to_vec(),
+    }
 }
 
 accounts_struct! {
@@ -529,15 +529,12 @@ accounts_struct! {
     }
 }
 
-pub fn claim_validator_fees(
-    program_id: &Pubkey,
-    accounts: &ClaimValidatorFeeMeta,
-) -> Result<Instruction, ProgramError> {
-    Ok(Instruction {
+pub fn claim_validator_fees(program_id: &Pubkey, accounts: &ClaimValidatorFeeMeta) -> Instruction {
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data: LidoInstruction::ClaimValidatorFees.try_to_vec()?,
-    })
+        data: LidoInstruction::ClaimValidatorFees.to_vec(),
+    }
 }
 
 accounts_struct! {
@@ -557,15 +554,12 @@ accounts_struct! {
     }
 }
 
-pub fn add_maintainer(
-    program_id: &Pubkey,
-    accounts: &AddMaintainerMeta,
-) -> Result<Instruction, ProgramError> {
-    Ok(Instruction {
+pub fn add_maintainer(program_id: &Pubkey, accounts: &AddMaintainerMeta) -> Instruction {
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data: LidoInstruction::AddMaintainer.try_to_vec()?,
-    })
+        data: LidoInstruction::AddMaintainer.to_vec(),
+    }
 }
 
 accounts_struct! {
@@ -585,15 +579,12 @@ accounts_struct! {
     }
 }
 
-pub fn remove_maintainer(
-    program_id: &Pubkey,
-    accounts: &RemoveMaintainerMeta,
-) -> Result<Instruction, ProgramError> {
-    Ok(Instruction {
+pub fn remove_maintainer(program_id: &Pubkey, accounts: &RemoveMaintainerMeta) -> Instruction {
+    Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data: LidoInstruction::RemoveMaintainer.try_to_vec()?,
-    })
+        data: LidoInstruction::RemoveMaintainer.to_vec(),
+    }
 }
 
 accounts_struct! {

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -312,8 +312,7 @@ impl Context {
                         developer_account: result.developer_st_sol_account,
                         reserve_account: result.reserve_address,
                     },
-                )
-                .unwrap(),
+                ),
             ],
             vec![&result.solido],
         )
@@ -537,8 +536,7 @@ impl Context {
                     manager: self.manager.pubkey(),
                     maintainer: maintainer,
                 },
-            )
-            .unwrap()],
+            )],
             vec![&self.manager],
         )
         .await
@@ -564,8 +562,7 @@ impl Context {
                     manager: self.manager.pubkey(),
                     maintainer: maintainer,
                 },
-            )
-            .unwrap()],
+            )],
             vec![&self.manager],
         )
         .await
@@ -587,8 +584,7 @@ impl Context {
                     validator_vote_account: accounts.vote_account,
                     validator_fee_st_sol_account: accounts.fee_account,
                 },
-            )
-            .unwrap()],
+            )],
             vec![&self.manager],
         )
         .await
@@ -624,8 +620,7 @@ impl Context {
                     manager: self.manager.pubkey(),
                     validator_vote_account_to_remove: vote_account,
                 },
-            )
-            .unwrap()],
+            )],
             vec![&self.manager],
         )
         .await
@@ -656,8 +651,7 @@ impl Context {
                     mint_authority: self.mint_authority,
                 },
                 amount,
-            )
-            .unwrap()],
+            )],
             vec![&user],
         )
         .await
@@ -723,8 +717,7 @@ impl Context {
                     stake_authority: self.stake_authority,
                 },
                 amount,
-            )
-            .unwrap()],
+            )],
             vec![maintainer],
         )
         .await?;


### PR DESCRIPTION
Serializing to a byte array should never fail; we don't need to fiddle around with `Result` everywhere.

Although it shouldn’t matter at runtime, this does also reduce the number of `unwrap` calls, which helps for #292.