### PR TITLE
Fix support for usb://ledger keypair path without ?key query param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "borsh",
  "bs58 0.4.0",
  "clap 3.0.0-beta.2",
+ "derivation-path",
  "lido",
  "multisig",
  "num-traits",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ bincode = "1.3.1"
 borsh = "0.8"
 bs58 = "0.4.0"
 clap = "3.0.0-beta.2"
+derivation-path = "0.1.3"
 lido = {path = "../program", features = ["no-entrypoint"]}
 multisig = {path = "../multisig/programs/multisig"}
 num-traits = "0.2"


### PR DESCRIPTION
With #343, we added support for `?key=` derivation paths in `usb://ledger` keypair paths, but I broke support for the bare `usb://ledger` path. This should fix that, and it adds a test to ensure that we can parse both.

@fkbenjamin, can you check whether you can use the `usb://ledger` path again with this version?