### PR TITLE
Pretty-print `SignerError`s

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -214,7 +214,10 @@ impl<'a> SnapshotConfig<'a> {
     ) -> snapshot::Result<Transaction> {
         let mut tx = Transaction::new_with_payer(instructions, Some(&self.signer.pubkey()));
         let recent_blockhash = self.client.get_recent_blockhash()?;
-        tx.sign(signers, recent_blockhash);
+        tx.try_sign(signers, recent_blockhash).map_err(|err| {
+            let boxed_error: Error = Box::new(err);
+            boxed_error
+        })?;
         Ok(tx)
     }
 


### PR DESCRIPTION
In particular, add a hint about the Ledger "blind signing" setting, to make the error a bit more actionable for the user.

@enriquefynn I don’t have a Ledger at hand at the moment, can you verify that this prints the right hint when the "blind signing" setting is disabled?