### PR TITLE
Specify mint and Solido keys.

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -279,6 +279,16 @@ cli_opt_struct! {
         #[clap(long, value_name = "address")]
         developer_account_owner: Pubkey,
 
+        /// Optional argument for the mint address, if not passed a random one
+        /// will be created.
+        #[clap(long)]
+        mint_address: Pubkey => Pubkey::default(),
+
+        /// Optional argument for the solido address, if not passed a random one
+        /// will be created.
+        #[clap(long)]
+        solido_key_path: PathBuf => PathBuf::default(),
+
         /// Used to compute Solido's manager. Multisig instance.
         #[clap(long, value_name = "address")]
         multisig_address: Pubkey,
@@ -379,13 +389,24 @@ cli_opt_struct! {
 
 cli_opt_struct! {
      ShowSolidoOpts {
-        /// The solido instance to show
+        /// The solido instance to show.
         #[clap(long, value_name = "address")]
         solido_address: Pubkey,
         /// Address of the Solido program.
         #[clap(long, value_name = "address")]
         solido_program_id: Pubkey,
     }
+}
+
+cli_opt_struct! {
+    ShowSolidoAuthoritiesOpts {
+        /// The solido instance to show authorities.
+        #[clap(long, value_name = "address")]
+        solido_address: Pubkey,
+        /// Address of the Solido program.
+        #[clap(long, value_name = "address")]
+        solido_program_id: Pubkey,
+   }
 }
 
 cli_opt_struct! {

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -106,12 +106,10 @@ pub fn command_create_solido(
     let lido_signer = {
         if opts.solido_key_path() != &PathBuf::default() {
             // If we've been given a solido private key, use it to create the solido instance.
-            let signer = get_signer(opts.solido_key_path().clone());
-            signer
+            get_signer(opts.solido_key_path().clone())
         } else {
             // If not, use a random key
-            let lido_keypair = Keypair::new();
-            Box::new(lido_keypair)
+            Box::new(Keypair::new())
         }
     };
 
@@ -148,7 +146,7 @@ pub fn command_create_solido(
 
     let st_sol_mint_pubkey = {
         if opts.mint_address() != &Pubkey::default() {
-            // If we've been given a minter address, return its public address.
+            // If we've been given a minter address, return its public key.
             *opts.mint_address()
         } else {
             // If not, set up the Lido stSOL SPL token mint account.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -321,7 +321,8 @@ fn main() {
         SubCommand::ShowAuthorities(solido_pubkey) => {
             let result =
                 config.with_snapshot(|_config| command_show_solido_authorities(&solido_pubkey));
-            let output = result.ok_or_abort_with("Failed to show Solido data.");
+            let output =
+                result.ok_or_abort_with("Failed to show authorities for Solido public key.");
             print_output(output_mode, &output);
         }
         SubCommand::Deposit(cmd_opts) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use clap::Clap;
+use helpers::command_show_solido_authorities;
 use helpers::command_withdraw;
 use serde::Serialize;
 use solana_client::rpc_client::RpcClient;
@@ -147,6 +148,9 @@ REWARDS
 
     /// Show an instance of solido in detail
     ShowSolido(ShowSolidoOpts),
+
+    /// Show Solido authorities, useful for testing.
+    ShowAuthorities(ShowSolidoAuthoritiesOpts),
 
     /// Execute one iteration of periodic maintenance logic.
     ///
@@ -314,6 +318,12 @@ fn main() {
             let output = result.ok_or_abort_with("Failed to show Solido data.");
             print_output(output_mode, &output);
         }
+        SubCommand::ShowAuthorities(solido_pubkey) => {
+            let result =
+                config.with_snapshot(|_config| command_show_solido_authorities(&solido_pubkey));
+            let output = result.ok_or_abort_with("Failed to show Solido data.");
+            print_output(output_mode, &output);
+        }
         SubCommand::Deposit(cmd_opts) => {
             let result = command_deposit(&mut config, &cmd_opts);
             let output = result.ok_or_abort_with("Failed to deposit.");
@@ -340,6 +350,7 @@ fn merge_with_config_and_environment(
         SubCommand::Deposit(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::Withdraw(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::ShowSolido(opts) => opts.merge_with_config_and_environment(config_file),
+        SubCommand::ShowAuthorities(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::PerformMaintenance(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::Multisig(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::RunMaintainer(opts) => opts.merge_with_config_and_environment(config_file),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -149,7 +149,7 @@ REWARDS
     /// Show an instance of solido in detail
     ShowSolido(ShowSolidoOpts),
 
-    /// Show Solido authorities, useful for testing.
+    /// Show Solido authorities, useful for testing and when specifying an existing token mint.
     ShowAuthorities(ShowSolidoAuthoritiesOpts),
 
     /// Execute one iteration of periodic maintenance logic.

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -146,6 +146,10 @@ pub enum LidoError {
     /// There is a validator that has more stake than the selected one.
     #[error("ValidatorWithMoreStakeExists")]
     ValidatorWithMoreStakeExists = 37,
+
+    /// The provided mint is invalid.
+    #[error("InvalidMint")]
+    InvalidMint = 38,
 }
 
 impl From<ArithmeticError> for LidoError {

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -33,6 +33,10 @@ pub(crate) fn check_rent_exempt(
     Ok(())
 }
 
+/// Check if the mint program coin supply is zero and the mint authority is set
+/// to `mint_authority`.
+/// The check has to be done only in Solido's initialization phase, since we
+/// store the mint public key in the solido structure, and it never changes.
 pub(crate) fn check_mint(
     rent: &Rent,
     mint: &AccountInfo,

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use solana_program::entrypoint::ProgramResult;
+use solana_program::program_option::COption;
 use solana_program::program_pack::Pack;
 use solana_program::stake::state::StakeAuthorize;
 use solana_program::{
@@ -31,6 +32,40 @@ pub(crate) fn check_rent_exempt(
     }
     Ok(())
 }
+
+pub(crate) fn check_mint(
+    rent: &Rent,
+    mint: &AccountInfo,
+    mint_authority: &Pubkey,
+) -> Result<(), ProgramError> {
+    if !rent.is_exempt(mint.lamports(), mint.data_len()) {
+        msg!("Mint is not rent-exempt");
+        return Err(ProgramError::AccountNotRentExempt);
+    }
+    let spl_mint = spl_token::state::Mint::unpack_from_slice(&mint.data.borrow())?;
+    if spl_mint.supply != 0 {
+        msg!(
+            "Mint should not have minted tokens, has {}.",
+            spl_mint.supply
+        );
+        return Err(LidoError::InvalidMint.into());
+    }
+    if let COption::Some(authority) = spl_mint.mint_authority {
+        if &authority != mint_authority {
+            msg!(
+                "Mint authority should be {}, it's {} instead.",
+                mint_authority,
+                authority
+            );
+            return Err(LidoError::InvalidMint.into());
+        }
+    } else {
+        msg!("Mint should have an authority.");
+        return Err(LidoError::InvalidMint.into());
+    }
+    Ok(())
+}
+
 /// Subtract the minimum rent-exempt balance from the given reserve balance.
 ///
 /// The rent-exempt amount can never be transferred, or the account would

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -11,8 +11,8 @@ use crate::{
         WithdrawInactiveStakeInfo,
     },
     logic::{
-        burn_st_sol, check_rent_exempt, create_account_overwrite_if_exists, deserialize_lido,
-        distribute_fees, initialize_stake_account_undelegated, mint_st_sol_to,
+        burn_st_sol, check_mint, check_rent_exempt, create_account_overwrite_if_exists,
+        deserialize_lido, distribute_fees, initialize_stake_account_undelegated, mint_st_sol_to,
         transfer_stake_authority, CreateAccountOptions,
     },
     metrics::Metrics,
@@ -95,8 +95,10 @@ pub fn process_initialize(
         program_id,
     );
 
-    let (_, mint_bump_seed) =
+    let (mint_authority, mint_bump_seed) =
         Pubkey::find_program_address(&[&accounts.lido.key.to_bytes(), MINT_AUTHORITY], program_id);
+    // Check if the token has no minted tokens and right mint authority.
+    check_mint(rent, accounts.st_sol_mint, &mint_authority)?;
 
     let (_, rewards_withdraw_authority_bump_seed) = Pubkey::find_program_address(
         &[&accounts.lido.key.to_bytes(), REWARDS_WITHDRAW_AUTHORITY],

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -151,6 +151,8 @@ result = solido(
     mint_address.pubkey,
     keypair_path=test_addrs[0].keypair_path,
 )
+# The previously created instance is not used throughout the test, and it's
+# done to test creating an instance with a separate mint.
 
 print('\nCreating Solido instance ...')
 result = solido(

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -27,6 +27,7 @@ from util import (
     solana,
     solana_program_deploy,
     solido,
+    spl_token,
 )
 
 # We start by generating an account that we will need later. We put the tests
@@ -104,6 +105,52 @@ def approve_and_execute(
         keypair_path=signer.keypair_path,
     )
 
+
+# Test creating a solido instance with a known minter.
+solido_test_account = create_test_account('tests/.keys/solido_address.json', fund=False)
+authorities = solido(
+    'show-authorities',
+    '--solido-address',
+    solido_test_account.pubkey,
+    '--solido-program-id',
+    solido_program_id,
+)
+
+mint_address = create_test_account('tests/.keys/mint_address.json', fund=False)
+spl_token('create-token', 'tests/.keys/mint_address.json')
+# Test changing the mint authority.
+spl_token('authorize', mint_address.pubkey, 'mint', authorities['mint_authority'])
+print('\nCreating Solido instance with a known solido and minter address...')
+result = solido(
+    'create-solido',
+    '--multisig-program-id',
+    multisig_program_id,
+    '--solido-program-id',
+    solido_program_id,
+    '--max-validators',
+    '9',
+    '--max-maintainers',
+    '1',
+    '--treasury-fee-share',
+    '5',
+    '--validation-fee-share',
+    '3',
+    '--developer-fee-share',
+    '2',
+    '--st-sol-appreciation-share',
+    '90',
+    '--treasury-account-owner',
+    treasury_account_owner.pubkey,
+    '--developer-account-owner',
+    developer_account_owner.pubkey,
+    '--multisig-address',
+    multisig_instance,
+    '--solido-key-path',
+    solido_test_account.keypair_path,
+    '--mint-address',
+    mint_address.pubkey,
+    keypair_path=test_addrs[0].keypair_path,
+)
 
 print('\nCreating Solido instance ...')
 result = solido(


### PR DESCRIPTION
Adds the possibility of specifying the minter and Solido keys for the Solido initialization. Also creates the command `show-authorities` to show the Solido authorities given a known public key. When initializing the Solido instance with an existing key, the initialization step changes slightly. Now it is also required to make a new private key for the Solido instance and pass it in the initialization method.

Adds extra check for the mint, now we require that the mint has the Solido authority for minting and hasn't minted any tokens yet (supply is zero).