### PR TITLE
Implement `Withdraw` in the client.

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -315,7 +315,7 @@ cli_opt_struct! {
          #[clap(long, value_name = "address")]
          solido_address: Pubkey,
 
-         /// Amount to withdraw, in stSOL, using . as decimal separator.
+         /// Amount to withdraw in stSOL, using . as decimal separator.
          #[clap(long, value_name = "st_sol")]
          amount_st_sol: StLamports,
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -11,8 +11,8 @@ use serde::Deserialize;
 use serde_json::Value;
 use solana_sdk::pubkey::{ParsePubkeyError, Pubkey};
 
-use lido::state::Weight;
 use lido::token::Lamports;
+use lido::{state::Weight, token::StLamports};
 
 pub fn get_option_from_config<T: FromStr>(
     name: &'static str,
@@ -302,6 +302,22 @@ cli_opt_struct! {
         /// Amount to deposit, in SOL, using . as decimal separator.
         #[clap(long, value_name = "sol")]
         amount_sol: Lamports,
+    }
+}
+
+cli_opt_struct! {
+    WithdrawOpts {
+         /// Address of the Solido program.
+         #[clap(long, value_name = "address")]
+         solido_program_id: Pubkey,
+
+         /// Account that stores the data for this Solido instance.
+         #[clap(long, value_name = "address")]
+         solido_address: Pubkey,
+
+         /// Amount to withdraw, in stSOL, using . as decimal separator.
+         #[clap(long, value_name = "st_sol")]
+         amount_st_sol: StLamports,
     }
 }
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -297,7 +297,7 @@ fn start_http_server(
 /// Run the maintenance daemon.
 pub fn main(config: &mut SnapshotClientConfig, opts: &RunMaintainerOpts) {
     let snapshot_mutex = Arc::new(Mutex::new(None));
-    let http_threads = start_http_server(&opts, snapshot_mutex.clone());
+    let http_threads = start_http_server(opts, snapshot_mutex.clone());
 
     run_main_loop(config, opts, &*snapshot_mutex);
 

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -654,6 +654,7 @@ pub fn command_withdraw(
             solido.get_stake_authority(opts.solido_program_id(), opts.solido_address())?;
 
         // Get heaviest validator.
+        // TODO(ruuda): Use `CliError` to handle the following error.
         let heaviest_validator = get_validator_to_withdraw(&solido.validators).map_err(|_| {
             MaintenanceError::new(
                 "The instance has no active validators to withdraw from.".to_owned(),

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -617,7 +617,7 @@ pub fn command_deposit(
 #[derive(Serialize)]
 pub struct WithdrawOutput {
     #[serde(serialize_with = "serialize_b58")]
-    pub from_token: Pubkey,
+    pub from_token_address: Pubkey,
 
     /// Amount of SOL that was withdrawn.
     pub withdrawn_sol: Lamports,
@@ -630,7 +630,7 @@ pub struct WithdrawOutput {
 
 impl fmt::Display for WithdrawOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "Withdrawn from:          {}", self.from_token)?;
+        writeln!(f, "Withdrawn from:          {}", self.from_token_address)?;
         writeln!(f, "Total SOL withdrawn:     {}", self.withdrawn_sol)?;
         writeln!(f, "New stake account:       {}", self.new_stake_account)?;
         Ok(())
@@ -701,7 +701,7 @@ pub fn command_withdraw(
         Ok(Lamports(stake_account.lamports()))
     })?;
     let result = WithdrawOutput {
-        from_token: st_sol_address,
+        from_token_address: st_sol_address,
         withdrawn_sol: stake_sol,
         new_stake_account: new_stake_account.pubkey(),
     };

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -5,18 +5,25 @@ use std::fmt;
 
 use serde::Serialize;
 use solana_program::{pubkey::Pubkey, system_instruction};
-use solana_sdk::signature::{Keypair, Signer};
+use solana_sdk::{
+    account::ReadableAccount,
+    signature::{Keypair, Signer},
+};
 
 use lido::{
     metrics::LamportsHistogram,
-    state::{Lido, RewardDistribution},
-    token::StLamports,
+    state::{Lido, RewardDistribution, Validator},
+    token::{Lamports, StLamports},
     util::serialize_b58,
     MINT_AUTHORITY, RESERVE_ACCOUNT,
 };
 
-use crate::config::{
-    AddRemoveMaintainerOpts, AddValidatorOpts, CreateSolidoOpts, DepositOpts, ShowSolidoOpts,
+use crate::{
+    config::{
+        AddRemoveMaintainerOpts, AddValidatorOpts, CreateSolidoOpts, DepositOpts, ShowSolidoOpts,
+        WithdrawOpts,
+    },
+    error::MaintenanceError,
 };
 use crate::{
     multisig::{get_multisig_program_address, propose_instruction, ProposeInstructionOutput},
@@ -603,6 +610,116 @@ pub fn command_deposit(
         expected_st_sol,
         st_sol_balance_increase,
         created_associated_st_sol_account: created_recipient,
+    };
+    Ok(result)
+}
+
+#[derive(Serialize)]
+pub struct WithdrawOutput {
+    #[serde(serialize_with = "serialize_b58")]
+    pub from_token: Pubkey,
+
+    /// Amount of SOL that was withdrawn.
+    pub withdrawn_sol: Lamports,
+
+    /// Newly created stake account, where the source stake account will be
+    /// split to.
+    #[serde(serialize_with = "serialize_b58")]
+    pub new_stake_account: Pubkey,
+}
+
+impl fmt::Display for WithdrawOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Withdrawn from:          {}", self.from_token)?;
+        writeln!(f, "Total SOL withdrawn:     {}", self.withdrawn_sol)?;
+        writeln!(f, "New stake account:       {}", self.new_stake_account)?;
+        Ok(())
+    }
+}
+
+pub fn command_withdraw(
+    config: &mut SnapshotClientConfig,
+    opts: &WithdrawOpts,
+) -> std::result::Result<WithdrawOutput, crate::error::Error> {
+    // Gets the token address and delegate it to us.
+    let (st_sol_address, stake_authority) = config.with_snapshot(|config| {
+        let solido = config.client.get_solido(opts.solido_address())?;
+        let token_address = spl_associated_token_account::get_associated_token_address(
+            &config.signer.pubkey(),
+            &solido.st_sol_mint,
+        );
+        let stake_authority =
+            solido.get_stake_authority(opts.solido_program_id(), opts.solido_address())?;
+
+        // Authorize the token to be burned.
+        let approve_instruction = spl_token::instruction::approve(
+            &spl_token::id(),
+            &token_address,
+            &stake_authority,
+            &config.signer.pubkey(),
+            &[],
+            u64::MAX,
+        )?;
+        config.sign_and_send_transaction(&[approve_instruction], &[config.signer])?;
+        Ok((token_address, stake_authority))
+    })?;
+
+    let (sol_amount, new_stake_account) = config.with_snapshot(|config| {
+        let solido = config.client.get_solido(opts.solido_address())?;
+        // Get heaviest validator.
+        let heaviest_validator = solido
+            .validators
+            .entries
+            .iter()
+            .max_by(|&x, &y| {
+                x.entry
+                    .stake_accounts_balance
+                    .cmp(&y.entry.stake_accounts_balance)
+            })
+            .ok_or_else(|| {
+                MaintenanceError::new(
+                    "The instance has no active validators to withdraw from.".to_owned(),
+                )
+            })?;
+
+        let (stake_address, _bump_seed) = Validator::find_stake_account_address(
+            opts.solido_program_id(),
+            opts.solido_address(),
+            &heaviest_validator.pubkey,
+            heaviest_validator.entry.stake_accounts_seed_begin,
+        );
+
+        let destination_stake_account = Keypair::new();
+
+        let instr = lido::instruction::withdraw(
+            opts.solido_program_id(),
+            &lido::instruction::WithdrawAccountsMeta {
+                lido: *opts.solido_address(),
+                st_sol_mint: solido.st_sol_mint,
+                st_sol_account_owner: config.signer.pubkey(),
+                st_sol_account: st_sol_address,
+                validator_vote_account: heaviest_validator.pubkey,
+                source_stake_account: stake_address,
+                destination_stake_account: destination_stake_account.pubkey(),
+                stake_authority,
+            },
+            *opts.amount_st_sol(),
+        );
+        config.sign_and_send_transaction(&[instr], &[config.signer, &destination_stake_account])?;
+
+        let stake_account = config
+            .client
+            .get_account(&destination_stake_account.pubkey())?;
+
+        Ok((
+            Lamports(stake_account.lamports()),
+            destination_stake_account.pubkey(),
+        ))
+    })?;
+    let result = WithdrawOutput {
+        from_token: st_sol_address,
+        withdrawn_sol: sol_amount,
+        new_stake_account,
     };
     Ok(result)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,6 +140,7 @@ REWARDS
     /// If the associated token account does not yet exist, it will be created.
     Deposit(DepositOpts),
 
+    /// Withdraw StSOL, receive a delegated stake account in return.
     Withdraw(WithdrawOpts),
 
     /// Show an instance of solido in detail

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,6 @@ mod daemon;
 mod error;
 mod helpers;
 mod maintenance;
-#[allow(clippy::all)]
 mod multisig;
 mod prometheus;
 mod snapshot;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use clap::Clap;
+use helpers::command_withdraw;
 use serde::Serialize;
 use solana_client::rpc_client::RpcClient;
 use solana_remote_wallet::locator::Locator;
@@ -138,6 +139,8 @@ REWARDS
     /// The recipient will be set to the associated token account for the signer.
     /// If the associated token account does not yet exist, it will be created.
     Deposit(DepositOpts),
+
+    Withdraw(WithdrawOpts),
 
     /// Show an instance of solido in detail
     ShowSolido(ShowSolidoOpts),
@@ -313,6 +316,11 @@ fn main() {
             let output = result.ok_or_abort_with("Failed to deposit.");
             print_output(output_mode, &output);
         }
+        SubCommand::Withdraw(cmd_opts) => {
+            let result = command_withdraw(&mut config, &cmd_opts);
+            let output = result.ok_or_abort_with("Failed to withdraw.");
+            print_output(output_mode, &output);
+        }
     }
 }
 
@@ -327,6 +335,7 @@ fn merge_with_config_and_environment(
             opts.merge_with_config_and_environment(config_file)
         }
         SubCommand::Deposit(opts) => opts.merge_with_config_and_environment(config_file),
+        SubCommand::Withdraw(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::ShowSolido(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::PerformMaintenance(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::Multisig(opts) => opts.merge_with_config_and_environment(config_file),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -141,6 +141,8 @@ REWARDS
     Deposit(DepositOpts),
 
     /// Withdraw StSOL, receive a delegated stake account in return.
+    ///
+    /// The amount of SOL is calculated and stored in the returned stake.
     Withdraw(WithdrawOpts),
 
     /// Show an instance of solido in detail

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,6 +33,7 @@ mod daemon;
 mod error;
 mod helpers;
 mod maintenance;
+#[allow(clippy)]
 mod multisig;
 mod prometheus;
 mod snapshot;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,7 @@ mod daemon;
 mod error;
 mod helpers;
 mod maintenance;
-#[allow(clippy)]
+#[allow(clippy::all)]
 mod multisig;
 mod prometheus;
 mod snapshot;

--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -518,12 +518,8 @@ impl fmt::Display for ShowTransactionOutput {
                         writeln!(f, "    Solido instance:       {}", solido_instance)?;
                         writeln!(f, "    Manager:               {}", manager)?;
                         writeln!(f)?;
-                        print_changed_reward_distribution(
-                            f,
-                            &current_solido,
-                            &reward_distribution,
-                        )?;
-                        print_changed_recipients(f, &current_solido, &fee_recipients)?;
+                        print_changed_reward_distribution(f, current_solido, reward_distribution)?;
+                        print_changed_recipients(f, current_solido, fee_recipients)?;
                     }
                 }
             }

--- a/cli/src/spl_token_utils.rs
+++ b/cli/src/spl_token_utils.rs
@@ -41,7 +41,7 @@ pub fn push_create_spl_token_mint(
     instructions.push(spl_token::instruction::initialize_mint(
         &spl_token::id(),
         &keypair.pubkey(),
-        &mint_authority,
+        mint_authority,
         freeze_authority,
         num_decimals,
     )?);

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -3,7 +3,8 @@
 
 //! Logic for keeping the stake pool balanced.
 
-use crate::state::Validators;
+use crate::account_map::PubkeyAndEntry;
+use crate::state::{Validator, Validators};
 use crate::{
     error::LidoError,
     token,
@@ -117,6 +118,20 @@ pub fn get_validator_furthest_below_target(
     }
 
     (index, amount)
+}
+
+pub fn get_validator_to_withdraw(
+    validators: &Validators,
+) -> Result<&PubkeyAndEntry<Validator>, crate::error::LidoError> {
+    validators
+        .entries
+        .iter()
+        .max_by(|&x, &y| {
+            x.entry
+                .stake_accounts_balance
+                .cmp(&y.entry.stake_accounts_balance)
+        })
+        .ok_or_else(|| LidoError::EmptySetOfValidators)
 }
 
 #[cfg(test)]

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -52,7 +52,7 @@ pub fn get_target_balance(
                 numerator: validator.weight.0 as u64,
                 denominator: total_weights,
             })
-        .map_err(|_| LidoError::NoActiveValidators)?
+        .map_err(|_| LidoError::EmptySetOfValidators)?
     }
 
     // The total lamports to distribute may be slightly larger than the total

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -131,7 +131,7 @@ pub fn get_validator_to_withdraw(
                 .stake_accounts_balance
                 .cmp(&y.entry.stake_accounts_balance)
         })
-        .ok_or_else(|| LidoError::EmptySetOfValidators)
+        .ok_or(LidoError::EmptySetOfValidators)
 }
 
 #[cfg(test)]

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -98,9 +98,9 @@ pub enum LidoError {
     /// required to hold variable structures
     #[error("InvalidAccountMember")]
     InvalidLidoSize = 26,
-    /// There are no validators with an active stake account to delegate to.
-    #[error("NoActiveValidators")]
-    NoActiveValidators = 27,
+    /// The instance has no validators.
+    #[error("EmptySetOfValidators")]
+    EmptySetOfValidators = 27,
 
     /// When staking part of the reserve to a new stake account, the next
     /// program-derived address for the stake account associated with the given
@@ -146,10 +146,6 @@ pub enum LidoError {
     /// There is a validator that has more stake than the selected one.
     #[error("ValidatorWithMoreStakeExists")]
     ValidatorWithMoreStakeExists = 37,
-
-    /// The instance has no validators.
-    #[error("EmptySetOfValidators")]
-    EmptySetOfValidators = 38,
 }
 
 impl From<ArithmeticError> for LidoError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -146,6 +146,10 @@ pub enum LidoError {
     /// There is a validator that has more stake than the selected one.
     #[error("ValidatorWithMoreStakeExists")]
     ValidatorWithMoreStakeExists = 37,
+
+    /// The instance has no validators.
+    #[error("EmptySetOfValidators")]
+    EmptySetOfValidators = 38,
 }
 
 impl From<ArithmeticError> for LidoError {

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -104,7 +104,7 @@ pub fn create_account_overwrite_if_exists<'a, 'b>(
             options.account.clone(),
             system_program.clone(),
         ],
-        &[&reserve_account_seeds, options.sign_seeds],
+        &[reserve_account_seeds, options.sign_seeds],
     )?;
     Ok(())
 }
@@ -162,10 +162,10 @@ pub fn mint_st_sol_to<'a>(
     let mint_to_signers = [];
 
     let instruction = spl_token::instruction::mint_to(
-        &spl_token_program.key,
-        &st_sol_mint.key,
-        &recipient.key,
-        &mint_authority.key,
+        spl_token_program.key,
+        st_sol_mint.key,
+        recipient.key,
+        mint_authority.key,
         &mint_to_signers,
         amount.0,
     )?;
@@ -211,10 +211,10 @@ pub fn burn_st_sol<'a, 'b>(
     // use those.
     let burn_signers = [];
     let instruction = spl_token::instruction::burn(
-        &accounts.spl_token.key,
-        &accounts.st_sol_account.key,
-        &accounts.st_sol_mint.key,
-        &accounts.st_sol_account_owner.key,
+        accounts.spl_token.key,
+        accounts.st_sol_account.key,
+        accounts.st_sol_mint.key,
+        accounts.st_sol_account_owner.key,
         &burn_signers,
         amount.0,
     )?;
@@ -237,9 +237,9 @@ pub fn transfer_stake_authority(
 ) -> ProgramResult {
     invoke_signed(
         &solana_program::stake::instruction::authorize(
-            &accounts.destination_stake_account.key,
-            &accounts.stake_authority.key,
-            &accounts.st_sol_account_owner.key,
+            accounts.destination_stake_account.key,
+            accounts.stake_authority.key,
+            accounts.st_sol_account_owner.key,
             StakeAuthorize::Withdrawer,
             None,
         ),
@@ -257,9 +257,9 @@ pub fn transfer_stake_authority(
     )?;
     invoke_signed(
         &solana_program::stake::instruction::authorize(
-            &accounts.destination_stake_account.key,
-            &accounts.stake_authority.key,
-            &accounts.st_sol_account_owner.key,
+            accounts.destination_stake_account.key,
+            accounts.stake_authority.key,
+            accounts.st_sol_account_owner.key,
             StakeAuthorize::Staker,
             None,
         ),

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -29,8 +29,8 @@ pub fn process_change_reward_distribution(
     let mut lido = deserialize_lido(program_id, accounts.lido)?;
     lido.check_manager(accounts.manager)?;
 
-    lido.check_is_st_sol_account(&accounts.treasury_account)?;
-    lido.check_is_st_sol_account(&accounts.developer_account)?;
+    lido.check_is_st_sol_account(accounts.treasury_account)?;
+    lido.check_is_st_sol_account(accounts.developer_account)?;
 
     lido.reward_distribution = new_reward_distribution;
     lido.fee_recipients.treasury_account = *accounts.treasury_account.key;
@@ -48,7 +48,7 @@ pub fn process_add_validator(
     let mut lido = deserialize_lido(program_id, accounts.lido)?;
     let rent = &Rent::from_account_info(accounts.sysvar_rent)?;
     lido.check_manager(accounts.manager)?;
-    lido.check_is_st_sol_account(&accounts.validator_fee_st_sol_account)?;
+    lido.check_is_st_sol_account(accounts.validator_fee_st_sol_account)?;
 
     check_rent_exempt(
         rent,
@@ -225,7 +225,7 @@ pub fn process_merge_stake(program_id: &Pubkey, accounts_raw: &[AccountInfo]) ->
     let merge_instructions = solana_program::stake::instruction::merge(
         &to_stake_addr,
         &from_stake_addr,
-        &accounts.stake_authority.key,
+        accounts.stake_authority.key,
     );
 
     // For some reason, `merge` returns a `Vec`, but when we look at the

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -124,8 +124,8 @@ pub fn process_initialize(
     };
 
     // Confirm that the fee recipients are actually stSOL accounts.
-    lido.check_is_st_sol_account(&accounts.treasury_account)?;
-    lido.check_is_st_sol_account(&accounts.developer_account)?;
+    lido.check_is_st_sol_account(accounts.treasury_account)?;
+    lido.check_is_st_sol_account(accounts.developer_account)?;
 
     lido.save(accounts.lido)
 }
@@ -185,12 +185,12 @@ pub fn process_stake_deposit(
 
     let validator = lido
         .validators
-        .get_mut(&accounts.validator_vote_account.key)?;
+        .get_mut(accounts.validator_vote_account.key)?;
 
     let stake_account_bump_seed = Lido::check_stake_account(
         program_id,
-        &accounts.lido.key,
-        &validator,
+        accounts.lido.key,
+        validator,
         validator.entry.stake_accounts_seed_end,
         accounts.stake_account_end,
     )?;
@@ -216,7 +216,7 @@ pub fn process_stake_deposit(
     // Create the account that is going to hold the new stake account data.
     // Even if it was already funded.
     create_account_overwrite_if_exists(
-        &accounts.lido.key,
+        accounts.lido.key,
         CreateAccountOptions {
             fund_amount: amount,
             data_size: std::mem::size_of::<stake_program::state::StakeState>() as u64,
@@ -297,8 +297,8 @@ pub fn process_stake_deposit(
         }
         Lido::check_stake_account(
             program_id,
-            &accounts.lido.key,
-            &validator,
+            accounts.lido.key,
+            validator,
             // Does not underflow, because end > begin >= 0.
             validator.entry.stake_accounts_seed_end - 1,
             accounts.stake_account_merge_into,
@@ -384,8 +384,8 @@ pub fn withdraw_excess_inactive_sol<'a, 'b>(
     let stake_info = StakeAccount::from_delegated_account(
         Lamports(stake_account.lamports()),
         &stake,
-        &clock,
-        &stake_history,
+        clock,
+        stake_history,
         stake_account_seed,
     );
     let excess_balance = Lamports(

--- a/program/src/token.rs
+++ b/program/src/token.rs
@@ -135,64 +135,64 @@ macro_rules! impl_token {
                 Ok(sum)
             }
         }
+        /// Parse a numeric string as an amount of Lamports, i.e., with 9 digit precision.
+        ///
+        /// Note that this parses the Lamports amount divided by 10<sup>9</sup>,
+        /// which can include a decimal point. It does not parse the number of
+        /// Lamports! This makes this function the semi-inverse of `Display`
+        /// (only `Display` adds the suffixes, and we do not expect that
+        /// here).
+        impl std::str::FromStr for $TokenLamports {
+            type Err = &'static str;
+            fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+                let mut value = 0_u64;
+                let mut is_after_decimal = false;
+                let mut exponent = 9_i32;
+                let mut had_digit = false;
+
+                // Walk the bytes one by one, we only expect ASCII digits or '.', so bytes
+                // suffice. We build up the value as we go, and if we get past the decimal
+                // point, we also track how far we are past it.
+                for ch in s.as_bytes() {
+                    match ch {
+                        b'0'..=b'9' => {
+                            value = value * 10 + ((ch - b'0') as u64);
+                            if is_after_decimal {
+                                exponent -= 1;
+                            }
+                            had_digit = true;
+                        }
+                        b'.' if !is_after_decimal => is_after_decimal = true,
+                        b'.' => return Err("Value can contain at most one '.' (decimal point)."),
+                        b'_' => { /* As a courtesy, allow numeric underscores for readability. */ }
+                        _ => return Err("Invalid value, only digits, '_', and '.' are allowed."),
+                    }
+
+                    if exponent < 0 {
+                        return Err("Value can contain at most 9 digits after the decimal point.");
+                    }
+                }
+
+                if !had_digit {
+                    return Err("Value must contain at least one digit.");
+                }
+
+                // If the value contained fewer than 9 digits behind the decimal point
+                // (or no decimal point at all), scale up the value so it is measured
+                // in lamports.
+                while exponent > 0 {
+                    value *= 10;
+                    exponent -= 1;
+                }
+
+                Ok($TokenLamports(value))
+            }
+        }
     };
 }
 
 impl_token!(Lamports, "SOL");
 impl_token!(StLamports, "stSOL");
-
-/// Parse a numeric string as an amount of SOL.
-///
-/// Note that this parses the SOL, which can include a decimal point. It does
-/// not parse the number of lamports! This makes this function the semi-inverse
-/// of `Display` (only `Display` adds the "SOL" suffix, and we do not expect that
-/// here).
-impl std::str::FromStr for Lamports {
-    type Err = &'static str;
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let mut value = 0_u64;
-        let mut is_after_decimal = false;
-        let mut exponent = 9_i32;
-        let mut had_digit = false;
-
-        // Walk the bytes one by one, we only expect ASCII digits or '.', so bytes
-        // suffice. We build up the value as we go, and if we get past the decimal
-        // point, we also track how far we are past it.
-        for ch in s.as_bytes() {
-            match ch {
-                b'0'..=b'9' => {
-                    value = value * 10 + ((ch - b'0') as u64);
-                    if is_after_decimal {
-                        exponent -= 1;
-                    }
-                    had_digit = true;
-                }
-                b'.' if !is_after_decimal => is_after_decimal = true,
-                b'.' => return Err("A SOL value can contain at most one '.' (decimal point)."),
-                b'_' => { /* As a courtesy, allow numeric underscores for readability. */ }
-                _ => return Err("Invalid SOL value, only digits, '_', and '.' are allowed."),
-            }
-
-            if exponent < 0 {
-                return Err("A SOL value can contain at most 9 digits after the decimal point.");
-            }
-        }
-
-        if !had_digit {
-            return Err("A SOL value must contain at least one digit.");
-        }
-
-        // If the value contained fewer than 9 digits behind the decimal point
-        // (or no decimal point at all), scale up the value so it is measured
-        // in lamports.
-        while exponent > 0 {
-            value *= 10;
-            exponent -= 1;
-        }
-
-        Ok(Lamports(value))
-    }
-}
 
 #[cfg(test)]
 pub mod test {


### PR DESCRIPTION
Just as the `Deposit` instruction has a client-side implementation, this PR implements the client-side for `Withdraw`.
It's mainly useful for testing, as withdrawals will be done in the browser UI.