### PR TITLE
222 check writable attributes from instructions

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -609,6 +609,7 @@ accounts_struct! {
         },
         pub st_sol_mint {
             is_signer: false,
+            // Is writable due to fee mint (spl_token::instruction::mint_to)
             is_writable: true,
         },
         pub mint_authority {
@@ -617,6 +618,7 @@ accounts_struct! {
         },
         pub validator_fee_st_sol_account {
             is_signer: false,
+            // Is writable due to fee mint (spl_token::instruction::mint_to)
             is_writable: true,
         },
         const spl_token = spl_token::id(),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -429,6 +429,7 @@ accounts_struct! {
         // Needs to be writable so we withdraw from it.
         pub validator_vote_account {
             is_signer: false,
+            // Is writable due to withdraw to reserve (vote_instruction::withdraw)
             is_writable: true,
         },
 
@@ -436,6 +437,7 @@ accounts_struct! {
         // mint, and the fee accounts to deposit the stSOL into.
         pub st_sol_mint {
             is_signer: false,
+            // Is writable due to fee mint (spl_token::instruction::mint_to)
             is_writable: true,
         },
 
@@ -447,15 +449,18 @@ accounts_struct! {
 
         pub treasury_st_sol_account {
             is_signer: false,
+            // Is writable due to fee mint (spl_token::instruction::mint_to)
             is_writable: true,
         },
         pub developer_st_sol_account {
             is_signer: false,
+            // Is writable due to fee mint (spl_token::instruction::mint_to)
             is_writable: true,
         },
 
         pub reserve {
             is_signer: false,
+            // Is writable due to withdraw to reserve (vote_instruction::withdraw)
             is_writable: true,
         },
         // Used to get the rewards out of the validator vote account.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -449,12 +449,12 @@ accounts_struct! {
 
         pub treasury_st_sol_account {
             is_signer: false,
-            // Is writable due to fee mint (spl_token::instruction::mint_to)
+            // Is writable due to fee mint (spl_token::instruction::mint_to) to treasury
             is_writable: true,
         },
         pub developer_st_sol_account {
             is_signer: false,
-            // Is writable due to fee mint (spl_token::instruction::mint_to)
+            // Is writable due to fee mint (spl_token::instruction::mint_to) to developer
             is_writable: true,
         },
 
@@ -609,7 +609,8 @@ accounts_struct! {
         },
         pub st_sol_mint {
             is_signer: false,
-            // Is writable due to fee mint (spl_token::instruction::mint_to)
+            // Is writable due to fee mint (spl_token::instruction::mint_to) to validator fee
+            // st_sol account
             is_writable: true,
         },
         pub mint_authority {
@@ -618,7 +619,8 @@ accounts_struct! {
         },
         pub validator_fee_st_sol_account {
             is_signer: false,
-            // Is writable due to fee mint (spl_token::instruction::mint_to)
+            // Is writable due to fee mint (spl_token::instruction::mint_to) to validator fee
+            // st_sol account
             is_writable: true,
         },
         const spl_token = spl_token::id(),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -209,10 +209,12 @@ accounts_struct! {
         // This should be owned by the user.
         pub st_sol_account {
             is_signer: false,
+            // Is writable due to st_sol burn (spl_token::instruction::burn)
             is_writable: true,
         },
         pub st_sol_mint {
             is_signer: false,
+            // Is writable due to st_sol burn (spl_token::instruction::burn)
             is_writable: true,
         },
         pub validator_vote_account {
@@ -222,11 +224,14 @@ accounts_struct! {
         // Stake account to withdraw from.
         pub source_stake_account {
             is_signer: false,
+            // Is writable due to spliti stake (solana_program::stake::instruction::split)
             is_writable: true,
         },
         // Stake where the withdrawn amounts will go.
         pub destination_stake_account {
             is_signer: true,
+            // Is writable due to split stake (solana_program::stake::instruction::split) and
+            // transfer of stake authority (solana_program::stake::instruction::authorize
             is_writable: true,
         },
         // Used to split stake accounts and burn tokens.
@@ -375,6 +380,7 @@ accounts_struct! {
         },
         pub reserve {
             is_signer: false,
+            // Is writable due to withdraw from stake account to reserve (StakeAccount::stake_account_withdraw)
             is_writable: true,
         },
 

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -695,10 +695,12 @@ accounts_struct! {
         },
         pub from_stake {
             is_signer: false,
+            // Is writable due to merge (solana_program::stake::instruction::merge)
             is_writable: true,
         },
         pub to_stake {
             is_signer: false,
+            // Is writable due to merge (solana_program::stake::instruction::merge)
             is_writable: true,
         },
         // This instruction doesn’t reference the authority directly, but it

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -163,6 +163,8 @@ accounts_struct! {
         },
         pub st_sol_mint {
             is_signer: false,
+            // Is writable due to mint to (spl_token::instruction::mint_to) recipient from
+            // st_sol_mint
             is_writable: true,
         },
         pub reserve_account {
@@ -264,6 +266,8 @@ accounts_struct! {
         },
         pub reserve {
             is_signer: false,
+            // Is writable due to transfer (system_instruction::transfer) from reserve_account to
+            // stake_account_end
             is_writable: true,
         },
         pub validator_vote_account {
@@ -278,17 +282,22 @@ accounts_struct! {
         // should be set to the same value as `stake_account_end`.
         pub stake_account_merge_into {
             is_signer: false,
+            // Is writable due to merge (stake_program::intruction::merge) of stake_account_end
+            // into stake_account_merge_into under the condition that they are not equal
             is_writable: true,
         },
         // Must be set to the program-derived stake account for the given
         // validator, with seed `stake_accounts_seed_end`.
         pub stake_account_end {
             is_signer: false,
+            // Is writable due to transfer (system_instruction::transfer) from reserve_account to
+            // stake_account_end and stake program being initialized
+            // (stake_program::instruction::initialize)
             is_writable: true,
         },
         pub stake_authority {
             is_signer: false,
-            is_writable: true,
+            is_writable: false,
         },
         const sysvar_clock = sysvar::clock::id(),
         const system_program = system_program::id(),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -151,10 +151,14 @@ accounts_struct! {
         },
         pub user {
             is_signer: true,
+            // Is writable due to transfer (system_instruction::transfer) from user to
+            // reserve_account
             is_writable: true,
         },
         pub recipient {
             is_signer: false,
+            // Is writable due to mint to (spl_token::instruction::mint_to) recipient from
+            // st_sol_mint
             is_writable: true,
         },
         pub st_sol_mint {
@@ -163,6 +167,8 @@ accounts_struct! {
         },
         pub reserve_account {
             is_signer: false,
+            // Is writable due to transfer (system_instruction::transfer) from user to
+            // reserve_account
             is_writable: true,
         },
         pub mint_authority {


### PR DESCRIPTION
I went through all the accounts and added comments against the is_writable fields to hopefully make it easier to reason about why the said accounts are writable.  

Additionally set the stake_authority.is_writable : false in StakeDepositAccounts as per original comment on #222 