### PR TITLE
Rate limit airdrops in nightly tests even more

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
         solana config set --url https://api.devnet.solana.com
 
         # Loop airdrop as devnet allows at most 10 SOL at a time.
-        for i in {1..4}; do solana airdrop 10.0; sleep 20;  done
+        for i in {1..4}; do solana airdrop 10.0; sleep 30;  done
 
         NETWORK='https://api.devnet.solana.com' tests/test_solido.py
 
@@ -64,7 +64,7 @@ jobs:
         # should still be there from the previous run.
 
         # Loop airdrop as devnet allows at most 10 SOL at a time.
-        for i in {1..4}; do solana airdrop 10.0; sleep 20;  done
+        for i in {1..4}; do sleep 30; solana airdrop 10.0;  done
 
         NETWORK='https://api.devnet.solana.com' tests/test_multisig.py
 


### PR DESCRIPTION
The nightly build and test now made it through the Solido tests, but in the second airdrop of the second airdrop round, it failed again on rate limits. Slow down even more, so hopefully we make it through this round of airdrops too.