### PR TITLE
Add token transfer to the client.

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -608,3 +608,27 @@ impl From<&ProposeChangeMultisigOpts> for CreateMultisigOpts {
         }
     }
 }
+
+cli_opt_struct! {
+    TransferTokenOpts {
+        /// Address of the Multisig program.
+        #[clap(long)]
+        multisig_program_id: Pubkey,
+
+        /// Multisig instance.
+        #[clap(long, value_name = "address")]
+        multisig_address: Pubkey,
+
+        /// Source of the transfer.
+        #[clap(long, value_name = "address")]
+        from_address: Pubkey,
+
+        /// Destination of the transfer.
+        #[clap(long, value_name = "address")]
+        to_address: Pubkey,
+
+        /// Amount to be transferred in the smallest token denomination.
+        #[clap(long)]
+        amount: u64
+    }
+}

--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -858,7 +858,7 @@ fn try_parse_token_instruction(instr: &Instruction) -> Result<ParsedInstruction>
             ParsedInstruction::TokenInstruction(TokenInstruction::Transfer {
                 from_address: instr.accounts[0].pubkey,
                 to_address: instr.accounts[1].pubkey,
-                amount: amount,
+                amount,
             }),
         ),
         _ => Ok(ParsedInstruction::TokenInstruction(

--- a/program/tests/tests/withdrawals.rs
+++ b/program/tests/tests/withdrawals.rs
@@ -4,7 +4,6 @@
 #![cfg(feature = "test-bpf")]
 
 use bincode::deserialize;
-use solana_program::program_error::ProgramError;
 use solana_program::stake::state::StakeState;
 use solana_program_test::tokio;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;

--- a/program/tests/tests/withdrawals.rs
+++ b/program/tests/tests/withdrawals.rs
@@ -4,6 +4,7 @@
 #![cfg(feature = "test-bpf")]
 
 use bincode::deserialize;
+use solana_program::program_error::ProgramError;
 use solana_program::stake::state::StakeState;
 use solana_program_test::tokio;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;

--- a/tests/prepare_test_environment.py
+++ b/tests/prepare_test_environment.py
@@ -15,7 +15,7 @@ from typing import Optional, Dict, Any
 from util import (
     create_test_account,
     solana_program_deploy,
-    create_spl_token,
+    create_spl_token_account,
     create_vote_account,
     get_network,
     solana,
@@ -119,7 +119,7 @@ def add_validator(index: int, vote_account: Optional[str]) -> str:
     validator_fee_st_sol_account_owner = create_test_account(
         f'tests/.keys/validator-{index}-fee-st-sol-account.json'
     )
-    validator_fee_st_sol_account = create_spl_token(
+    validator_fee_st_sol_account = create_spl_token_account(
         validator_fee_st_sol_account_owner.keypair_path,
         st_sol_mint_account,
     )

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -553,6 +553,7 @@ result = multisig(
 assert result['parsed_instruction']['TokenInstruction']['Transfer'] == {
     'from_address': test_token_account_1.pubkey,
     'to_address': test_token_account_2.pubkey,
+    'token_address': test_token.pubkey,
     'amount': 10,
 }
 

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -19,7 +19,7 @@ import json
 
 from util import (
     TestAccount,
-    create_spl_token,
+    create_spl_token_account,
     create_test_account,
     create_vote_account,
     get_solido_program_path,
@@ -227,7 +227,7 @@ print(f'> Creating validator vote account {validator_vote_account}')
 print(f'> Creating validator token account with owner {validator_fee_account_owner}')
 
 # Create SPL token
-validator_fee_account = create_spl_token(
+validator_fee_account = create_spl_token_account(
     'tests/.keys/validator-token-account-key.json', st_sol_mint_account
 )
 print(f'> Validator stSol token account: {validator_fee_account}')

--- a/tests/util.py
+++ b/tests/util.py
@@ -193,7 +193,7 @@ def create_vote_account(
     return test_account
 
 
-def create_spl_token(owner_keypair_fname: str, minter: str) -> str:
+def create_spl_token_account(owner_keypair_fname: str, minter: str) -> str:
     """
     Creates an spl token for the given minter
     spl_token command returns 'Creating account <address>


### PR DESCRIPTION
Add a new subcommand `token` to the multisig subcommand. In the future we may support more token instructions, e.g., burning, creating. For now we support only token transfers.

Note: when doing just the `multisig token` params, there's a clap error: "`Option::unwrap()` on a `None` value".
I'm still verifying what can be done, but it works well with the `--help` flag. 🤷 

Closes #320