### PR TITLE
Warn that transactions may have executed on error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,8 +140,8 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: lint-1.7.3-v3-${{ hashFiles('Cargo.lock') }}
-        restore-keys: lint-1.7.3-v3
+        key: lint-1.7.3-v4-${{ hashFiles('Cargo.lock') }}
+        restore-keys: lint-1.7.3-v4
 
     - name: Install linters
       run: |
@@ -153,6 +153,7 @@ jobs:
         # the same version locally.
         sudo pip3 install mypy==0.902
         rustup component add clippy
+        cargo install cargo-license --version 0.4.1
 
     - name: Run Clippy
       run: |
@@ -162,6 +163,10 @@ jobs:
     - name: Typecheck Python
       run: |
         git ls-files | grep '\.py$' | xargs mypy --strict
+
+    - name: Check license compatibility
+      run: |
+        tests/check_licenses.py
 
   coverage:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ This repository contains both the Solana program (./program) and a client (./cli
 the program.
 
 The full documentation can be found at [https://chorusone.github.io/solido/docs/](https://chorusone.github.io/solido/docs/)
+
+## License
+
+Solido is licensed under the GNU General Public License version 3.

--- a/docker/Dockerfile.maintainer
+++ b/docker/Dockerfile.maintainer
@@ -3,6 +3,8 @@ FROM chorusone/solido-base
 ENV SOLIDOBUILDPATH="/solido-build"
 ENV SOLIDOPATH="/solido"
 
+RUN cargo install cargo-license --version 0.4.1
+
 # Make dirs for build artefacts
 RUN mkdir -p $SOLIDOBUILDPATH
 
@@ -12,11 +14,17 @@ COPY . $SOLIDOBUILDPATH/
 RUN cd $SOLIDOBUILDPATH \
     && cargo build --release --bin solido
 
-
 RUN useradd -m -d $SOLIDOPATH solido
 
 # Copy from build container
 RUN cp -rf  /solido-build/target/release/* $SOLIDOPATH
+
+# Include list of dependency licenses, for redistribution.
+COPY LICENSE $SOLIDOPATH
+COPY docker/LICENSE $SOLIDOPATH/LICENSE-DEPENDENCIES
+RUN cd $SOLIDOBUILDPATH \
+    && cargo license --manifest-path cli/Cargo.toml --avoid-dev-deps --avoid-build-deps \
+    >> $SOLIDOPATH/LICENSE-DEPENDENCIES
 
 COPY docker/setup.sh $SOLIDOPATH
 

--- a/docker/LICENSE
+++ b/docker/LICENSE
@@ -1,0 +1,16 @@
+This file lists the dependencies of the "solido" command-line program, and their
+licenses. An up to date list can be generated with
+
+    cargo license --manifest-path cli/Cargo.toml --avoid-dev-deps --avoid-build-deps
+
+Solido itself is licensed under the GNU Public License version 3. The situation
+for "ring" is more subtle, see its license file at [1] (this is a permalink).
+For the other libraries, you can look up the license text itself by identifier
+at the SPDX website [2]. Most of these licenses are also present in the
+/usr/share/common-licenses directory of the container image.
+
+[1]: https://github.com/briansmith/ring/blob/1bf024dacfeb38eef7400b7880f46af5620cab42/LICENSE
+[2]: https://spdx.org/licenses/
+
+This file is automatically extended with the license list when bundled in the
+container image; in the repository it is only the template.

--- a/tests/check_licenses.py
+++ b/tests/check_licenses.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 Chorus One AG
+# SPDX-License-Identifier: GPL-3.0
+
+"""
+Check license compatibility of Solido dependencies. Requires "cargo-license" to
+be installed.
+"""
+
+from typing import Any, Dict, List
+from subprocess import run
+
+import json
+import sys
+
+# Dependencies that use these licenses, are OK to include in the on-chain program,
+# or in the CLI binary.
+ALLOWED_LICENSES = [
+    'Apache-2.0',
+    'BSD-2-Clause',
+    'BSD-3-Clause',
+    'CC0-1.0',
+    'GPL-3.0',
+    'ISC',
+    'MIT',
+    'MPL-2.0',
+]
+
+# These dependencies do not satisfy the above condition, but are allowed anyway
+# for reasons listed below.
+ALLOWED_DEPENDENCIES = [
+    # Actually Apache 2.0, but it's not part of the crate metadata.
+    'multisig',
+    # Has a complex licensing situation, that has been verified by Wenger & Vieli
+    # to be compatible with Solido.
+    'ring',
+    # All runtime code that we depend on is covered by an ISC-style license.
+    'webpki',
+]
+
+
+def get_deps(manifest_path: str) -> List[Dict[str, Any]]:
+    """
+    Return all runtime dependencies and their licenses. Example element:
+    {
+      "name": "solana-vote-program",
+      "version": "1.7.3",
+      "authors": "Solana Maintainers <maintainers@solana.foundation>",
+      "repository": "https://github.com/solana-labs/solana",
+      "license": "Apache-2.0",
+      "license_file": null,
+      "description": "Solana Vote program"
+    }
+    """
+    result = run(
+        [
+            'cargo',
+            'license',
+            '--avoid-dev-deps',
+            '--avoid-build-deps',
+            '--json',
+            '--manifest-path',
+            manifest_path,
+        ],
+        check=True,
+        capture_output=True,
+        encoding='utf-8',
+    )
+    result_parsed: List[Dict[str, Any]] = json.loads(result.stdout)
+    return result_parsed
+
+
+def main() -> None:
+    all_ok = True
+
+    # Get the dependencies of the on-chain program, and of the CLI binary.
+    deps_on_chain = get_deps('program/Cargo.toml')
+    deps_cli = get_deps('cli/Cargo.toml')
+    deps = deps_on_chain + deps_cli
+
+    for dep in deps:
+        dep_name = dep['name']
+        if dep_name in ALLOWED_DEPENDENCIES:
+            continue
+
+        license = dep.get('license')
+
+        if license is None:
+            print(f'{dep_name} does not have a machine-readable license specified')
+            all_ok = False
+            continue
+
+        options = license.split(' OR ')
+        is_ok = any(option in ALLOWED_LICENSES for option in options)
+
+        if not is_ok:
+            print(f'{dep_name} has an unknown license: {license}')
+            all_ok = False
+
+    if all_ok:
+        print('All dependency licenses are ok.')
+    else:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
We just ran into this while testing on testnet, where the RPC returned an error, but the transaction did execute. Add a warning for this particular error, to point this out to the user. I don't know if there are other cases where a transaction may have executed though, should we always warn?