### PR TITLE
Confirm that deactivating stake gains rewards

### DIFF
--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -520,6 +520,24 @@ impl Context {
         .expect("Failed to merge stake.");
     }
 
+    /// Deactivate a stake account, outside of Solido.
+    pub async fn deactivate_stake_account(
+        &mut self,
+        stake_account: Pubkey,
+        authorized_staker: &Keypair,
+    ) {
+        use solana_program::stake::instruction as stake;
+        let instruction = stake::deactivate_stake(&stake_account, &authorized_staker.pubkey());
+        send_transaction(
+            &mut self.context,
+            &mut self.nonce,
+            &[instruction],
+            vec![authorized_staker],
+        )
+        .await
+        .expect("Failed to deactivate stake.");
+    }
+
     /// Create a vote account for the given validator.
     pub async fn create_vote_account(&mut self, node_key: &Keypair) -> Pubkey {
         let rent = self.context.banks_client.get_rent().await.unwrap();

--- a/program/tests/tests/solana_assumptions.rs
+++ b/program/tests/tests/solana_assumptions.rs
@@ -65,3 +65,92 @@ async fn test_stake_merge_is_symmetric() {
 
     // If we get here, then both merges worked.
 }
+
+enum StakeMode {
+    Inactive,
+    Active,
+    Deactivating,
+}
+
+/// Set up a stake account, possibly activate it, wait for it to be active,
+/// possibly deactivate it, and then measure how many rewards we got.
+///
+/// We have to spin up the entire test context for this, to ensure that the
+/// stake being active or deactivating is the only difference. The staking
+/// rewards depend on the epoch number, and they appear to also depend on the
+/// stake history, so we can’t just measure in two consecutive epochs, because
+/// the rewards would differ.
+async fn measure_staking_rewards(mode: StakeMode) -> Lamports {
+    let amount = Lamports(1_000_000_000);
+
+    let mut context = Context::new_with_maintainer_and_validator().await;
+    let vote_account = context.validator.as_ref().unwrap().vote_account.clone();
+    let authority = context.deterministic_keypair.new_keypair();
+
+    let epoch_schedule = context.context.genesis_config().epoch_schedule;
+    let slots_per_epoch = epoch_schedule.slots_per_epoch;
+    let start_slot = epoch_schedule.first_normal_slot;
+
+    context.context.warp_to_slot(start_slot).unwrap();
+
+    // Create a stake account and delegate it to the vote account, which is a
+    // 100% commission vote account, so all rewards go to the vote account.
+    let stake_account = context
+        .create_stake_account(amount, authority.pubkey())
+        .await;
+
+    match mode {
+        StakeMode::Inactive => { /* Don't activate the stake if we want inactive stake. */ }
+        StakeMode::Active | StakeMode::Deactivating => {
+            context
+                .delegate_stake_account(stake_account, vote_account, &authority)
+                .await;
+        }
+    }
+
+    // Move ahead one epoch so the stake becomes active.
+    context
+        .context
+        .warp_to_slot(start_slot + 1 * slots_per_epoch)
+        .unwrap();
+
+    let balance_t0 = context.get_sol_balance(vote_account).await;
+
+    // Deactivate the stake if needed.
+    match mode {
+        StakeMode::Inactive | StakeMode::Active => {}
+        StakeMode::Deactivating => {
+            context
+                .deactivate_stake_account(stake_account, &authority)
+                .await
+        }
+    }
+
+    // Vote, and then move one more epoch, so we get the validation rewards.
+    context
+        .context
+        .increment_vote_account_credits(&vote_account, 1);
+    context
+        .context
+        .warp_to_slot(start_slot + 2 * slots_per_epoch)
+        .unwrap();
+
+    let balance_t1 = context.get_sol_balance(vote_account).await;
+
+    (balance_t1 - balance_t0).unwrap()
+}
+
+/// Confirm that deactivating stake still earns rewards in that epoch.
+#[tokio::test]
+async fn test_deactivating_stake_earns_rewards() {
+    let rewards_inactive = measure_staking_rewards(StakeMode::Inactive).await;
+    let rewards_active = measure_staking_rewards(StakeMode::Active).await;
+    let rewards_deactivating = measure_staking_rewards(StakeMode::Deactivating).await;
+
+    // For some reason, when stake is deactivating, the rewards are always two
+    // lamports less. Two Lamports out of 1.2k SOL is a negligible difference,
+    // so we'll assume that deactivation does not prevent rewards.
+    assert_eq!(rewards_inactive, Lamports(0));
+    assert_eq!(rewards_active, Lamports(1_244_921_728_174));
+    assert_eq!(rewards_deactivating, Lamports(1_244_921_728_172));
+}


### PR DESCRIPTION
Solana does not document whether deactivating stake gains rewards, but it is essential for Lido to know for #93. If we do gain rewards, then churn (withdraw + re-deposit) does not cause us to miss rewards, so we do not need to prevent it.

It turns out, deactivating stake *does* still gain rewards, but it gains 2 lamports less than active stake, a difference of 0.000000000002%. :thinking: 

That difference is negligible for us, so I think we are good for withdraws :tada: 