### PR TITLE
Prevent Codecov bot from commenting on pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+# Prevent the Codecov bot from commenting on every pull request.
+comment: false


### PR DESCRIPTION
I think this creates more noise than that it is helpful in most cases, let’s disable it.

Reference: https://docs.codecov.com/docs/pull-request-comments#disable-comment