### PR TITLE
Add `solido deactivate-validator` subcommand

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -359,6 +359,30 @@ cli_opt_struct! {
 }
 
 cli_opt_struct! {
+    DeactivateValidatorOpts {
+        /// Address of the Solido program.
+        #[clap(long, value_name = "address")]
+        solido_program_id: Pubkey,
+
+        /// Account that stores the data for this Solido instance.
+        #[clap(long, value_name = "address")]
+        solido_address: Pubkey,
+
+        /// Address of the validator vote account.
+        #[clap(long, value_name = "address")]
+        validator_vote_account: Pubkey,
+
+        /// Multisig instance.
+        #[clap(long, value_name = "address")]
+        multisig_address: Pubkey,
+
+        /// Address of the Multisig program.
+        #[clap(long)]
+        multisig_program_id: Pubkey,
+    }
+}
+
+cli_opt_struct! {
     AddRemoveMaintainerOpts {
         /// Address of the Solido program.
         #[clap(long, value_name = "address")]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -377,7 +377,7 @@ cli_opt_struct! {
         multisig_address: Pubkey,
 
         /// Address of the Multisig program.
-        #[clap(long)]
+        #[clap(long, value_name = "address")]
         multisig_program_id: Pubkey,
     }
 }

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -22,8 +22,8 @@ use lido::{
 
 use crate::{
     config::{
-        AddRemoveMaintainerOpts, AddValidatorOpts, CreateSolidoOpts, DepositOpts,
-        ShowSolidoAuthoritiesOpts, ShowSolidoOpts, WithdrawOpts,
+        AddRemoveMaintainerOpts, AddValidatorOpts, CreateSolidoOpts, DeactivateValidatorOpts,
+        DepositOpts, ShowSolidoAuthoritiesOpts, ShowSolidoOpts, WithdrawOpts,
     },
     error::CliError,
     get_signer,
@@ -227,7 +227,7 @@ pub fn command_create_solido(
     Ok(result)
 }
 
-/// Command to add a validator to Solido.
+/// CLI entry point to add a validator to Solido.
 pub fn command_add_validator(
     config: &mut SnapshotConfig,
     opts: &AddValidatorOpts,
@@ -252,7 +252,31 @@ pub fn command_add_validator(
     )
 }
 
-/// Command to add a validator to Solido.
+/// CLI entry point to deactivate a validator.
+pub fn command_deactivate_validator(
+    config: &mut SnapshotConfig,
+    opts: &DeactivateValidatorOpts,
+) -> Result<ProposeInstructionOutput> {
+    let (multisig_address, _) =
+        get_multisig_program_address(opts.multisig_program_id(), opts.multisig_address());
+
+    let instruction = lido::instruction::deactivate_validator(
+        opts.solido_program_id(),
+        &lido::instruction::DeactivateValidatorMeta {
+            lido: *opts.solido_address(),
+            manager: multisig_address,
+            validator_vote_account_to_deactivate: *opts.validator_vote_account(),
+        },
+    );
+    propose_instruction(
+        config,
+        opts.multisig_program_id(),
+        *opts.multisig_address(),
+        instruction,
+    )
+}
+
+/// CLI entry point to to add a maintainer to Solido.
 pub fn command_add_maintainer(
     config: &mut SnapshotConfig,
     opts: &AddRemoveMaintainerOpts,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,8 +23,8 @@ use solana_sdk::transaction::Transaction;
 use crate::config::*;
 use crate::error::{Abort, CliError, Error};
 use crate::helpers::{
-    command_add_maintainer, command_add_validator, command_create_solido, command_deposit,
-    command_remove_maintainer, command_show_solido,
+    command_add_maintainer, command_add_validator, command_create_solido,
+    command_deactivate_validator, command_deposit, command_remove_maintainer, command_show_solido,
 };
 use crate::multisig::MultisigOpts;
 use crate::snapshot::{Snapshot, SnapshotClient};
@@ -128,6 +128,9 @@ REWARDS
 
     /// Adds a new validator
     AddValidator(AddValidatorOpts),
+
+    /// Deactivates a validator and initiates the removal process
+    DeactivateValidator(DeactivateValidatorOpts),
 
     /// Adds a maintainer to the Solido instance
     AddMaintainer(AddRemoveMaintainerOpts),
@@ -318,6 +321,12 @@ fn main() {
             let output = result.ok_or_abort_with("Failed to add validator.");
             print_output(output_mode, &output);
         }
+        SubCommand::DeactivateValidator(cmd_opts) => {
+            let result =
+                config.with_snapshot(|config| command_deactivate_validator(config, &cmd_opts));
+            let output = result.ok_or_abort_with("Failed to deactivate validator.");
+            print_output(output_mode, &output);
+        }
         SubCommand::AddMaintainer(cmd_opts) => {
             let result = config.with_snapshot(|config| command_add_maintainer(config, &cmd_opts));
             let output = result.ok_or_abort_with("Failed to add maintainer.");
@@ -361,6 +370,9 @@ fn merge_with_config_and_environment(
     match subcommand {
         SubCommand::CreateSolido(opts) => opts.merge_with_config_and_environment(config_file),
         SubCommand::AddValidator(opts) => opts.merge_with_config_and_environment(config_file),
+        SubCommand::DeactivateValidator(opts) => {
+            opts.merge_with_config_and_environment(config_file)
+        }
         SubCommand::AddMaintainer(opts) | SubCommand::RemoveMaintainer(opts) => {
             opts.merge_with_config_and_environment(config_file)
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -135,7 +135,7 @@ REWARDS
     /// Adds a maintainer to the Solido instance
     AddMaintainer(AddRemoveMaintainerOpts),
 
-    /// Adds a maintainer to the Solido instance
+    /// Removes a maintainer from the Solido instance
     RemoveMaintainer(AddRemoveMaintainerOpts),
 
     /// Deposit some SOL, receive stSOL in return.
@@ -144,15 +144,18 @@ REWARDS
     /// If the associated token account does not yet exist, it will be created.
     Deposit(DepositOpts),
 
-    /// Withdraw StSOL, receive a delegated stake account in return.
+    /// Withdraw stSOL, receive a delegated stake account in return.
     ///
     /// The amount of SOL is calculated and stored in the returned stake.
     Withdraw(WithdrawOpts),
 
-    /// Show an instance of solido in detail
+    /// Show an instance of Solido in detail
     ShowSolido(ShowSolidoOpts),
 
-    /// Show Solido authorities, useful for testing and when specifying an existing token mint.
+    /// Show Solido authorities, even if the instance is not initialized.
+    ///
+    /// This is useful for testing, and when setting up a token mint ahead of
+    /// time, to be used later when initializing the Solido instance.
     ShowAuthorities(ShowSolidoAuthoritiesOpts),
 
     /// Execute one iteration of periodic maintenance logic.

--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -18,18 +18,17 @@ use solana_sdk::signature::{Keypair, Signature, Signer};
 use solana_sdk::system_instruction;
 use solana_sdk::sysvar;
 
-use lido::instruction::{
-    AddMaintainerMeta, AddValidatorMeta, ChangeRewardDistributionMeta, DeactivateValidatorMeta,
-    LidoInstruction, RemoveMaintainerMeta,
+use lido::{
+    instruction::{
+        AddMaintainerMeta, AddValidatorMeta, ChangeRewardDistributionMeta, DeactivateValidatorMeta,
+        LidoInstruction, RemoveMaintainerMeta,
+    },
+    state::{FeeRecipients, Lido, RewardDistribution},
+    util::{serialize_b58, serialize_b58_slice},
 };
-use lido::state::FeeRecipients;
-use lido::state::Lido;
-use lido::state::RewardDistribution;
-use lido::util::{serialize_b58, serialize_b58_slice};
 
-use crate::config::ConfigFile;
 use crate::config::{
-    ApproveOpts, CreateMultisigOpts, ExecuteTransactionOpts, ProposeChangeMultisigOpts,
+    ApproveOpts, ConfigFile, CreateMultisigOpts, ExecuteTransactionOpts, ProposeChangeMultisigOpts,
     ProposeUpgradeOpts, ShowMultisigOpts, ShowTransactionOpts,
 };
 use crate::error::{Abort, AsPrettyError};

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -524,3 +524,47 @@ expected_result = {
     }
 }
 print('> Staked as expected.')
+
+print(f'\n Deactivating validator {validator_vote_account.pubkey} ...')
+transaction_result = solido(
+    'deactivate-validator',
+    '--multisig-program-id',
+    multisig_program_id,
+    '--multisig-address',
+    multisig_instance,
+    '--solido-program-id',
+    solido_program_id,
+    '--solido-address',
+    solido_address,
+    '--validator-vote-account',
+    validator_vote_account.pubkey,
+    keypair_path=test_addrs[0].keypair_path,
+)
+transaction_address = transaction_result['transaction_address']
+print(f'> Deactivation multisig transaction address is {transaction_address}.')
+transaction_status = multisig(
+    'show-transaction',
+    '--multisig-program-id',
+    multisig_program_id,
+    '--solido-program-id',
+    solido_program_id,
+    '--transaction-address',
+    transaction_address,
+)
+assert (
+    'DeactivateValidator'
+    in transaction_status['parsed_instruction']['SolidoInstruction']
+)
+approve_and_execute(transaction_address, test_addrs[1])
+
+solido_instance = solido(
+    'show-solido',
+    '--solido-program-id',
+    solido_program_id,
+    '--solido-address',
+    solido_address,
+)
+assert not solido_instance['solido']['validators']['entries'][0]['entry'][
+    'active'
+], 'Validator should be inactive after deactivation.'
+print('> Validator is inactive as expected.')


### PR DESCRIPTION
This is a follow-up to #370 and implements the final part of #364:

* Add support for the `Deactivate` instruction in `solido multisig show-transaction`.
* Add `solido deactivate-validator` to propose a `Deactivate` to the multisig.
* Test it in `test_solido.py`.
* As a drive-by fix, fix some of the command descriptions.