### PR TITLE
Make listen an option to run-maintainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## (unreleased)
+
+**Compatibility**:
+
+ * `solido run-maintainer` now accepts the listen address with the `--listen`
+   option, instead of accepting it directly; this was an oversight in previous
+   versions.
+
 ## v0.4.0
 
 Released 2021-07-30.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -581,6 +581,7 @@ cli_opt_struct! {
         solido_address: Pubkey,
 
         /// Listen address and port for the http server that serves a /metrics endpoint. Defaults to 0.0.0.0:8923.
+        #[clap(long)]
         listen: String => "0.0.0.0:8923".to_owned(),
 
         // The expected wait time is half the max poll interval. A max poll interval


### PR DESCRIPTION
I noticed while reviewing our deployment of the maintainer that the listen address is a positional argument rather than one with a long-form flag. I think this was an oversight, make it `--listen` instead.