### PR TITLE
Add `Deactivate` instruction

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -71,7 +71,25 @@ pub enum LidoInstruction {
         #[allow(dead_code)] // but it's not
         new_reward_distribution: RewardDistribution,
     },
+
+    /// Add a new validator to the validator set.
+    ///
+    /// Requires the manager to sign.
     AddValidator,
+
+    /// Set the `active` flag to false for a given validator.
+    ///
+    /// Requires the manager to sign.
+    ///
+    /// Deactivation initiates the validator removal process:
+    ///
+    /// * It prevents new funds from being staked with the validator.
+    /// * It signals to the maintainer bot to start unstaking from this validator.
+    ///
+    /// Once there are no more delegations to this validator, and it has no
+    /// unclaimed fee credits, then the validator can be removed.
+    DeactivateValidator,
+
     RemoveValidator,
     AddMaintainer,
     RemoveMaintainer,
@@ -590,6 +608,31 @@ pub fn remove_validator(program_id: &Pubkey, accounts: &RemoveValidatorMeta) -> 
         program_id: *program_id,
         accounts: accounts.to_vec(),
         data: LidoInstruction::RemoveValidator.to_vec(),
+    }
+}
+
+accounts_struct! {
+    DeactivateValidatorMeta, DeactivateValidatorInfo {
+        pub lido {
+            is_signer: false,
+            is_writable: true,
+        },
+        pub manager {
+            is_signer: true,
+            is_writable: false,
+        },
+        pub validator_vote_account_to_deactivate {
+            is_signer: false,
+            is_writable: false,
+        },
+    }
+}
+
+pub fn deactivate_validator(program_id: &Pubkey, accounts: &DeactivateValidatorMeta) -> Instruction {
+    Instruction {
+        program_id: *program_id,
+        accounts: accounts.to_vec(),
+        data: LidoInstruction::DeactivateValidator.to_vec(),
     }
 }
 

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -628,7 +628,10 @@ accounts_struct! {
     }
 }
 
-pub fn deactivate_validator(program_id: &Pubkey, accounts: &DeactivateValidatorMeta) -> Instruction {
+pub fn deactivate_validator(
+    program_id: &Pubkey,
+    accounts: &DeactivateValidatorMeta,
+) -> Instruction {
     Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -12,7 +12,7 @@ use crate::{
     error::LidoError,
     instruction::{
         AddMaintainerInfo, AddValidatorInfo, ChangeRewardDistributionInfo, ClaimValidatorFeeInfo,
-        MergeStakeInfo, RemoveMaintainerInfo, RemoveValidatorInfo, DeactivateValidatorInfo,
+        DeactivateValidatorInfo, MergeStakeInfo, RemoveMaintainerInfo, RemoveValidatorInfo,
     },
     logic::{deserialize_lido, mint_st_sol_to},
     state::{RewardDistribution, Validator},

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -12,7 +12,7 @@ use crate::{
     error::LidoError,
     instruction::{
         AddMaintainerInfo, AddValidatorInfo, ChangeRewardDistributionInfo, ClaimValidatorFeeInfo,
-        MergeStakeInfo, RemoveMaintainerInfo, RemoveValidatorInfo,
+        MergeStakeInfo, RemoveMaintainerInfo, RemoveValidatorInfo, DeactivateValidatorInfo,
     },
     logic::{deserialize_lido, mint_st_sol_to},
     state::{RewardDistribution, Validator},
@@ -92,6 +92,29 @@ pub fn process_remove_validator(
         msg!("Validator still has tokens to claim. Reclaim tokens before removing the validator");
         return Err(LidoError::ValidatorHasUnclaimedCredit.into());
     }
+
+    lido.save(accounts.lido)
+}
+
+/// Set the `active` flag to false for a given validator.
+///
+/// This prevents new funds from being staked with this validator, and enables
+/// removing the validator once no stake is delegated to it any more, and once
+/// it has no unclaimed fee credit.
+pub fn process_deactivate_validator(
+    program_id: &Pubkey,
+    accounts_raw: &[AccountInfo],
+) -> ProgramResult {
+    let accounts = DeactivateValidatorInfo::try_from_slice(accounts_raw)?;
+    let mut lido = deserialize_lido(program_id, accounts.lido)?;
+    lido.check_manager(accounts.manager)?;
+
+    let validator = lido
+        .validators
+        .get_mut(accounts.validator_vote_account_to_deactivate.key)?;
+
+    validator.entry.active = false;
+    msg!("Validator {} deactivated.", validator.pubkey);
 
     lido.save(accounts.lido)
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -19,7 +19,7 @@ use crate::{
     process_management::{
         process_add_maintainer, process_add_validator, process_change_reward_distribution,
         process_claim_validator_fee, process_merge_stake, process_remove_maintainer,
-        process_remove_validator,
+        process_remove_validator, process_deactivate_validator,
     },
     stake_account::{deserialize_stake_account, StakeAccount},
     state::{
@@ -789,6 +789,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
         } => process_change_reward_distribution(program_id, new_reward_distribution, accounts),
         LidoInstruction::AddValidator => process_add_validator(program_id, accounts),
         LidoInstruction::RemoveValidator => process_remove_validator(program_id, accounts),
+        LidoInstruction::DeactivateValidator => process_deactivate_validator(program_id, accounts),
         LidoInstruction::AddMaintainer => process_add_maintainer(program_id, accounts),
         LidoInstruction::RemoveMaintainer => process_remove_maintainer(program_id, accounts),
         LidoInstruction::MergeStake => process_merge_stake(program_id, accounts),

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -18,8 +18,8 @@ use crate::{
     metrics::Metrics,
     process_management::{
         process_add_maintainer, process_add_validator, process_change_reward_distribution,
-        process_claim_validator_fee, process_merge_stake, process_remove_maintainer,
-        process_remove_validator, process_deactivate_validator,
+        process_claim_validator_fee, process_deactivate_validator, process_merge_stake,
+        process_remove_maintainer, process_remove_validator,
     },
     stake_account::{deserialize_stake_account, StakeAccount},
     state::{

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -704,6 +704,24 @@ impl Context {
         accounts
     }
 
+    pub async fn deactivate_validator(&mut self, vote_account: Pubkey) {
+        send_transaction(
+            &mut self.context,
+            &mut self.nonce,
+            &[lido::instruction::deactivate_validator(
+                &id(),
+                &lido::instruction::DeactivateValidatorMeta {
+                    lido: self.solido.pubkey(),
+                    manager: self.manager.pubkey(),
+                    validator_vote_account_to_deactivate: vote_account,
+                },
+            )],
+            vec![&self.manager],
+        )
+            .await
+            .expect("Failed to deactivate validator.");
+    }
+
     pub async fn try_remove_validator(&mut self, vote_account: Pubkey) -> transport::Result<()> {
         send_transaction(
             &mut self.context,

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -718,8 +718,8 @@ impl Context {
             )],
             vec![&self.manager],
         )
-            .await
-            .expect("Failed to deactivate validator.");
+        .await
+        .expect("Failed to deactivate validator.");
     }
 
     pub async fn try_remove_validator(&mut self, vote_account: Pubkey) -> transport::Result<()> {

--- a/program/tests/tests/add_remove_validator.rs
+++ b/program/tests/tests/add_remove_validator.rs
@@ -51,3 +51,27 @@ async fn test_remove_validator_without_unclaimed_credits() {
     let solido = context.get_solido().await;
     assert_eq!(solido.validators.len(), 0);
 }
+
+#[tokio::test]
+async fn test_deactivate_validator() {
+    let mut context = Context::new_with_maintainer().await;
+
+    let validator = context.add_validator().await;
+
+    // Initially, the validator should be active.
+    let solido = context.get_solido().await;
+    assert_eq!(solido.validators.len(), 1);
+    assert!(solido.validators.entries[0].entry.active);
+
+    context.deactivate_validator(validator.vote_account).await;
+
+    // After deactivation, it should be inactive.
+    let solido = context.get_solido().await;
+    assert_eq!(solido.validators.len(), 1);
+    assert!(!solido.validators.entries[0].entry.active);
+
+    // Deactivation is idempotent.
+    context.deactivate_validator(validator.vote_account).await;
+    let solido_after_second_deactivation = context.get_solido().await;
+    assert_eq!(solido, solido_after_second_deactivation);
+}


### PR DESCRIPTION
This implements part 1 of #364: adding a `Deactivate` instruction.

I will open a follow-up pull request to allow proposing a multisig transaction for this.