### PR TITLE
Improve multisig user experience for `approve` and `execute`, improve error reporting

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,7 @@ use solana_remote_wallet::remote_wallet::maybe_wallet_manager;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::derivation_path::DerivationPath;
 use solana_sdk::instruction::Instruction;
-use solana_sdk::signature::read_keypair_file;
+use solana_sdk::signature::{read_keypair_file, Signature};
 use solana_sdk::signer::Signer;
 use solana_sdk::signers::Signers;
 use solana_sdk::transaction::Transaction;
@@ -28,7 +28,6 @@ use crate::helpers::{
 };
 use crate::multisig::MultisigOpts;
 use crate::snapshot::{Snapshot, SnapshotClient};
-use anchor_client::solana_sdk::signature::Signature;
 
 mod config;
 mod daemon;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,6 +28,7 @@ use crate::helpers::{
 };
 use crate::multisig::MultisigOpts;
 use crate::snapshot::{Snapshot, SnapshotClient};
+use anchor_client::solana_sdk::signature::Signature;
 
 mod config;
 mod daemon;
@@ -222,7 +223,7 @@ impl<'a> SnapshotConfig<'a> {
         &mut self,
         instructions: &[Instruction],
         signers: &T,
-    ) -> snapshot::Result<()> {
+    ) -> snapshot::Result<Signature> {
         let transaction = self.sign_transaction(instructions, signers)?;
         let signature_result = match self.output_mode {
             OutputMode::Text => {
@@ -252,10 +253,7 @@ impl<'a> SnapshotConfig<'a> {
             _ => {}
         }
 
-        // Propagate the error if there was any.
-        let _signature = signature_result?;
-
-        Ok(())
+        Ok(signature_result?)
     }
 }
 

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -215,7 +215,7 @@ else:
 
 
 print('\nApproving transaction from a second account ...')
-multisig(
+result = multisig(
     'approve',
     '--multisig-program-id',
     multisig_program_id,
@@ -225,6 +225,9 @@ multisig(
     upgrade_transaction_address,
     keypair_path=addr2.keypair_path,
 )
+assert result['num_approvals'] == 2
+assert result['threshold'] == 2
+
 result = multisig(
     'show-transaction',
     '--multisig-program-id',
@@ -330,7 +333,7 @@ print(f'> Transaction address is {change_multisig_transaction_address}.')
 
 
 print('\nApproving transaction from a second account ...')
-multisig(
+result = multisig(
     'approve',
     '--multisig-program-id',
     multisig_program_id,
@@ -340,6 +343,9 @@ multisig(
     change_multisig_transaction_address,
     keypair_path=addr3.keypair_path,
 )
+assert result['num_approvals'] == 2
+assert result['threshold'] == 2
+
 result = multisig(
     'show-transaction',
     '--multisig-program-id',

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -246,7 +246,7 @@ print(f'> Transaction is now signed by {addr2} as well.')
 
 
 print('\nTrying to execute with 2 of 2 signatures, which should succeed ...')
-multisig(
+result = multisig(
     'execute-transaction',
     '--multisig-program-id',
     multisig_program_id,
@@ -255,6 +255,7 @@ multisig(
     '--transaction-address',
     upgrade_transaction_address,
 )
+assert 'transaction_id' in result
 result = multisig(
     'show-transaction',
     '--multisig-program-id',
@@ -364,7 +365,7 @@ print('> Transaction has the required number of signatures.')
 
 
 print('\nExecuting multisig change transaction ...')
-multisig(
+result = multisig(
     'execute-transaction',
     '--multisig-program-id',
     multisig_program_id,
@@ -373,6 +374,7 @@ multisig(
     '--transaction-address',
     change_multisig_transaction_address,
 )
+assert 'transaction_id' in result
 result = multisig(
     'show-transaction',
     '--multisig-program-id',


### PR DESCRIPTION
Previously `multisig approve` and `multisig execute-transaction` would not print anything. Now they print the Solana transaction id, so you can look it up in a block explorer. `approve` also prints how many approvals the transaction has afterwards, so you know immediately if you can execute it.

While testing this, I ran into the RPC returning `InstructionError(0, Custom(105))`, which is not particularly helpful, so I also extended the error reporting to try and convert this back to a Solido error or Multisig error. Unfortunately there seems to be a bug in Anchor, that prevents converting back from an error code to the structured error. But at least for Solido we should now get more details.

Previous output:

```
Solana RPC client returned an error:

  Request:    Some(SendTransaction)
  Kind:       RPC response error
  Error code: -32002
  Message:    Transaction simulation failed: Error processing Instruction 0: custom program error: 0x69
  Reason:     Transaction preflight failure
  Error:      Some(InstructionError(0, Custom(105)))
  Logs:      

    Program 9eQaW16uVwBGemawfJ2wGtUH3geb1tVpfeG3YhkKs9YF invoke [1]
    Program log: Custom program error: 0x69
    Program 9eQaW16uVwBGemawfJ2wGtUH3geb1tVpfeG3YhkKs9YF consumed 12174 of 200000 compute units
    Program 9eQaW16uVwBGemawfJ2wGtUH3geb1tVpfeG3YhkKs9YF failed: custom program error: 0x69
```
New output:
```
Solana RPC client returned an error:

  Request:    Some(SendTransaction)
  Kind:       RPC response error
  Error code: -32002
  Message:    Transaction simulation failed: Error processing Instruction 0: custom program error: 0x69
  Reason:     Transaction preflight failure
  Error:     

    Raw:      InstructionError(0, Custom(105))
    Display:  Error processing Instruction 0: custom program error: 0x69

  Error code interpretations:

    Error 105 is not a known Solido error.
    Error 105 is not a known Multisig error.

  Logs:      

    Program 9eQaW16uVwBGemawfJ2wGtUH3geb1tVpfeG3YhkKs9YF invoke [1]
    Program log: Custom program error: 0x69
    Program 9eQaW16uVwBGemawfJ2wGtUH3geb1tVpfeG3YhkKs9YF consumed 12174 of 200000 compute units
    Program 9eQaW16uVwBGemawfJ2wGtUH3geb1tVpfeG3YhkKs9YF failed: custom program error: 0x69
```
This part where it says “Error 105 is not a known Multisig error.” should really say “Multisig error 105 is AlreadyExecuted. The given transaction has already been executed.”, but I think this is a problem in Anchor, see https://github.com/ChorusOne/solido/issues/177#issuecomment-894212882.