### PR TITLE
Active flag

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use solana_sdk::pubkey::{ParsePubkeyError, Pubkey};
 
 use lido::token::Lamports;
-use lido::{state::Weight, token::StLamports};
+use lido::token::StLamports;
 
 pub fn get_option_from_config<T: FromStr>(
     name: &'static str,
@@ -355,12 +355,6 @@ cli_opt_struct! {
         /// Address of the Multisig program.
         #[clap(long)]
         multisig_program_id: Pubkey,
-
-        /// Validator weight. Used when calculating the stake amount for keeping
-        /// a weighted balance, also defines the validator's share of fees.
-        /// Defaults to 1000.
-        #[clap(long)]
-        weight: Weight => Weight(1000),
     }
 }
 

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -237,7 +237,6 @@ pub fn command_add_validator(
 
     let instruction = lido::instruction::add_validator(
         opts.solido_program_id(),
-        opts.weight().clone(),
         &lido::instruction::AddValidatorMeta {
             lido: *opts.solido_address(),
             manager: multisig_address,

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -876,7 +876,6 @@ pub fn get_opt_default_pubkey(pubkey: Pubkey) -> Option<Pubkey> {
 
 #[cfg(test)]
 mod test {
-    use lido::state::Weight;
 
     use super::*;
 
@@ -919,10 +918,7 @@ mod test {
         state
             .solido
             .validators
-            .add(
-                Pubkey::new_unique(),
-                Validator::new(Pubkey::new_unique(), Weight::default()),
-            )
+            .add(Pubkey::new_unique(), Validator::new(Pubkey::new_unique()))
             .unwrap();
         state.validator_stake_accounts.push(vec![]);
         // Put some SOL in the reserve, but not enough to stake.
@@ -952,18 +948,12 @@ mod test {
         state
             .solido
             .validators
-            .add(
-                Pubkey::new_unique(),
-                Validator::new(Pubkey::new_unique(), Weight::default()),
-            )
+            .add(Pubkey::new_unique(), Validator::new(Pubkey::new_unique()))
             .unwrap();
         state
             .solido
             .validators
-            .add(
-                Pubkey::new_unique(),
-                Validator::new(Pubkey::new_unique(), Weight::default()),
-            )
+            .add(Pubkey::new_unique(), Validator::new(Pubkey::new_unique()))
             .unwrap();
         state.validator_stake_accounts = vec![vec![], vec![]];
 

--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -16,6 +16,7 @@ use borsh::ser::BorshSerialize;
 use clap::Clap;
 use serde::Serialize;
 
+use lido::instruction::AddMaintainerMeta;
 use lido::instruction::AddValidatorMeta;
 use lido::instruction::ChangeRewardDistributionMeta;
 use lido::instruction::LidoInstruction;
@@ -24,7 +25,6 @@ use lido::state::FeeRecipients;
 use lido::state::Lido;
 use lido::state::RewardDistribution;
 use lido::util::{serialize_b58, serialize_b58_slice};
-use lido::{instruction::AddMaintainerMeta, state::Weight};
 use multisig::accounts as multisig_accounts;
 use multisig::instruction as multisig_instruction;
 
@@ -338,8 +338,6 @@ enum SolidoInstruction {
 
         #[serde(serialize_with = "serialize_b58")]
         validator_fee_st_sol_account: Pubkey,
-
-        weight: Weight,
     },
     AddMaintainer {
         #[serde(serialize_with = "serialize_b58")]
@@ -476,7 +474,6 @@ impl fmt::Display for ShowTransactionOutput {
                         manager,
                         validator_vote_account,
                         validator_fee_st_sol_account,
-                        weight,
                     } => {
                         writeln!(f, "It adds a validator to Solido")?;
                         writeln!(f, "    Solido instance:        {}", solido_instance)?;
@@ -487,7 +484,6 @@ impl fmt::Display for ShowTransactionOutput {
                             "    Validator fee account:  {}",
                             validator_fee_st_sol_account
                         )?;
-                        writeln!(f, "    Validator weight:       {}", weight.0)?;
                     }
                     SolidoInstruction::AddMaintainer {
                         solido_instance,
@@ -753,14 +749,13 @@ fn try_parse_solido_instruction(
                 },
             })
         }
-        LidoInstruction::AddValidator { weight } => {
+        LidoInstruction::AddValidator => {
             let accounts = AddValidatorMeta::try_from_slice(&instr.accounts)?;
             ParsedInstruction::SolidoInstruction(SolidoInstruction::AddValidator {
                 solido_instance: accounts.lido,
                 manager: accounts.manager,
                 validator_vote_account: accounts.validator_vote_account,
                 validator_fee_st_sol_account: accounts.validator_fee_st_sol_account,
-                weight,
             })
         }
         LidoInstruction::AddMaintainer => {

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -247,7 +247,7 @@ mod test {
 
     #[test]
     fn get_target_balance_works_with_inactive_for_integer_multiple() {
-        // 500 Lamports delegated, but only two active validator out of three.
+        // 500 Lamports delegated, but only two active validators out of three.
         // All target should be divided equally within the active validators.
         let mut validators = Validators::new_fill_default(3);
         validators.entries[0].entry.stake_accounts_balance = Lamports(100);

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -150,6 +150,10 @@ pub enum LidoError {
     /// The provided mint is invalid.
     #[error("InvalidMint")]
     InvalidMint = 38,
+
+    /// Tried to deposit stake to inactive validator.
+    #[error("StakeToInactiveValidator")]
+    StakeToInactiveValidator = 39,
 }
 
 impl From<ArithmeticError> for LidoError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -99,8 +99,8 @@ pub enum LidoError {
     #[error("InvalidAccountMember")]
     InvalidLidoSize = 26,
     /// The instance has no validators.
-    #[error("EmptySetOfValidators")]
-    EmptySetOfValidators = 27,
+    #[error("NoActiveValidators")]
+    NoActiveValidators = 27,
 
     /// When staking part of the reserve to a new stake account, the next
     /// program-derived address for the stake account associated with the given

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -18,7 +18,7 @@ use solana_program::{
 use crate::{
     accounts_struct, accounts_struct_meta,
     error::LidoError,
-    state::{RewardDistribution, Weight},
+    state::RewardDistribution,
     token::{Lamports, StLamports},
 };
 
@@ -71,10 +71,7 @@ pub enum LidoInstruction {
         #[allow(dead_code)] // but it's not
         new_reward_distribution: RewardDistribution,
     },
-    AddValidator {
-        #[allow(dead_code)] // but it's not
-        weight: Weight,
-    },
+    AddValidator,
     RemoveValidator,
     AddMaintainer,
     RemoveMaintainer,
@@ -561,16 +558,11 @@ accounts_struct! {
     }
 }
 
-pub fn add_validator(
-    program_id: &Pubkey,
-    weight: Weight,
-    accounts: &AddValidatorMeta,
-) -> Instruction {
-    let data = LidoInstruction::AddValidator { weight };
+pub fn add_validator(program_id: &Pubkey, accounts: &AddValidatorMeta) -> Instruction {
     Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),
-        data: data.to_vec(),
+        data: LidoInstruction::AddValidator.to_vec(),
     }
 }
 

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -15,7 +15,7 @@ use crate::{
         MergeStakeInfo, RemoveMaintainerInfo, RemoveValidatorInfo,
     },
     logic::{deserialize_lido, mint_st_sol_to},
-    state::{RewardDistribution, Validator, Weight},
+    state::{RewardDistribution, Validator},
     token::StLamports,
     STAKE_AUTHORITY,
 };
@@ -39,11 +39,7 @@ pub fn process_change_reward_distribution(
     lido.save(accounts.lido)
 }
 
-pub fn process_add_validator(
-    program_id: &Pubkey,
-    weight: Weight,
-    accounts_raw: &[AccountInfo],
-) -> ProgramResult {
+pub fn process_add_validator(program_id: &Pubkey, accounts_raw: &[AccountInfo]) -> ProgramResult {
     let accounts = AddValidatorInfo::try_from_slice(accounts_raw)?;
     let mut lido = deserialize_lido(program_id, accounts.lido)?;
     let rent = &Rent::from_account_info(accounts.sysvar_rent)?;
@@ -66,7 +62,7 @@ pub fn process_add_validator(
 
     lido.validators.add(
         *accounts.validator_vote_account.key,
-        Validator::new(*accounts.validator_fee_st_sol_account.key, weight),
+        Validator::new(*accounts.validator_fee_st_sol_account.key),
     )?;
 
     lido.save(accounts.lido)

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -189,6 +189,13 @@ pub fn process_stake_deposit(
     let validator = lido
         .validators
         .get_mut(accounts.validator_vote_account.key)?;
+    if validator.entry.inactive {
+        msg!(
+            "Validator {} is inactive, new deposits are not allowed",
+            validator.pubkey
+        );
+        return Err(LidoError::StakeToInactiveValidator.into());
+    }
 
     let stake_account_bump_seed = Lido::check_stake_account(
         program_id,
@@ -780,9 +787,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
         LidoInstruction::ChangeRewardDistribution {
             new_reward_distribution,
         } => process_change_reward_distribution(program_id, new_reward_distribution, accounts),
-        LidoInstruction::AddValidator { weight } => {
-            process_add_validator(program_id, weight, accounts)
-        }
+        LidoInstruction::AddValidator => process_add_validator(program_id, accounts),
         LidoInstruction::RemoveValidator => process_remove_validator(program_id, accounts),
         LidoInstruction::AddMaintainer => process_add_maintainer(program_id, accounts),
         LidoInstruction::RemoveMaintainer => process_remove_maintainer(program_id, accounts),

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -189,7 +189,7 @@ pub fn process_stake_deposit(
     let validator = lido
         .validators
         .get_mut(accounts.validator_vote_account.key)?;
-    if validator.entry.inactive {
+    if !validator.entry.active {
         msg!(
             "Validator {} is inactive, new deposits are not allowed",
             validator.pubkey

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -658,7 +658,7 @@ impl Validator {
 impl Default for Validator {
     fn default() -> Self {
         Validator {
-            fee_address: Pubkey::new_unique(),
+            fee_address: Pubkey::default(),
             fee_credit: StLamports(0),
             stake_accounts_seed_begin: 0,
             stake_accounts_seed_end: 0,

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -38,7 +38,7 @@ pub type Validators = AccountMap<Validator>;
 
 impl Validators {
     pub fn iter_active(&self) -> impl Iterator<Item = &Validator> {
-        self.iter_entries().filter(|&v| !v.inactive)
+        self.iter_entries().filter(|&v| v.active)
     }
 }
 pub type Maintainers = AccountSet;
@@ -592,9 +592,7 @@ impl Lido {
 }
 
 #[repr(C)]
-#[derive(
-    Clone, Debug, Default, Eq, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Serialize,
-)]
+#[derive(Clone, Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Serialize)]
 pub struct Validator {
     /// Fees in stSOL that the validator is entitled too, but hasn't claimed yet.
     pub fee_credit: StLamports,
@@ -630,7 +628,7 @@ pub struct Validator {
 
     /// Controls if a validator is allowed to have new stake deposits.
     /// When removing a validator, this flag should be set to `true`.
-    pub inactive: bool,
+    pub active: bool,
 }
 
 impl Validator {
@@ -654,6 +652,19 @@ impl Validator {
             &seed.to_le_bytes()[..],
         ];
         Pubkey::find_program_address(&seeds, program_id)
+    }
+}
+
+impl Default for Validator {
+    fn default() -> Self {
+        Validator {
+            fee_address: Pubkey::new_unique(),
+            fee_credit: StLamports(0),
+            stake_accounts_seed_begin: 0,
+            stake_accounts_seed_end: 0,
+            stake_accounts_balance: Lamports(0),
+            active: true,
+        }
     }
 }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -627,7 +627,7 @@ pub struct Validator {
     pub stake_accounts_balance: Lamports,
 
     /// Controls if a validator is allowed to have new stake deposits.
-    /// When removing a validator, this flag should be set to `true`.
+    /// When removing a validator, this flag should be set to `false`.
     pub active: bool,
 }
 

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -27,12 +27,9 @@ use solana_sdk::transport::TransportError;
 use solana_vote_program::vote_instruction;
 use solana_vote_program::vote_state::{VoteInit, VoteState};
 
+use lido::token::{Lamports, StLamports};
 use lido::{
     error::LidoError, instruction, RESERVE_ACCOUNT, REWARDS_WITHDRAW_AUTHORITY, STAKE_AUTHORITY,
-};
-use lido::{
-    state::Weight,
-    token::{Lamports, StLamports},
 };
 use lido::{
     state::{FeeRecipients, Lido, RewardDistribution, Validator},
@@ -676,7 +673,6 @@ impl Context {
             &mut self.nonce,
             &[lido::instruction::add_validator(
                 &id(),
-                Weight::default(),
                 &lido::instruction::AddValidatorMeta {
                     lido: self.solido.pubkey(),
                     manager: self.manager.pubkey(),

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -247,8 +247,6 @@ transaction_result = solido(
     validator_fee_account,
     '--multisig-address',
     multisig_instance,
-    '--weight',
-    '2000',
     keypair_path=test_addrs[1].keypair_path,
 )
 transaction_address = transaction_result['transaction_address']

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -303,7 +303,7 @@ assert solido_instance['solido']['validators']['entries'][0] == {
         'stake_accounts_seed_begin': 0,
         'stake_accounts_seed_end': 0,
         'stake_accounts_balance': 0,
-        'inactive': False,
+        'active': True,
     },
 }, f'Unexpected validator entry, in {json.dumps(solido_instance, indent=True)}'
 

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -303,7 +303,7 @@ assert solido_instance['solido']['validators']['entries'][0] == {
         'stake_accounts_seed_begin': 0,
         'stake_accounts_seed_end': 0,
         'stake_accounts_balance': 0,
-        'weight': 2000,
+        'inactive': False,
     },
 }, f'Unexpected validator entry, in {json.dumps(solido_instance, indent=True)}'
 


### PR DESCRIPTION
Steps towards validator's removal #347.
Replaces the validator's weight with the boolean flag `active`.
When the `active` flag is `false`, the validator cannot receive stake deposits. The maintenance bot should also ignore inactive validators and not try to stake more Sol to them.