### PR TITLE
Correct name in `show-solido` validator print

### DIFF
--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -418,16 +418,34 @@ impl fmt::Display for ShowSolidoOutput {
         for pe in &self.solido.validators.entries {
             writeln!(
                 f,
-                "  - \
+                "\n  - \
                 Vote account:  {}\n    \
                 Fee address:   {}\n    \
-                Unclaimed fee: {}",
-                pe.pubkey, pe.entry.fee_address, pe.entry.fee_credit
+                Unclaimed fee: {}\n    \
+                Stake:         {}\n    \
+                Stake accounts (seed, address):",
+                pe.pubkey,
+                pe.entry.fee_address,
+                pe.entry.fee_credit,
+                pe.entry.stake_accounts_balance,
             )?;
+            for seed in pe.entry.stake_accounts_seed_begin..pe.entry.stake_accounts_seed_end {
+                writeln!(
+                    f,
+                    "      - {}: {}",
+                    seed,
+                    pe.find_stake_account_address(
+                        &self.solido_program_id,
+                        &self.solido_address,
+                        seed
+                    )
+                    .0
+                )?;
+            }
         }
         writeln!(
             f,
-            "\nMaintainers: {} in use out of {} that the instance can support",
+            "\nMaintainers: {} in use out of {} that the instance can support\n",
             self.solido.maintainers.len(),
             self.solido.maintainers.maximum_entries
         )?;


### PR DESCRIPTION
The key in the validator map is the vote account, not the stake account. Also print it over multiple lines, to make the output a bit more readable. And while I’m at it, print a bit more information. New output:

```
Validators: 1 in use out of 10 that the instance can support

  - Vote account:  EAsHKTdxL9GELqQatEFFe3mbSBcbxyEiA8yoPihGhoM6
    Fee address:   B5iV2iu7yuiKqQRKSn4YJMj3LpmZaNfseHZ9X3nNgpaH
    Unclaimed fee: 0.000000000 stSOL
    Stake:         33394.736116078 SOL
    Stake accounts (seed, address):
      - 0: 6KdZAndEpXnjvrRXpa27sPSWqYXaevWSUhN9vRnCPNKq
      - 1: 64JSdne2Kz8RRHnuEFc1nhx3b44GWLbMn4mbPRLzw42r
```