### PR TITLE
Implement the `Unstake` instruction.

### DIFF
--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -479,14 +479,17 @@ impl fmt::Display for ShowSolidoOutput {
                 pe.entry.fee_credit,
                 pe.entry.stake_accounts_balance,
             )?;
-            for seed in pe.entry.stake_accounts_seed_begin..pe.entry.stake_accounts_seed_end {
+            for seed in pe.entry.stake_seeds.stake_accounts_seed_begin
+                ..pe.entry.stake_seeds.stake_accounts_seed_end
+            {
                 writeln!(
                     f,
                     "      - {}: {}",
                     seed,
-                    pe.find_stake_account_address(
+                    Validator::find_stake_account_address(
                         &self.solido_program_id,
                         &self.solido_address,
+                        &pe.pubkey,
                         seed
                     )
                     .0
@@ -773,7 +776,10 @@ pub fn command_withdraw(
             opts.solido_program_id(),
             opts.solido_address(),
             &heaviest_validator.pubkey,
-            heaviest_validator.entry.stake_accounts_seed_begin,
+            heaviest_validator
+                .entry
+                .stake_seeds
+                .stake_accounts_seed_begin,
         );
 
         let destination_stake_account = Keypair::new();

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -479,9 +479,7 @@ impl fmt::Display for ShowSolidoOutput {
                 pe.entry.fee_credit,
                 pe.entry.stake_accounts_balance,
             )?;
-            for seed in pe.entry.stake_seeds.stake_accounts_seed_begin
-                ..pe.entry.stake_seeds.stake_accounts_seed_end
-            {
+            for seed in pe.entry.stake_seeds.begin..pe.entry.stake_seeds.end {
                 writeln!(
                     f,
                     "      - {}: {}",
@@ -776,10 +774,7 @@ pub fn command_withdraw(
             opts.solido_program_id(),
             opts.solido_address(),
             &heaviest_validator.pubkey,
-            heaviest_validator
-                .entry
-                .stake_seeds
-                .stake_accounts_seed_begin,
+            heaviest_validator.entry.stake_seeds.begin,
         );
 
         let destination_stake_account = Keypair::new();

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -14,7 +14,7 @@ use lido::{
     balance::get_validator_to_withdraw,
     find_authority_program_address,
     metrics::LamportsHistogram,
-    state::{Lido, RewardDistribution, Validator},
+    state::{Lido, RewardDistribution},
     token::{Lamports, StLamports},
     util::serialize_b58,
     MINT_AUTHORITY, RESERVE_ACCOUNT, REWARDS_WITHDRAW_AUTHORITY, STAKE_AUTHORITY,
@@ -484,10 +484,9 @@ impl fmt::Display for ShowSolidoOutput {
                     f,
                     "      - {}: {}",
                     seed,
-                    Validator::find_stake_account_address(
+                    pe.find_stake_account_address(
                         &self.solido_program_id,
                         &self.solido_address,
-                        &pe.pubkey,
                         seed
                     )
                     .0
@@ -770,10 +769,9 @@ pub fn command_withdraw(
             )
         })?;
 
-        let (stake_address, _bump_seed) = Validator::find_stake_account_address(
+        let (stake_address, _bump_seed) = heaviest_validator.find_stake_account_address(
             opts.solido_program_id(),
             opts.solido_address(),
-            &heaviest_validator.pubkey,
             heaviest_validator.entry.stake_seeds.begin,
         );
 

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -479,7 +479,7 @@ impl fmt::Display for ShowSolidoOutput {
                 pe.entry.fee_credit,
                 pe.entry.stake_accounts_balance,
             )?;
-            for seed in pe.entry.stake_seeds.begin..pe.entry.stake_seeds.end {
+            for seed in &pe.entry.stake_seeds {
                 writeln!(
                     f,
                     "      - {}: {}",

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -209,7 +209,9 @@ fn get_validator_stake_accounts(
     validator: &PubkeyAndEntry<Validator>,
 ) -> Result<Vec<(Pubkey, StakeAccount)>> {
     let mut result = Vec::new();
-    for seed in validator.entry.stake_accounts_seed_begin..validator.entry.stake_accounts_seed_end {
+    for seed in validator.entry.stake_seeds.stake_accounts_seed_begin
+        ..validator.entry.stake_seeds.stake_accounts_seed_end
+    {
         let (addr, _bump_seed) = Validator::find_stake_account_address(
             solido_program_id,
             solido_address,
@@ -351,10 +353,11 @@ impl SolidoState {
             );
         let validator = &self.solido.validators.entries[validator_index];
 
-        let (stake_account_end, _bump_seed_end) = validator.find_stake_account_address(
+        let (stake_account_end, _bump_seed_end) = Validator::find_stake_account_address(
             &self.solido_program_id,
             &self.solido_address,
-            validator.entry.stake_accounts_seed_end,
+            &validator.pubkey,
+            validator.entry.stake_seeds.stake_accounts_seed_end,
         );
 
         // Top up the validator to at most its target. If that means we don't use the full

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -953,10 +953,9 @@ mod test {
         // balance.
         state.reserve_account.lamports += 4 * MINIMUM_STAKE_ACCOUNT_BALANCE.0;
 
-        let stake_account_0 = Validator::find_stake_account_address(
+        let stake_account_0 = state.solido.validators.entries[0].find_stake_account_address(
             &state.solido_program_id,
             &state.solido_address,
-            &state.solido.validators.entries[0].pubkey,
             0,
         );
 
@@ -970,10 +969,9 @@ mod test {
             }
         );
 
-        let stake_account_1 = Validator::find_stake_account_address(
+        let stake_account_1 = state.solido.validators.entries[1].find_stake_account_address(
             &state.solido_program_id,
             &state.solido_address,
-            &state.solido.validators.entries[1].pubkey,
             0,
         );
 

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -209,9 +209,7 @@ fn get_validator_stake_accounts(
     validator: &PubkeyAndEntry<Validator>,
 ) -> Result<Vec<(Pubkey, StakeAccount)>> {
     let mut result = Vec::new();
-    for seed in validator.entry.stake_seeds.stake_accounts_seed_begin
-        ..validator.entry.stake_seeds.stake_accounts_seed_end
-    {
+    for seed in validator.entry.stake_seeds.begin..validator.entry.stake_seeds.end {
         let (addr, _bump_seed) = Validator::find_stake_account_address(
             solido_program_id,
             solido_address,
@@ -357,7 +355,7 @@ impl SolidoState {
             &self.solido_program_id,
             &self.solido_address,
             &validator.pubkey,
-            validator.entry.stake_seeds.stake_accounts_seed_end,
+            validator.entry.stake_seeds.end,
         );
 
         // Top up the validator to at most its target. If that means we don't use the full

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM chorusone/solido-base
 
-ENV SOLVERSION=1.7.3
-ENV SOLINSTALLCHECKSUM=b5ef6183da7d489a0e6ebc203d64e82e4dd24a9144ead3e564df692625d91b10
+ENV SOLVERSION=1.7.10
+ENV SOLINSTALLCHECKSUM=a155853b3ab42701fce66205977728bc46ce0c3f374c30b7f12beb19b58b37c0
 ENV SOLPATH="/root/.local/share/solana/install/active_release/bin"
 ENV SOLIDOBUILDPATH="$SOLPATH/solido-build"
 ENV SOLIDORELEASEPATH="$SOLPATH/solido"
@@ -33,8 +33,9 @@ RUN cd $SOLIDOBUILDPATH \
 RUN cd $SOLIDOBUILDPATH \
     && cp -rf $SOLIDOBUILDPATH/target/deploy $SOLIDORELEASEPATH \
     && cp -rf $SOLIDOBUILDPATH/target/release/* $SOLIDORELEASEPATH/cli \
-    && cp -rf $SOLIDOBUILDPATH/tests/* $SOLIDORELEASEPATH/tests \
-    && rm -rf $SOLIDOBUILDPATH
+    && cp -rf $SOLIDOBUILDPATH/tests/* $SOLIDORELEASEPATH/tests
+#\
+#    && rm -rf $SOLIDOBUILDPATH
 
 # Hash on-chain programs
 RUN cd $SOLIDORELEASEPATH/deploy \

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -154,6 +154,14 @@ pub enum LidoError {
     /// Tried to deposit stake to inactive validator.
     #[error("StakeToInactiveValidator")]
     StakeToInactiveValidator = 39,
+
+    /// Tried to remove a validator when it when it was active or had stake accounts.
+    #[error("ValidatorIsStillActive")]
+    ValidatorIsStillActive = 40,
+
+    /// Tried to remove a validator when it when it was active or had stake accounts.
+    #[error("ValidatorShouldHaveNoStakeAccounts")]
+    ValidatorShouldHaveNoStakeAccounts = 41,
 }
 
 impl From<ArithmeticError> for LidoError {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -367,18 +367,16 @@ accounts_struct! {
         // the given validator, with seed `stake_seeds.stake_accounts_seed_end - 1`.
         pub source_stake_account {
             is_signer: false,
-            // Is writable due to split (`stake_program::intruction::split`) of stake_account_end
-            // into stake_account_merge_into under the condition that they are not equal
+            // Is writable due to split (`stake_program::intruction::split`).
             is_writable: true,
         },
         // Destination stake account is the last unstake stake account that will
-        // receive the split of the funds.  Determined by the program-derived
+        // receive the split of the funds. Determined by the program-derived
         // stake account for the given validator, with seed
         // `unstake_seeds.stake_accounts_seed_end`.
         pub destination_stake_account {
             is_signer: false,
-            // Is writable due to the first two instructions from split
-            // (`stake_program::intruction::split`).
+            // Is writable due to the first two instructions from split.
             is_writable: true,
         },
         // Stake authority, to be able to split the stake.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -364,7 +364,7 @@ accounts_struct! {
         },
         // Source stake account is the last active stake account that we'll try
         // to unstake from.  Determined by the program-derived stake account for
-        // the given validator, with seed `stake_seeds.stake_accounts_seed_end - 1`.
+        // the given validator, with seed `stake_seeds.begin`.
         pub source_stake_account {
             is_signer: false,
             // Is writable due to split (`stake_program::intruction::split`).
@@ -372,8 +372,7 @@ accounts_struct! {
         },
         // Destination stake account is the last unstake stake account that will
         // receive the split of the funds. Determined by the program-derived
-        // stake account for the given validator, with seed
-        // `unstake_seeds.stake_accounts_seed_end`.
+        // stake account for the given validator, with seed `unstake_seeds.end`.
         pub destination_stake_account {
             is_signer: false,
             // Is writable due to the first two instructions from split.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -304,7 +304,7 @@ accounts_struct! {
         // For a `StakeDeposit` where we temporarily create an undelegated
         // account at `stake_account_end`, but immediately merge it into
         // `stake_account_merge_into`, this must be set to the program-derived
-        // stake account for the validator, with seed `stake_accounts_seed_end
+        // stake account for the validator, with seed `stake_seed.end
         // - 1`. For a `StakeDeposit` where we create a new stake account, this
         // should be set to the same value as `stake_account_end`.
         pub stake_account_merge_into {
@@ -314,7 +314,7 @@ accounts_struct! {
             is_writable: true,
         },
         // Must be set to the program-derived stake account for the given
-        // validator, with seed `stake_accounts_seed_end`.
+        // validator, with seed `stake_seeds.end`.
         pub stake_account_end {
             is_signer: false,
             // Is writable due to transfer (system_instruction::transfer) from reserve_account to

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -362,7 +362,7 @@ accounts_struct! {
             is_signer: false,
             is_writable: false,
         },
-        // Source stake account is the last active stake account that we'll try
+        // Source stake account is the oldest active stake account that we'll try
         // to unstake from.  Determined by the program-derived stake account for
         // the given validator, with seed `stake_seeds.begin`.
         pub source_stake_account {
@@ -370,7 +370,7 @@ accounts_struct! {
             // Is writable due to split (`stake_program::intruction::split`).
             is_writable: true,
         },
-        // Destination stake account is the last unstake stake account that will
+        // Destination stake account is the oldest unstake stake account that will
         // receive the split of the funds. Determined by the program-derived
         // stake account for the given validator, with seed `unstake_seeds.end`.
         pub destination_stake_account {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -362,33 +362,36 @@ accounts_struct! {
             is_signer: false,
             is_writable: false,
         },
-        // Source stake account is the first, possibly active stake account that we'll try to unstake from.
-        // Determined by the
+        // Source stake account is the last active stake account that we'll try
+        // to unstake from.  Determined by the program-derived stake account for
+        // the given validator, with seed `stake_seeds.stake_accounts_seed_end - 1`.
         pub source_stake_account {
             is_signer: false,
-            // Is writable due to merge (stake_program::intruction::merge) of stake_account_end
+            // Is writable due to split (`stake_program::intruction::split`) of stake_account_end
             // into stake_account_merge_into under the condition that they are not equal
             is_writable: true,
         },
-        // Must be set to the program-derived stake account for the given
-        // validator, with seed `stake_accounts_seed_end`.
+        // Destination stake account is the last unstake stake account that will
+        // receive the split of the funds.  Determined by the program-derived
+        // stake account for the given validator, with seed
+        // `unstake_seeds.stake_accounts_seed_end`.
         pub destination_stake_account {
             is_signer: false,
-            // Is writable due to transfer (system_instruction::transfer) from reserve_account to
-            // stake_account_end and stake program being initialized
-            // (stake_program::instruction::initialize)
+            // Is writable due to the first two instructions from split
+            // (`stake_program::intruction::split`).
             is_writable: true,
         },
+        // Stake authority, to be able to split the stake.
         pub stake_authority {
             is_signer: false,
             is_writable: false,
         },
+        // Required to call `solana_program::stake::instruction::deactivate_stake`.
         const sysvar_clock = sysvar::clock::id(),
+        // Required to call cross-program.
         const system_program = system_program::id(),
-        const sysvar_rent = sysvar::rent::id(),
+        // Required to call `stake_program::intruction::split`.
         const stake_program = stake_program::program::id(),
-        const stake_history = stake_history::id(),
-        const stake_program_config = stake_program::config::id(),
     }
 }
 

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -56,10 +56,7 @@ pub enum LidoInstruction {
         #[allow(dead_code)] // but it's not
         amount: Lamports,
     },
-    /// Unstake from a validator to a new stake account
-    ///
-    /// Splits the stake account determined by the validator's inactive stake
-    /// seeds.
+    /// Unstake from a validator to a new stake account.
     Unstake {
         #[allow(dead_code)] // but it's not
         amount: Lamports,
@@ -365,12 +362,8 @@ accounts_struct! {
             is_signer: false,
             is_writable: false,
         },
-        // For a `StakeDeposit` where we temporarily create an undelegated
-        // account at `stake_account_end`, but immediately merge it into
-        // `stake_account_merge_into`, this must be set to the program-derived
-        // stake account for the validator, with seed `stake_accounts_seed_end
-        // - 1`. For a `StakeDeposit` where we create a new stake account, this
-        // should be set to the same value as `stake_account_end`.
+        // Source stake account is the first, possibly active stake account that we'll try to unstake from.
+        // Determined by the
         pub source_stake_account {
             is_signer: false,
             // Is writable due to merge (stake_program::intruction::merge) of stake_account_end

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -56,7 +56,14 @@ pub enum LidoInstruction {
         #[allow(dead_code)] // but it's not
         amount: Lamports,
     },
-
+    /// Unstake from a validator to a new stake account
+    ///
+    /// Splits the stake account determined by the validator's inactive stake
+    /// seeds.
+    Unstake {
+        #[allow(dead_code)] // but it's not
+        amount: Lamports,
+    },
     /// Update the exchange rate, at the beginning of the epoch.
     ///
     /// This can be called by anybody.
@@ -337,6 +344,67 @@ pub fn stake_deposit(
     amount: Lamports,
 ) -> Instruction {
     let data = LidoInstruction::StakeDeposit { amount };
+    Instruction {
+        program_id: *program_id,
+        accounts: accounts.to_vec(),
+        data: data.to_vec(),
+    }
+}
+
+accounts_struct! {
+    UnstakeAccountsMeta, UnstakeAccountsInfo {
+        pub lido {
+            is_signer: false,
+            is_writable: true,
+        },
+        pub maintainer {
+            is_signer: true,
+            is_writable: false,
+        },
+        pub validator_vote_account {
+            is_signer: false,
+            is_writable: false,
+        },
+        // For a `StakeDeposit` where we temporarily create an undelegated
+        // account at `stake_account_end`, but immediately merge it into
+        // `stake_account_merge_into`, this must be set to the program-derived
+        // stake account for the validator, with seed `stake_accounts_seed_end
+        // - 1`. For a `StakeDeposit` where we create a new stake account, this
+        // should be set to the same value as `stake_account_end`.
+        pub source_stake_account {
+            is_signer: false,
+            // Is writable due to merge (stake_program::intruction::merge) of stake_account_end
+            // into stake_account_merge_into under the condition that they are not equal
+            is_writable: true,
+        },
+        // Must be set to the program-derived stake account for the given
+        // validator, with seed `stake_accounts_seed_end`.
+        pub destination_stake_account {
+            is_signer: false,
+            // Is writable due to transfer (system_instruction::transfer) from reserve_account to
+            // stake_account_end and stake program being initialized
+            // (stake_program::instruction::initialize)
+            is_writable: true,
+        },
+        pub stake_authority {
+            is_signer: false,
+            is_writable: false,
+        },
+        const sysvar_clock = sysvar::clock::id(),
+        const system_program = system_program::id(),
+        const sysvar_rent = sysvar::rent::id(),
+        const stake_program = stake_program::program::id(),
+        const stake_history = stake_history::id(),
+        const stake_program_config = stake_program::config::id(),
+    }
+}
+
+pub fn unstake(
+    program_id: &Pubkey,
+    accounts: &UnstakeAccountsMeta,
+    amount: Lamports,
+) -> Instruction {
+    let data = LidoInstruction::Unstake { amount };
     Instruction {
         program_id: *program_id,
         accounts: accounts.to_vec(),

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -32,8 +32,10 @@ pub const MINT_AUTHORITY: &[u8] = b"mint_authority";
 /// Seed for managing the stake.
 pub const STAKE_AUTHORITY: &[u8] = b"stake_authority";
 
-/// Additional seed for validator stake accounts.
+/// Additional seed for active/activating validator stake accounts.
 pub const VALIDATOR_STAKE_ACCOUNT: &[u8] = b"validator_stake_account";
+/// Additional seed for inactive/deactivating validator stake accounts.
+pub const VALIDATOR_UNSTAKE_ACCOUNT: &[u8] = b"validator_unstake_account";
 
 /// Authority responsible for withdrawing the stake rewards.
 pub const REWARDS_WITHDRAW_AUTHORITY: &[u8] = b"rewards_withdraw_authority";

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -399,9 +399,6 @@ pub fn check_unstake_accounts(
         );
         return Err(LidoError::InvalidStakeAccount.into());
     }
-    // Does not underflow. If `stake_seeds.end == 0` the previous
-    // condition would have failed. And `stake_seeds.end` is always greater than
-    // `stake_seeds.begin`.
     let source_stake_seed = validator.entry.stake_seeds.begin;
     let destination_stake_seed = validator.entry.unstake_seeds.end;
 
@@ -424,8 +421,8 @@ pub fn check_unstake_accounts(
         msg!(
             "Destination stake account differs from the one calculated by seed {}, should be {}, is {}.",
             destination_stake_seed,
-            source_stake_account,
-            accounts.source_stake_account.key
+            destination_stake_account,
+            accounts.destination_stake_account.key
         );
         return Err(LidoError::InvalidStakeAccount.into());
     }

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -396,7 +396,10 @@ pub fn check_unstake_accounts(
     if validator.entry.stake_seeds.stake_accounts_seed_begin
         == validator.entry.stake_seeds.stake_accounts_seed_end
     {
-        msg!("Attempting to unstake from accounts in a validator that has no stake accounts.");
+        msg!(
+            "Attempting to unstake from a validator {} that has no stake accounts.",
+            validator.pubkey
+        );
         return Err(LidoError::InvalidStakeAccount.into());
     }
     // Does not underflow. If `stake_accounts_seed_end == 0` the previous
@@ -448,6 +451,13 @@ pub struct SplitStakeAccounts<'a, 'b> {
     pub stake_program: &'a AccountInfo<'b>,
 }
 
+/// Splits `amount` Lamports from the stake in `accounts.source_stake_account`
+/// to the stake in `accounts.destination_stake_account`.
+///
+/// Issue 3 transactions with `invoke_signed` signed with seeds specified by `seeds`:
+///   - Allocates space in the `accounts.destination_stake_account`.
+///   - Assigns the owner of the `accounts.destination_stake_account` to the stake program.
+///   - Splits the stake.
 pub fn split_stake_account(
     lido_address: &Pubkey,
     lido: &Lido,

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -393,19 +393,18 @@ pub fn check_unstake_accounts(
     let validator = lido.validators.get(accounts.validator_vote_account.key)?;
 
     // If a validator doesn't have a stake account, it cannot be unstaked.
-    if validator.entry.stake_seeds.stake_accounts_seed_begin
-        == validator.entry.stake_seeds.stake_accounts_seed_end
-    {
+    if validator.entry.stake_seeds.begin == validator.entry.stake_seeds.end {
         msg!(
             "Attempting to unstake from a validator {} that has no stake accounts.",
             validator.pubkey
         );
         return Err(LidoError::InvalidStakeAccount.into());
     }
-    // Does not underflow. If `stake_accounts_seed_end == 0` the previous
-    // condition would have failed.
-    let source_stake_seed = validator.entry.stake_seeds.stake_accounts_seed_end - 1;
-    let destination_stake_seed = validator.entry.unstake_seeds.stake_accounts_seed_end;
+    // Does not underflow. If `stake_seeds.end == 0` the previous
+    // condition would have failed. And `stake_seeds.end` is always greater than
+    // `stake_seeds.begin`.
+    let source_stake_seed = validator.entry.stake_seeds.begin;
+    let destination_stake_seed = validator.entry.unstake_seeds.end;
 
     let (source_stake_account, _) = Validator::find_stake_account_address(
         program_id,

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -392,7 +392,7 @@ pub fn check_unstake_accounts(
     let validator = lido.validators.get(accounts.validator_vote_account.key)?;
 
     // If a validator doesn't have a stake account, it cannot be unstaked.
-    if validator.entry.stake_seeds.begin == validator.entry.stake_seeds.end {
+    if !validator.entry.has_stake_accounts() {
         msg!(
             "Attempting to unstake from a validator {} that has no stake accounts.",
             validator.pubkey

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -11,7 +11,6 @@ use solana_program::{
     stake as stake_program, system_instruction,
 };
 
-use crate::state::Validator;
 use crate::STAKE_AUTHORITY;
 use crate::{
     error::LidoError,
@@ -406,12 +405,8 @@ pub fn check_unstake_accounts(
     let source_stake_seed = validator.entry.stake_seeds.begin;
     let destination_stake_seed = validator.entry.unstake_seeds.end;
 
-    let (source_stake_account, _) = Validator::find_stake_account_address(
-        program_id,
-        accounts.lido.key,
-        accounts.validator_vote_account.key,
-        source_stake_seed,
-    );
+    let (source_stake_account, _) =
+        validator.find_stake_account_address(program_id, accounts.lido.key, source_stake_seed);
 
     if &source_stake_account != accounts.source_stake_account.key {
         msg!(
@@ -423,13 +418,8 @@ pub fn check_unstake_accounts(
         return Err(LidoError::InvalidStakeAccount.into());
     }
 
-    let (destination_stake_account, destination_bump_seed) =
-        Validator::find_unstake_account_address(
-            program_id,
-            accounts.lido.key,
-            accounts.validator_vote_account.key,
-            destination_stake_seed,
-        );
+    let (destination_stake_account, destination_bump_seed) = validator
+        .find_unstake_account_address(program_id, accounts.lido.key, destination_stake_seed);
     if &destination_stake_account != accounts.destination_stake_account.key {
         msg!(
             "Destination stake account differs from the one calculated by seed {}, should be {}, is {}.",

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -202,12 +202,8 @@ pub fn process_merge_stake(program_id: &Pubkey, accounts_raw: &[AccountInfo]) ->
     }
 
     // Recalculate the `from_stake`.
-    let (from_stake_addr, _) = Validator::find_stake_account_address(
-        program_id,
-        accounts.lido.key,
-        accounts.validator_vote_account.key,
-        from_seed,
-    );
+    let (from_stake_addr, _) =
+        validator.find_stake_account_address(program_id, accounts.lido.key, from_seed);
     // Compare with the stake passed in `accounts`.
     if &from_stake_addr != accounts.from_stake.key {
         msg!(
@@ -218,12 +214,8 @@ pub fn process_merge_stake(program_id: &Pubkey, accounts_raw: &[AccountInfo]) ->
         );
         return Err(LidoError::InvalidStakeAccount.into());
     }
-    let (to_stake_addr, _) = Validator::find_stake_account_address(
-        program_id,
-        accounts.lido.key,
-        accounts.validator_vote_account.key,
-        to_seed,
-    );
+    let (to_stake_addr, _) =
+        validator.find_stake_account_address(program_id, accounts.lido.key, to_seed);
     if &to_stake_addr != accounts.to_stake.key {
         msg!(
             "Calculated to_stake {} for seed {} is different from received {}.",

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -192,11 +192,11 @@ pub fn process_merge_stake(program_id: &Pubkey, accounts_raw: &[AccountInfo]) ->
     let mut validator = lido
         .validators
         .get_mut(accounts.validator_vote_account.key)?;
-    let from_seed = validator.entry.stake_seeds.stake_accounts_seed_begin;
-    let to_seed = validator.entry.stake_seeds.stake_accounts_seed_begin + 1;
+    let from_seed = validator.entry.stake_seeds.begin;
+    let to_seed = validator.entry.stake_seeds.begin + 1;
 
     // Check that there are at least two accounts to merge
-    if to_seed >= validator.entry.stake_seeds.stake_accounts_seed_end {
+    if to_seed >= validator.entry.stake_seeds.end {
         msg!("Attempting to merge accounts in a validator that has fewer than two stake accounts.");
         return Err(LidoError::InvalidStakeAccount.into());
     }
@@ -233,7 +233,7 @@ pub fn process_merge_stake(program_id: &Pubkey, accounts_raw: &[AccountInfo]) ->
         );
         return Err(LidoError::InvalidStakeAccount.into());
     }
-    validator.entry.stake_seeds.stake_accounts_seed_begin += 1;
+    validator.entry.stake_seeds.begin += 1;
     // Merge `from_stake_addr` to `to_stake_addr`, at the end of the
     // instruction, `from_stake_addr` ceases to exist.
     let merge_instructions = solana_program::stake::instruction::merge(

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -192,11 +192,11 @@ pub fn process_merge_stake(program_id: &Pubkey, accounts_raw: &[AccountInfo]) ->
     let mut validator = lido
         .validators
         .get_mut(accounts.validator_vote_account.key)?;
-    let from_seed = validator.entry.stake_accounts_seed_begin;
-    let to_seed = validator.entry.stake_accounts_seed_begin + 1;
+    let from_seed = validator.entry.stake_seeds.stake_accounts_seed_begin;
+    let to_seed = validator.entry.stake_seeds.stake_accounts_seed_begin + 1;
 
     // Check that there are at least two accounts to merge
-    if to_seed >= validator.entry.stake_accounts_seed_end {
+    if to_seed >= validator.entry.stake_seeds.stake_accounts_seed_end {
         msg!("Attempting to merge accounts in a validator that has fewer than two stake accounts.");
         return Err(LidoError::InvalidStakeAccount.into());
     }
@@ -233,7 +233,7 @@ pub fn process_merge_stake(program_id: &Pubkey, accounts_raw: &[AccountInfo]) ->
         );
         return Err(LidoError::InvalidStakeAccount.into());
     }
-    validator.entry.stake_accounts_seed_begin += 1;
+    validator.entry.stake_seeds.stake_accounts_seed_begin += 1;
     // Merge `from_stake_addr` to `to_stake_addr`, at the end of the
     // instruction, `from_stake_addr` ceases to exist.
     let merge_instructions = solana_program::stake::instruction::merge(

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -77,16 +77,12 @@ pub fn process_remove_validator(
 ) -> ProgramResult {
     let accounts = RemoveValidatorInfo::try_from_slice(accounts_raw)?;
     let mut lido = deserialize_lido(program_id, accounts.lido)?;
-    lido.check_manager(accounts.manager)?;
 
     let removed_validator = lido
         .validators
         .remove(accounts.validator_vote_account_to_remove.key)?;
 
-    if removed_validator.fee_credit != StLamports(0) {
-        msg!("Validator still has tokens to claim. Reclaim tokens before removing the validator");
-        return Err(LidoError::ValidatorHasUnclaimedCredit.into());
-    }
+    removed_validator.check_can_be_removed()?;
 
     lido.save(accounts.lido)
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -427,7 +427,6 @@ pub fn process_unstake(
         .validators
         .get_mut(accounts.validator_vote_account.key)?;
     // Increase the `unstake_accounts_balance` by `amount`.
-
     if validator.entry.active {
         if (validator.entry.stake_accounts_balance - amount)? < MINIMUM_STAKE_ACCOUNT_BALANCE {
             msg!(

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -428,8 +428,13 @@ pub fn process_unstake(
         .get_mut(accounts.validator_vote_account.key)?;
     // Increase the `unstake_accounts_balance` by `amount`.
     validator.entry.unstake_accounts_balance = (validator.entry.unstake_accounts_balance + amount)?;
+    msg!(
+        "VALIDATOR ACTIVE: {}, STAKE ACCOUNT:{}",
+        validator.entry.active,
+        validator.entry.stake_accounts_balance
+    );
     if validator.entry.active
-        && validator.entry.stake_accounts_balance < MINIMUM_STAKE_ACCOUNT_BALANCE
+        && (validator.entry.stake_accounts_balance - amount)? < MINIMUM_STAKE_ACCOUNT_BALANCE
     {
         msg!(
             "Unstake operation will leave the active validator with {}, less than the minimum balance {}.\\

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -370,6 +370,8 @@ pub fn process_stake_deposit(
     lido.save(accounts.lido)
 }
 
+/// Unstakes from a validator, the funds are moved to the stake defined by the
+/// validator's unstake seed. Caller must be a maintainer.
 pub fn process_unstake(
     program_id: &Pubkey,
     amount: Lamports,
@@ -381,12 +383,12 @@ pub fn process_unstake(
     lido.check_stake_authority(program_id, accounts.lido.key, accounts.stake_authority)?;
     let destination_bump_seed = check_unstake_accounts(program_id, &lido, &accounts)?;
 
-    let provided_validator = lido.validators.get(accounts.validator_vote_account.key)?;
+    let validator = lido.validators.get(accounts.validator_vote_account.key)?;
     let seeds = [
         &accounts.lido.key.to_bytes(),
         &accounts.validator_vote_account.key.to_bytes(),
         VALIDATOR_UNSTAKE_ACCOUNT,
-        &provided_validator
+        &validator
             .entry
             .unstake_seeds
             .stake_accounts_seed_end
@@ -414,7 +416,7 @@ pub fn process_unstake(
     );
 
     // Deactivates the stake. After this transaction, the Lamports on this stake
-    // account need to go back to the reserve account using another instruction.
+    // account need to go back to the reserve account by using another instruction.
     invoke_signed(
         &deactivate_stake_instruction,
         &[
@@ -430,15 +432,11 @@ pub fn process_unstake(
         ]],
     )?;
 
-    let provided_validator = lido
+    let validator = lido
         .validators
         .get_mut(accounts.validator_vote_account.key)?;
-    provided_validator.entry.stake_accounts_balance =
-        (provided_validator.entry.stake_accounts_balance - amount)?;
-    provided_validator
-        .entry
-        .unstake_seeds
-        .stake_accounts_seed_end += 1;
+    validator.entry.stake_accounts_balance = (validator.entry.stake_accounts_balance - amount)?;
+    validator.entry.unstake_seeds.stake_accounts_seed_end += 1;
 
     lido.save(accounts.lido)
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -212,7 +212,7 @@ pub fn process_stake_deposit(
         program_id,
         accounts.lido.key,
         validator,
-        validator.entry.stake_seeds.stake_accounts_seed_end,
+        validator.entry.stake_seeds.end,
         accounts.stake_account_end,
         VALIDATOR_STAKE_ACCOUNT,
     )?;
@@ -225,11 +225,7 @@ pub fn process_stake_deposit(
         return Err(LidoError::WrongStakeState.into());
     }
 
-    let stake_account_seed = validator
-        .entry
-        .stake_seeds
-        .stake_accounts_seed_end
-        .to_le_bytes();
+    let stake_account_seed = validator.entry.stake_seeds.end.to_le_bytes();
     let stake_account_bump_seed = [stake_account_bump_seed];
     let stake_account_seeds = &[
         accounts.lido.key.as_ref(),
@@ -289,7 +285,7 @@ pub fn process_stake_deposit(
         // Case 1: we delegate, and we don't touch `stake_account_merge_into`.
         msg!(
             "Delegating stake account at seed {} ...",
-            validator.entry.stake_seeds.stake_accounts_seed_end
+            validator.entry.stake_seeds.end
         );
         invoke_signed(
             &stake_program::instruction::delegate_stake(
@@ -314,12 +310,10 @@ pub fn process_stake_deposit(
         )?;
 
         // We now consumed this stake account, bump the index.
-        validator.entry.stake_seeds.stake_accounts_seed_end += 1;
+        validator.entry.stake_seeds.end += 1;
     } else {
         // Case 2: Merge the new undelegated stake account into the existing one.
-        if validator.entry.stake_seeds.stake_accounts_seed_end
-            <= validator.entry.stake_seeds.stake_accounts_seed_begin
-        {
+        if validator.entry.stake_seeds.end <= validator.entry.stake_seeds.begin {
             msg!("Can only stake-merge if there is at least one stake account to merge into.");
             return Err(LidoError::InvalidStakeAccount.into());
         }
@@ -328,7 +322,7 @@ pub fn process_stake_deposit(
             accounts.lido.key,
             validator,
             // Does not underflow, because end > begin >= 0.
-            validator.entry.stake_seeds.stake_accounts_seed_end - 1,
+            validator.entry.stake_seeds.end - 1,
             accounts.stake_account_merge_into,
             VALIDATOR_STAKE_ACCOUNT,
         )?;
@@ -336,7 +330,7 @@ pub fn process_stake_deposit(
         // tried to merge, but the epoch is different, then this will fail.
         msg!(
             "Merging into existing stake account at seed {} ...",
-            validator.entry.stake_seeds.stake_accounts_seed_end - 1
+            validator.entry.stake_seeds.end - 1
         );
         let merge_instructions = stake_program::instruction::merge(
             accounts.stake_account_merge_into.key,
@@ -388,11 +382,7 @@ pub fn process_unstake(
         &accounts.lido.key.to_bytes(),
         &accounts.validator_vote_account.key.to_bytes(),
         VALIDATOR_UNSTAKE_ACCOUNT,
-        &validator
-            .entry
-            .unstake_seeds
-            .stake_accounts_seed_end
-            .to_le_bytes()[..],
+        &validator.entry.unstake_seeds.end.to_le_bytes()[..],
         &[destination_bump_seed],
     ];
 
@@ -415,8 +405,9 @@ pub fn process_unstake(
         accounts.stake_authority.key,
     );
 
-    // Deactivates the stake. After this transaction, the Lamports on this stake
-    // account need to go back to the reserve account by using another instruction.
+    // Deactivates the stake. After the stake has become inactive, the Lamports
+    // on this stake account need to go back to the reserve account by using
+    // another instruction.
     invoke_signed(
         &deactivate_stake_instruction,
         &[
@@ -436,7 +427,15 @@ pub fn process_unstake(
         .validators
         .get_mut(accounts.validator_vote_account.key)?;
     validator.entry.stake_accounts_balance = (validator.entry.stake_accounts_balance - amount)?;
-    validator.entry.unstake_seeds.stake_accounts_seed_end += 1;
+    if validator.entry.stake_accounts_balance < MINIMUM_STAKE_ACCOUNT_BALANCE {
+        msg!(
+            "Unstake operation will leave the validator with {}, less than the minimum balance {}.",
+            validator.entry.stake_accounts_balance,
+            MINIMUM_STAKE_ACCOUNT_BALANCE
+        );
+        return Err(LidoError::InvalidAmount.into());
+    }
+    validator.entry.unstake_seeds.end += 1;
 
     lido.save(accounts.lido)
 }
@@ -553,8 +552,8 @@ pub fn process_withdraw_inactive_stake(
     let mut observed_total = Lamports(0);
     let mut excess_removed = Lamports(0);
     let mut stake_accounts = accounts.stake_accounts.iter();
-    let begin = validator.entry.stake_seeds.stake_accounts_seed_begin;
-    let end = validator.entry.stake_seeds.stake_accounts_seed_end;
+    let begin = validator.entry.stake_seeds.begin;
+    let end = validator.entry.stake_seeds.end;
 
     // Visit the stake accounts one by one, and check how much SOL is in there.
     for seed in begin..end {
@@ -733,10 +732,7 @@ pub fn process_withdraw(
         program_id,
         accounts.lido.key,
         accounts.validator_vote_account.key,
-        provided_validator
-            .entry
-            .stake_seeds
-            .stake_accounts_seed_begin,
+        provided_validator.entry.stake_seeds.begin,
     );
     if &stake_account != accounts.source_stake_account.key {
         msg!("Stake account is different than the calculated by the given seed, should be {}, is {}.",

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -376,17 +376,10 @@ pub fn process_unstake(
     raw_accounts: &[AccountInfo],
 ) -> ProgramResult {
     let accounts = UnstakeAccountsInfo::try_from_slice(raw_accounts)?;
-
     let mut lido = deserialize_lido(program_id, accounts.lido)?;
-
     lido.check_maintainer(accounts.maintainer)?;
     lido.check_stake_authority(program_id, accounts.lido.key, accounts.stake_authority)?;
     let destination_bump_seed = check_unstake_accounts(program_id, &lido, &accounts)?;
-
-    // The Split instruction returns three instructions:
-    //   0 - Allocate instruction.
-    //   1 - Assign owner instruction.
-    //   2 - Split stake instruction.
 
     let provided_validator = lido.validators.get(accounts.validator_vote_account.key)?;
     let seeds = [
@@ -396,7 +389,7 @@ pub fn process_unstake(
         &provided_validator
             .entry
             .unstake_seeds
-            .stake_accounts_seed_begin
+            .stake_accounts_seed_end
             .to_le_bytes()[..],
         &[destination_bump_seed],
     ];

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     stake_account::{deserialize_stake_account, StakeAccount},
     state::{
-        ExchangeRate, FeeRecipients, Lido, Maintainers, RewardDistribution, Validator, Validators,
+        ExchangeRate, FeeRecipients, Lido, Maintainers, RewardDistribution, Validators,
         LIDO_CONSTANT_SIZE, LIDO_VERSION,
     },
     token::{Lamports, Rational, StLamports},
@@ -557,12 +557,8 @@ pub fn process_withdraw_inactive_stake(
 
     // Visit the stake accounts one by one, and check how much SOL is in there.
     for seed in begin..end {
-        let (stake_account_address, _bump_seed) = Validator::find_stake_account_address(
-            program_id,
-            accounts.lido.key,
-            &validator.pubkey,
-            seed,
-        );
+        let (stake_account_address, _bump_seed) =
+            validator.find_stake_account_address(program_id, accounts.lido.key, seed);
         let stake_account = match stake_accounts.next() {
             None => {
                 msg!(
@@ -715,24 +711,22 @@ pub fn process_withdraw(
     lido.check_exchange_rate_last_epoch(&clock, "Withdraw")?;
 
     // Should withdraw from the validator that has most stake
-    let provided_validator = lido.validators.get(accounts.validator_vote_account.key)?;
+    let validator = lido.validators.get(accounts.validator_vote_account.key)?;
 
-    for validator in lido.validators.entries.iter() {
-        if validator.entry.stake_accounts_balance > provided_validator.entry.stake_accounts_balance
-        {
+    for val in lido.validators.entries.iter() {
+        if val.entry.stake_accounts_balance > validator.entry.stake_accounts_balance {
             msg!(
                 "Validator {} has more stake than validator {}",
-                provided_validator.pubkey,
+                validator.pubkey,
                 validator.pubkey,
             );
             return Err(LidoError::ValidatorWithMoreStakeExists.into());
         }
     }
-    let (stake_account, _) = Validator::find_stake_account_address(
+    let (stake_account, _) = validator.find_stake_account_address(
         program_id,
         accounts.lido.key,
-        accounts.validator_vote_account.key,
-        provided_validator.entry.stake_seeds.begin,
+        validator.entry.stake_seeds.begin,
     );
     if &stake_account != accounts.source_stake_account.key {
         msg!("Stake account is different than the calculated by the given seed, should be {}, is {}.",

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -7,13 +7,14 @@ use crate::{
     error::LidoError,
     instruction::{
         CollectValidatorFeeInfo, DepositAccountsInfo, InitializeAccountsInfo, LidoInstruction,
-        StakeDepositAccountsInfo, UpdateExchangeRateAccountsInfo, WithdrawAccountsInfo,
-        WithdrawInactiveStakeInfo,
+        StakeDepositAccountsInfo, UnstakeAccountsInfo, UpdateExchangeRateAccountsInfo,
+        WithdrawAccountsInfo, WithdrawInactiveStakeInfo,
     },
     logic::{
-        burn_st_sol, check_mint, check_rent_exempt, create_account_overwrite_if_exists,
-        deserialize_lido, distribute_fees, initialize_stake_account_undelegated, mint_st_sol_to,
-        transfer_stake_authority, CreateAccountOptions,
+        burn_st_sol, check_mint, check_rent_exempt, check_unstake_accounts,
+        create_account_overwrite_if_exists, deserialize_lido, distribute_fees,
+        initialize_stake_account_undelegated, mint_st_sol_to, split_stake_account,
+        transfer_stake_authority, CreateAccountOptions, SplitStakeAccounts,
     },
     metrics::Metrics,
     process_management::{
@@ -29,6 +30,7 @@ use crate::{
     token::{Lamports, Rational, StLamports},
     vote_instruction, MINIMUM_STAKE_ACCOUNT_BALANCE, MINT_AUTHORITY, RESERVE_ACCOUNT,
     REWARDS_WITHDRAW_AUTHORITY, STAKE_AUTHORITY, VALIDATOR_STAKE_ACCOUNT,
+    VALIDATOR_UNSTAKE_ACCOUNT,
 };
 
 use solana_program::stake::{self as stake_program};
@@ -210,8 +212,9 @@ pub fn process_stake_deposit(
         program_id,
         accounts.lido.key,
         validator,
-        validator.entry.stake_accounts_seed_end,
+        validator.entry.stake_seeds.stake_accounts_seed_end,
         accounts.stake_account_end,
+        VALIDATOR_STAKE_ACCOUNT,
     )?;
 
     if accounts.stake_account_end.data.borrow().len() > 0 {
@@ -222,7 +225,11 @@ pub fn process_stake_deposit(
         return Err(LidoError::WrongStakeState.into());
     }
 
-    let stake_account_seed = validator.entry.stake_accounts_seed_end.to_le_bytes();
+    let stake_account_seed = validator
+        .entry
+        .stake_seeds
+        .stake_accounts_seed_end
+        .to_le_bytes();
     let stake_account_bump_seed = [stake_account_bump_seed];
     let stake_account_seeds = &[
         accounts.lido.key.as_ref(),
@@ -282,7 +289,7 @@ pub fn process_stake_deposit(
         // Case 1: we delegate, and we don't touch `stake_account_merge_into`.
         msg!(
             "Delegating stake account at seed {} ...",
-            validator.entry.stake_accounts_seed_end
+            validator.entry.stake_seeds.stake_accounts_seed_end
         );
         invoke_signed(
             &stake_program::instruction::delegate_stake(
@@ -307,10 +314,12 @@ pub fn process_stake_deposit(
         )?;
 
         // We now consumed this stake account, bump the index.
-        validator.entry.stake_accounts_seed_end += 1;
+        validator.entry.stake_seeds.stake_accounts_seed_end += 1;
     } else {
         // Case 2: Merge the new undelegated stake account into the existing one.
-        if validator.entry.stake_accounts_seed_end <= validator.entry.stake_accounts_seed_begin {
+        if validator.entry.stake_seeds.stake_accounts_seed_end
+            <= validator.entry.stake_seeds.stake_accounts_seed_begin
+        {
             msg!("Can only stake-merge if there is at least one stake account to merge into.");
             return Err(LidoError::InvalidStakeAccount.into());
         }
@@ -319,14 +328,15 @@ pub fn process_stake_deposit(
             accounts.lido.key,
             validator,
             // Does not underflow, because end > begin >= 0.
-            validator.entry.stake_accounts_seed_end - 1,
+            validator.entry.stake_seeds.stake_accounts_seed_end - 1,
             accounts.stake_account_merge_into,
+            VALIDATOR_STAKE_ACCOUNT,
         )?;
         // The stake program checks that the two accounts can be merged; if we
         // tried to merge, but the epoch is different, then this will fail.
         msg!(
             "Merging into existing stake account at seed {} ...",
-            validator.entry.stake_accounts_seed_end - 1
+            validator.entry.stake_seeds.stake_accounts_seed_end - 1
         );
         let merge_instructions = stake_program::instruction::merge(
             accounts.stake_account_merge_into.key,
@@ -356,6 +366,86 @@ pub fn process_stake_deposit(
             ]],
         )?;
     }
+
+    lido.save(accounts.lido)
+}
+
+pub fn process_unstake(
+    program_id: &Pubkey,
+    amount: Lamports,
+    raw_accounts: &[AccountInfo],
+) -> ProgramResult {
+    let accounts = UnstakeAccountsInfo::try_from_slice(raw_accounts)?;
+
+    let mut lido = deserialize_lido(program_id, accounts.lido)?;
+
+    lido.check_maintainer(accounts.maintainer)?;
+    lido.check_stake_authority(program_id, accounts.lido.key, accounts.stake_authority)?;
+    let destination_bump_seed = check_unstake_accounts(program_id, &lido, &accounts)?;
+
+    // The Split instruction returns three instructions:
+    //   0 - Allocate instruction.
+    //   1 - Assign owner instruction.
+    //   2 - Split stake instruction.
+
+    let provided_validator = lido.validators.get(accounts.validator_vote_account.key)?;
+    let seeds = [
+        &accounts.lido.key.to_bytes(),
+        &accounts.validator_vote_account.key.to_bytes(),
+        VALIDATOR_UNSTAKE_ACCOUNT,
+        &provided_validator
+            .entry
+            .unstake_seeds
+            .stake_accounts_seed_begin
+            .to_le_bytes()[..],
+        &[destination_bump_seed],
+    ];
+
+    split_stake_account(
+        accounts.lido.key,
+        &lido,
+        &SplitStakeAccounts {
+            source_stake_account: accounts.source_stake_account,
+            destination_stake_account: accounts.destination_stake_account,
+            authority: accounts.stake_authority,
+            system_program: accounts.system_program,
+            stake_program: accounts.stake_program,
+        },
+        amount,
+        &[&seeds],
+    )?;
+
+    let deactivate_stake_instruction = solana_program::stake::instruction::deactivate_stake(
+        accounts.destination_stake_account.key,
+        accounts.stake_authority.key,
+    );
+
+    // Deactivates the stake. After this transaction, the Lamports on this stake
+    // account need to go back to the reserve account using another instruction.
+    invoke_signed(
+        &deactivate_stake_instruction,
+        &[
+            accounts.destination_stake_account.clone(),
+            accounts.sysvar_clock.clone(),
+            accounts.stake_authority.clone(),
+            accounts.stake_program.clone(),
+        ],
+        &[&[
+            &accounts.lido.key.to_bytes(),
+            STAKE_AUTHORITY,
+            &[lido.stake_authority_bump_seed],
+        ]],
+    )?;
+
+    let provided_validator = lido
+        .validators
+        .get_mut(accounts.validator_vote_account.key)?;
+    provided_validator.entry.stake_accounts_balance =
+        (provided_validator.entry.stake_accounts_balance - amount)?;
+    provided_validator
+        .entry
+        .unstake_seeds
+        .stake_accounts_seed_end += 1;
 
     lido.save(accounts.lido)
 }
@@ -472,8 +562,8 @@ pub fn process_withdraw_inactive_stake(
     let mut observed_total = Lamports(0);
     let mut excess_removed = Lamports(0);
     let mut stake_accounts = accounts.stake_accounts.iter();
-    let begin = validator.entry.stake_accounts_seed_begin;
-    let end = validator.entry.stake_accounts_seed_end;
+    let begin = validator.entry.stake_seeds.stake_accounts_seed_begin;
+    let end = validator.entry.stake_seeds.stake_accounts_seed_end;
 
     // Visit the stake accounts one by one, and check how much SOL is in there.
     for seed in begin..end {
@@ -652,10 +742,14 @@ pub fn process_withdraw(
         program_id,
         accounts.lido.key,
         accounts.validator_vote_account.key,
-        provided_validator.entry.stake_accounts_seed_begin,
+        provided_validator
+            .entry
+            .stake_seeds
+            .stake_accounts_seed_begin,
     );
     if &stake_account != accounts.source_stake_account.key {
-        msg!("Stake account is different than the calculated by the given seed, should be {}, is {}.", stake_account, accounts.source_stake_account.key);
+        msg!("Stake account is different than the calculated by the given seed, should be {}, is {}.",
+        stake_account, accounts.source_stake_account.key);
         return Err(LidoError::InvalidStakeAccount.into());
     }
 
@@ -709,55 +803,18 @@ pub fn process_withdraw(
     // Update withdrawal metrics.
     lido.metrics.observe_withdrawal(amount, sol_to_withdraw)?;
 
-    // The Stake program already checks for a minimum rent on the destination
-    // stake account inside the `split` function.
-
-    // The Split instruction returns three instructions:
-    //   0 - Allocate instruction.
-    //   1 - Assign owner instruction.
-    //   2 - Split stake instruction.
-    let split_instructions = solana_program::stake::instruction::split(
-        &stake_account,
-        accounts.stake_authority.key,
-        sol_to_withdraw.0,
-        accounts.destination_stake_account.key,
-    );
-    assert_eq!(split_instructions.len(), 3);
-
-    let (allocate_instruction, assign_instruction, split_instruction) = (
-        &split_instructions[0],
-        &split_instructions[1],
-        &split_instructions[2],
-    );
-
-    invoke(
-        allocate_instruction,
-        &[
-            accounts.destination_stake_account.clone(),
-            accounts.system_program.clone(),
-        ],
-    )?;
-    invoke(
-        assign_instruction,
-        &[
-            accounts.destination_stake_account.clone(),
-            accounts.system_program.clone(),
-        ],
-    )?;
-
-    invoke_signed(
-        split_instruction,
-        &[
-            accounts.source_stake_account.clone(),
-            accounts.destination_stake_account.clone(),
-            accounts.stake_authority.clone(),
-            accounts.stake_program.clone(),
-        ],
-        &[&[
-            &accounts.lido.key.to_bytes(),
-            STAKE_AUTHORITY,
-            &[lido.stake_authority_bump_seed],
-        ]],
+    split_stake_account(
+        accounts.lido.key,
+        &lido,
+        &SplitStakeAccounts {
+            source_stake_account: accounts.source_stake_account,
+            destination_stake_account: accounts.destination_stake_account,
+            authority: accounts.stake_authority,
+            system_program: accounts.system_program,
+            stake_program: accounts.stake_program,
+        },
+        sol_to_withdraw,
+        &[&[]],
     )?;
 
     // Give control of the stake to the user.
@@ -791,6 +848,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
         LidoInstruction::StakeDeposit { amount } => {
             process_stake_deposit(program_id, amount, accounts)
         }
+        LidoInstruction::Unstake { amount } => process_unstake(program_id, amount, accounts),
         LidoInstruction::UpdateExchangeRate => process_update_exchange_rate(program_id, accounts),
         LidoInstruction::WithdrawInactiveStake => {
             process_withdraw_inactive_stake(program_id, accounts)

--- a/program/src/stake_account.rs
+++ b/program/src/stake_account.rs
@@ -23,7 +23,7 @@ use solana_program::{instruction::Instruction, stake_history::StakeHistory};
 /// The sum of the four fields is equal to the SOL balance of the stake account.
 /// Note that a stake account can have a portion in `inactive` and a portion in
 /// `active`, with zero being activating or deactivating.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct StakeBalance {
     pub inactive: Lamports,
     pub activating: Lamports,
@@ -31,7 +31,7 @@ pub struct StakeBalance {
     pub deactivating: Lamports,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 
 pub struct StakeAccount {
     pub balance: StakeBalance,
@@ -198,17 +198,19 @@ impl StakeAccount {
         // to true. See also https://github.com/ChorusOne/solido/issues/184#issuecomment-861653316.
         let fix_stake_deactivate = true;
 
-        let (active_lamports, activating_lamports, deactivating_lamports) = stake
+        let (mut active_lamports, activating_lamports, deactivating_lamports) = stake
             .delegation
             .stake_activating_and_deactivating(target_epoch, history, fix_stake_deactivate);
 
-        // Deactivating will be counted in the active lamports
-        let inactive_lamports = account_lamports
-            .0
+        // Deactivating lamports is counted on the active lamports.
+        active_lamports -= deactivating_lamports;
+        let inactive_lamports = account_lamports.0
             .checked_sub(active_lamports)
             .expect("Active stake cannot be larger than stake account balance.")
             .checked_sub(activating_lamports)
-            .expect("Activating stake cannot be larger than stake account balance - active.");
+            .expect("Activating stake cannot be larger than stake account balance - active.")
+            .checked_sub(deactivating_lamports)
+            .expect("Deactivating stake cannot be larger than stake account balance - active - activating.");
 
         StakeAccount {
             balance: StakeBalance {

--- a/program/src/stake_account.rs
+++ b/program/src/stake_account.rs
@@ -202,7 +202,12 @@ impl StakeAccount {
             .delegation
             .stake_activating_and_deactivating(target_epoch, history, fix_stake_deactivate);
 
-        // Deactivating lamports is counted on the active lamports.
+        // `stake_activating_and_deactivating` counts deactivating stake both as
+        // part of the active lamports, and as part of the deactivating
+        // lamports, but we want to split the lamports into mutually exclusive
+        // categories, so for us, active should not include deactivating
+        // lamports. There cannot be more lamports deactivating than there are
+        // active lamports, so this does not underflow.
         active_lamports -= deactivating_lamports;
         let inactive_lamports = account_lamports.0
             .checked_sub(active_lamports)

--- a/program/src/stake_account.rs
+++ b/program/src/stake_account.rs
@@ -23,7 +23,7 @@ use solana_program::{instruction::Instruction, stake_history::StakeHistory};
 /// The sum of the four fields is equal to the SOL balance of the stake account.
 /// Note that a stake account can have a portion in `inactive` and a portion in
 /// `active`, with zero being activating or deactivating.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StakeBalance {
     pub inactive: Lamports,
     pub activating: Lamports,

--- a/program/src/stake_account.rs
+++ b/program/src/stake_account.rs
@@ -202,13 +202,13 @@ impl StakeAccount {
             .delegation
             .stake_activating_and_deactivating(target_epoch, history, fix_stake_deactivate);
 
-        let inactive_lamports = account_lamports.0
+        // Deactivating will be counted in the active lamports
+        let inactive_lamports = account_lamports
+            .0
             .checked_sub(active_lamports)
             .expect("Active stake cannot be larger than stake account balance.")
             .checked_sub(activating_lamports)
-            .expect("Activating stake cannot be larger than stake account balance - active.")
-            .checked_sub(deactivating_lamports)
-            .expect("Deactivating stake cannot be larger than stake account balance - active - activating.");
+            .expect("Activating stake cannot be larger than stake account balance - active.");
 
         StakeAccount {
             balance: StakeBalance {

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -613,7 +613,7 @@ pub struct Validator {
     /// Seeds for inactive stake accounts.
     pub unstake_seeds: SeedRange,
 
-    /// Sum of the balances of the stake accounts.
+    /// Sum of the balances of the stake accounts and unstake accounts.
     pub stake_accounts_balance: Lamports,
 
     /// Sum of the balances of the unstake accounts.

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -685,6 +685,7 @@ impl Default for Validator {
             stake_seeds: SeedRange { begin: 0, end: 0 },
             unstake_seeds: SeedRange { begin: 0, end: 0 },
             stake_accounts_balance: Lamports(0),
+            unstake_accounts_balance: Lamports(0),
             active: true,
         }
     }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -619,6 +619,7 @@ pub struct Validator {
     /// When removing a validator, this flag should be set to `false`.
     pub active: bool,
 }
+
 #[repr(C)]
 #[derive(
     Clone, Debug, Default, Eq, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Serialize,
@@ -637,18 +638,18 @@ pub struct SeedRange {
     /// pool and bump `begin`. Accounts are not reused.
     ///
     /// The program enforces that creating new stake accounts is only allowed at
-    /// the `_end` seed, and depositing active stake is only allowed from the
-    /// `_begin` seed. This ensures that maintainers don’t race and accidentally
+    /// the `end` seed, and depositing active stake is only allowed from the
+    /// `begin` seed. This ensures that maintainers don’t race and accidentally
     /// stake more to this validator than intended. If the seed has changed
     /// since the instruction was created, the transaction fails.
     ///
     /// When we unstake SOL, we follow an analogous symmetric mechanism. We
     /// split the validator's stake in two, and retrieve the funds of the second
     /// to the reserve account where it can be re-staked.
-    pub stake_accounts_seed_begin: u64,
+    pub begin: u64,
 
     /// End (exclusive) of the seed range for stake accounts.
-    pub stake_accounts_seed_end: u64,
+    pub end: u64,
 }
 
 impl Validator {
@@ -711,8 +712,8 @@ impl Default for Validator {
         Validator {
             fee_address: Pubkey::default(),
             fee_credit: StLamports(0),
-            stake_seeds: SeedRange::default(),
-            unstake_seeds: SeedRange::default(),
+            stake_seeds: SeedRange { begin: 0, end: 0 },
+            unstake_seeds: SeedRange { begin: 0, end: 0 },
             stake_accounts_balance: Lamports(0),
             active: true,
         }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -3,6 +3,8 @@
 
 //! State transition types
 
+use std::ops::Range;
+
 use serde::Serialize;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
@@ -614,6 +616,9 @@ pub struct Validator {
     /// Sum of the balances of the stake accounts.
     pub stake_accounts_balance: Lamports,
 
+    /// Sum of the balances of the unstake accounts.
+    pub unstake_accounts_balance: Lamports,
+
     /// Controls if a validator is allowed to have new stake deposits.
     /// When removing a validator, this flag should be set to `false`.
     pub active: bool,
@@ -649,6 +654,18 @@ pub struct SeedRange {
 
     /// End (exclusive) of the seed range for stake accounts.
     pub end: u64,
+}
+
+impl IntoIterator for &SeedRange {
+    type Item = u64;
+    type IntoIter = Range<u64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Range {
+            start: self.begin,
+            end: self.end,
+        }
+    }
 }
 
 impl Validator {

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -33,7 +33,7 @@ pub const LIDO_VERSION: u8 = 0;
 ///
 /// To update this, run the tests and replace the value here with the test output.
 pub const LIDO_CONSTANT_SIZE: usize = 357;
-pub const VALIDATOR_CONSTANT_SIZE: usize = 81;
+pub const VALIDATOR_CONSTANT_SIZE: usize = 89;
 
 pub type Validators = AccountMap<Validator>;
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -498,11 +498,10 @@ impl Lido {
         stake_account: &AccountInfo,
         authority: &[u8],
     ) -> Result<u8, ProgramError> {
-        let (stake_addr, stake_addr_bump_seed) =
-            Validator::find_stake_account_address_with_authority(
+        let (stake_addr, stake_addr_bump_seed) = validator
+            .find_stake_account_address_with_authority(
                 program_id,
                 solido_address,
-                &validator.pubkey,
                 authority,
                 stake_account_seed,
             );
@@ -659,52 +658,6 @@ impl Validator {
             ..Default::default()
         }
     }
-
-    fn find_stake_account_address_with_authority(
-        program_id: &Pubkey,
-        solido_account: &Pubkey,
-        validator_vote_account: &Pubkey,
-        authority: &[u8],
-        seed: u64,
-    ) -> (Pubkey, u8) {
-        let seeds = [
-            &solido_account.to_bytes(),
-            &validator_vote_account.to_bytes(),
-            authority,
-            &seed.to_le_bytes()[..],
-        ];
-        Pubkey::find_program_address(&seeds, program_id)
-    }
-
-    pub fn find_stake_account_address(
-        program_id: &Pubkey,
-        solido_account: &Pubkey,
-        validator_vote_account: &Pubkey,
-        seed: u64,
-    ) -> (Pubkey, u8) {
-        Validator::find_stake_account_address_with_authority(
-            program_id,
-            solido_account,
-            validator_vote_account,
-            VALIDATOR_STAKE_ACCOUNT,
-            seed,
-        )
-    }
-
-    pub fn find_unstake_account_address(
-        program_id: &Pubkey,
-        solido_account: &Pubkey,
-        validator_vote_account: &Pubkey,
-        seed: u64,
-    ) -> (Pubkey, u8) {
-        Validator::find_stake_account_address_with_authority(
-            program_id,
-            solido_account,
-            validator_vote_account,
-            VALIDATOR_UNSTAKE_ACCOUNT,
-            seed,
-        )
-    }
 }
 
 impl Default for Validator {
@@ -717,6 +670,52 @@ impl Default for Validator {
             stake_accounts_balance: Lamports(0),
             active: true,
         }
+    }
+}
+
+impl PubkeyAndEntry<Validator> {
+    pub fn find_stake_account_address_with_authority(
+        &self,
+        program_id: &Pubkey,
+        solido_account: &Pubkey,
+        authority: &[u8],
+        seed: u64,
+    ) -> (Pubkey, u8) {
+        let seeds = [
+            &solido_account.to_bytes(),
+            &self.pubkey.to_bytes(),
+            authority,
+            &seed.to_le_bytes()[..],
+        ];
+        Pubkey::find_program_address(&seeds, program_id)
+    }
+
+    pub fn find_stake_account_address(
+        &self,
+        program_id: &Pubkey,
+        solido_account: &Pubkey,
+        seed: u64,
+    ) -> (Pubkey, u8) {
+        self.find_stake_account_address_with_authority(
+            program_id,
+            solido_account,
+            VALIDATOR_STAKE_ACCOUNT,
+            seed,
+        )
+    }
+
+    pub fn find_unstake_account_address(
+        &self,
+        program_id: &Pubkey,
+        solido_account: &Pubkey,
+        seed: u64,
+    ) -> (Pubkey, u8) {
+        self.find_stake_account_address_with_authority(
+            program_id,
+            solido_account,
+            VALIDATOR_UNSTAKE_ACCOUNT,
+            seed,
+        )
     }
 }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -19,12 +19,11 @@ use crate::logic::get_reserve_available_balance;
 use crate::metrics::Metrics;
 use crate::token::{self, Lamports, Rational, StLamports};
 use crate::util::serialize_b58;
-use crate::REWARDS_WITHDRAW_AUTHORITY;
 use crate::{
     account_map::{AccountMap, AccountSet, EntryConstantSize, PubkeyAndEntry},
     MINIMUM_STAKE_ACCOUNT_BALANCE, MINT_AUTHORITY, RESERVE_ACCOUNT, STAKE_AUTHORITY,
-    VALIDATOR_STAKE_ACCOUNT,
 };
+use crate::{REWARDS_WITHDRAW_AUTHORITY, VALIDATOR_STAKE_ACCOUNT, VALIDATOR_UNSTAKE_ACCOUNT};
 
 pub const LIDO_VERSION: u8 = 0;
 
@@ -32,7 +31,7 @@ pub const LIDO_VERSION: u8 = 0;
 ///
 /// To update this, run the tests and replace the value here with the test output.
 pub const LIDO_CONSTANT_SIZE: usize = 357;
-pub const VALIDATOR_CONSTANT_SIZE: usize = 65;
+pub const VALIDATOR_CONSTANT_SIZE: usize = 81;
 
 pub type Validators = AccountMap<Validator>;
 
@@ -497,9 +496,16 @@ impl Lido {
         validator: &PubkeyAndEntry<Validator>,
         stake_account_seed: u64,
         stake_account: &AccountInfo,
+        authority: &[u8],
     ) -> Result<u8, ProgramError> {
         let (stake_addr, stake_addr_bump_seed) =
-            validator.find_stake_account_address(program_id, solido_address, stake_account_seed);
+            Validator::find_stake_account_address_with_authority(
+                program_id,
+                solido_address,
+                &validator.pubkey,
+                authority,
+                stake_account_seed,
+            );
         if &stake_addr != stake_account.key {
             msg!(
                 "The derived stake address for seed {} is {}, \
@@ -601,7 +607,24 @@ pub struct Validator {
     #[serde(serialize_with = "serialize_b58")]
     pub fee_address: Pubkey,
 
-    /// Start (inclusive) of the seed range for currently active stake accounts.
+    /// Seeds for active stake accounts.
+    pub stake_seeds: SeedRange,
+    /// Seeds for inactive stake accounts.
+    pub unstake_seeds: SeedRange,
+
+    /// Sum of the balances of the stake accounts.
+    pub stake_accounts_balance: Lamports,
+
+    /// Controls if a validator is allowed to have new stake deposits.
+    /// When removing a validator, this flag should be set to `false`.
+    pub active: bool,
+}
+#[repr(C)]
+#[derive(
+    Clone, Debug, Default, Eq, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Serialize,
+)]
+pub struct SeedRange {
+    /// Start (inclusive) of the seed range for stake accounts.
     ///
     /// When we stake deposited SOL, we take it out of the reserve account, and
     /// transfer it to a stake account. The stake account address is a derived
@@ -618,17 +641,14 @@ pub struct Validator {
     /// `_begin` seed. This ensures that maintainers don’t race and accidentally
     /// stake more to this validator than intended. If the seed has changed
     /// since the instruction was created, the transaction fails.
+    ///
+    /// When we unstake SOL, we follow an analogous symmetric mechanism. We
+    /// split the validator's stake in two, and retrieve the funds of the second
+    /// to the reserve account where it can be re-staked.
     pub stake_accounts_seed_begin: u64,
 
-    /// End (exclusive) of the seed range for currently active stake accounts.
+    /// End (exclusive) of the seed range for stake accounts.
     pub stake_accounts_seed_end: u64,
-
-    /// Sum of the balances of the stake accounts.
-    pub stake_accounts_balance: Lamports,
-
-    /// Controls if a validator is allowed to have new stake deposits.
-    /// When removing a validator, this flag should be set to `false`.
-    pub active: bool,
 }
 
 impl Validator {
@@ -639,19 +659,50 @@ impl Validator {
         }
     }
 
+    fn find_stake_account_address_with_authority(
+        program_id: &Pubkey,
+        solido_account: &Pubkey,
+        validator_vote_account: &Pubkey,
+        authority: &[u8],
+        seed: u64,
+    ) -> (Pubkey, u8) {
+        let seeds = [
+            &solido_account.to_bytes(),
+            &validator_vote_account.to_bytes(),
+            authority,
+            &seed.to_le_bytes()[..],
+        ];
+        Pubkey::find_program_address(&seeds, program_id)
+    }
+
     pub fn find_stake_account_address(
         program_id: &Pubkey,
         solido_account: &Pubkey,
         validator_vote_account: &Pubkey,
         seed: u64,
     ) -> (Pubkey, u8) {
-        let seeds = [
-            &solido_account.to_bytes(),
-            &validator_vote_account.to_bytes(),
+        Validator::find_stake_account_address_with_authority(
+            program_id,
+            solido_account,
+            validator_vote_account,
             VALIDATOR_STAKE_ACCOUNT,
-            &seed.to_le_bytes()[..],
-        ];
-        Pubkey::find_program_address(&seeds, program_id)
+            seed,
+        )
+    }
+
+    pub fn find_unstake_account_address(
+        program_id: &Pubkey,
+        solido_account: &Pubkey,
+        validator_vote_account: &Pubkey,
+        seed: u64,
+    ) -> (Pubkey, u8) {
+        Validator::find_stake_account_address_with_authority(
+            program_id,
+            solido_account,
+            validator_vote_account,
+            VALIDATOR_UNSTAKE_ACCOUNT,
+            seed,
+        )
     }
 }
 
@@ -660,22 +711,11 @@ impl Default for Validator {
         Validator {
             fee_address: Pubkey::default(),
             fee_credit: StLamports(0),
-            stake_accounts_seed_begin: 0,
-            stake_accounts_seed_end: 0,
+            stake_seeds: SeedRange::default(),
+            unstake_seeds: SeedRange::default(),
             stake_accounts_balance: Lamports(0),
             active: true,
         }
-    }
-}
-
-impl PubkeyAndEntry<Validator> {
-    pub fn find_stake_account_address(
-        &self,
-        program_id: &Pubkey,
-        solido_account: &Pubkey,
-        seed: u64,
-    ) -> (Pubkey, u8) {
-        Validator::find_stake_account_address(program_id, solido_account, &self.pubkey, seed)
     }
 }
 

--- a/program/tests/tests/add_remove_validator.rs
+++ b/program/tests/tests/add_remove_validator.rs
@@ -6,10 +6,14 @@
 use solana_program_test::tokio;
 
 use crate::assert_solido_error;
-use crate::context::Context;
+use crate::context::{Context, StakeDeposit};
 
 use lido::error::LidoError;
-use lido::token::StLamports;
+use lido::state::Validator;
+use lido::token::{Lamports, StLamports};
+
+pub const TEST_DEPOSIT_AMOUNT: Lamports = Lamports(100_000_000_000);
+pub const TEST_STAKE_DEPOSIT_AMOUNT: Lamports = Lamports(10_000_000_000);
 
 #[tokio::test]
 async fn test_successful_add_validator() {
@@ -34,22 +38,73 @@ async fn test_successful_add_validator() {
 }
 
 #[tokio::test]
-async fn test_remove_validator_without_unclaimed_credits() {
+async fn test_successful_remove_validator() {
     let mut context = Context::new_with_maintainer_and_validator().await;
-
-    let solido = context.get_solido().await;
-    assert_eq!(solido.validators.len(), 1);
-
-    let vote_account = solido.validators.entries[0].pubkey;
-    assert_eq!(solido.validators.entries[0].entry.fee_credit, StLamports(0));
-
+    let validator = &context.get_solido().await.validators.entries[0];
+    context.deactivate_validator(validator.pubkey).await;
     context
-        .try_remove_validator(vote_account)
+        .try_remove_validator(validator.pubkey)
         .await
-        .expect("Failed to remove validator.");
+        .unwrap();
 
     let solido = context.get_solido().await;
     assert_eq!(solido.validators.len(), 0);
+}
+
+#[tokio::test]
+async fn test_remove_validator_with_unclaimed_credits() {
+    let mut context = Context::new_with_maintainer().await;
+    let validator = context.add_validator().await;
+    let initial_amount = Lamports(1_000_000_000);
+    context.deposit(initial_amount).await;
+    context
+        .stake_deposit(validator.vote_account, StakeDeposit::Append, initial_amount)
+        .await;
+
+    context
+        .context
+        .increment_vote_account_credits(&validator.vote_account, 1);
+
+    // Skip ahead a number of epochs.
+    let epoch_schedule = context.context.genesis_config().epoch_schedule;
+    let start_slot = epoch_schedule.first_normal_slot;
+    let slots_per_epoch = epoch_schedule.slots_per_epoch;
+    context.context.warp_to_slot(start_slot).unwrap();
+    context
+        .context
+        .increment_vote_account_credits(&validator.vote_account, 1);
+
+    context.update_exchange_rate().await;
+    context
+        .context
+        .warp_to_slot(start_slot + slots_per_epoch)
+        .unwrap();
+    context.update_exchange_rate().await;
+    context.collect_validator_fee(validator.vote_account).await;
+
+    let solido = context.get_solido().await;
+    let vote_account = solido.validators.entries[0].pubkey;
+    assert_eq!(
+        solido.validators.entries[0].entry.fee_credit,
+        StLamports(62_301_530_769)
+    );
+
+    context.deactivate_validator(vote_account).await;
+    // let solido = context.get_solido().await;
+    // let vote_account = solido.validators.entries[0].pubkey;
+    let result = context.try_remove_validator(vote_account).await;
+    assert_solido_error!(result, LidoError::ValidatorHasUnclaimedCredit);
+}
+
+#[tokio::test]
+async fn test_removing_validator_with_stake_accounts_should_fail() {
+    let (mut context, _) = Context::new_with_two_stake_accounts().await;
+    let validator = &context.get_solido().await.validators.entries[0];
+    let result = context.try_remove_validator(validator.pubkey).await;
+
+    // The validator should not be able to be removed if it is still active
+    //  (i.e. the active flag is set toe true OR it has stake accounts)
+    assert_solido_error!(result, LidoError::ValidatorIsStillActive);
 }
 
 #[tokio::test]

--- a/program/tests/tests/limits.rs
+++ b/program/tests/tests/limits.rs
@@ -28,7 +28,7 @@ async fn test_withdraw_inactive_stake_max_accounts() {
 
     // The maximum number of stake accounts per validator that we can support,
     // before WithdrawInactiveStake fails.
-    let max_accounts = 9;
+    let max_accounts = 10;
 
     for i in 0..=max_accounts {
         let amount = Lamports(2_000_000_000);

--- a/program/tests/tests/limits.rs
+++ b/program/tests/tests/limits.rs
@@ -67,7 +67,7 @@ async fn test_max_validators_maintainers() {
 
     // The maximum number of validators that we can support, before Deposit or
     // StakeDeposit fails.
-    let max_validators: u32 = 78;
+    let max_validators: u32 = 68;
 
     for i in 0..max_validators {
         context

--- a/program/tests/tests/limits.rs
+++ b/program/tests/tests/limits.rs
@@ -67,7 +67,7 @@ async fn test_max_validators_maintainers() {
 
     // The maximum number of validators that we can support, before Deposit or
     // StakeDeposit fails.
-    let max_validators: u32 = 68;
+    let max_validators: u32 = 64;
 
     for i in 0..max_validators {
         context

--- a/program/tests/tests/limits.rs
+++ b/program/tests/tests/limits.rs
@@ -28,7 +28,7 @@ async fn test_withdraw_inactive_stake_max_accounts() {
 
     // The maximum number of stake accounts per validator that we can support,
     // before WithdrawInactiveStake fails.
-    let max_accounts = 10;
+    let max_accounts = 9;
 
     for i in 0..=max_accounts {
         let amount = Lamports(2_000_000_000);

--- a/program/tests/tests/limits.rs
+++ b/program/tests/tests/limits.rs
@@ -82,11 +82,13 @@ async fn test_max_validators_maintainers() {
         context.maintainer = Some(maintainer);
 
         let validator = context.add_validator().await;
-        let amount = Lamports(1_000_000_000);
+        let amount = Lamports(2_000_000_000);
         context.deposit(amount).await;
         context
             .stake_deposit(validator.vote_account, StakeDeposit::Append, amount)
             .await;
+        context.validator = Some(validator);
+        context.unstake(Lamports(1_000_000_000)).await;
         // If we get here, then none of the transactions failed.
     }
 }

--- a/program/tests/tests/merge_stake.rs
+++ b/program/tests/tests/merge_stake.rs
@@ -51,8 +51,8 @@ async fn test_successful_merge_activating_stake() {
         .get(&validator_vote_account)
         .unwrap();
     assert_eq!(
-        validator_after.entry.stake_seeds.stake_accounts_seed_begin,
-        validator_before.entry.stake_seeds.stake_accounts_seed_begin + 1,
+        validator_after.entry.stake_seeds.begin,
+        validator_before.entry.stake_seeds.begin + 1,
     );
 
     let sol_before = solido_before.get_sol_balance(

--- a/program/tests/tests/merge_stake.rs
+++ b/program/tests/tests/merge_stake.rs
@@ -5,8 +5,7 @@
 
 use crate::assert_solido_error;
 use crate::context::{get_account_info, Context, StakeDeposit};
-use lido::{error::LidoError, stake_account::StakeAccount, state::Validator, token::Lamports};
-use solana_program::pubkey::Pubkey;
+use lido::{error::LidoError, state::Validator, token::Lamports};
 use solana_program_test::tokio;
 use solana_sdk::signer::Signer;
 
@@ -52,8 +51,8 @@ async fn test_successful_merge_activating_stake() {
         .get(&validator_vote_account)
         .unwrap();
     assert_eq!(
-        validator_after.entry.stake_accounts_seed_begin,
-        validator_before.entry.stake_accounts_seed_begin + 1,
+        validator_after.entry.stake_seeds.stake_accounts_seed_begin,
+        validator_before.entry.stake_seeds.stake_accounts_seed_begin + 1,
     );
 
     let sol_before = solido_before.get_sol_balance(
@@ -75,25 +74,6 @@ fn advance_epoch(context: &mut Context, current_slot: &mut u64) {
     let slots_per_epoch = epoch_schedule.slots_per_epoch;
     *current_slot = *current_slot + slots_per_epoch;
     context.context.warp_to_slot(*current_slot).unwrap();
-}
-
-async fn get_stake_account_from_seed(
-    context: &mut Context,
-    validator_vote_account: &Pubkey,
-    seed: u64,
-) -> StakeAccount {
-    let (stake_address, _) = Validator::find_stake_account_address(
-        &crate::context::id(),
-        &context.solido.pubkey(),
-        &validator_vote_account,
-        seed,
-    );
-
-    let clock = context.get_clock().await;
-    let stake_history = context.get_stake_history().await;
-    let stake_balance = context.get_sol_balance(stake_address).await;
-    let stake = context.get_stake_state(stake_address).await;
-    StakeAccount::from_delegated_account(stake_balance, &stake, &clock, &stake_history, seed)
 }
 
 // Test merging active to activating: should fail.
@@ -126,11 +106,13 @@ async fn test_merge_stake_combinations() {
         )
         .await;
 
-    let active_stake_account =
-        get_stake_account_from_seed(&mut context, &validator_vote_account, 0).await;
+    let active_stake_account = context
+        .get_stake_account_from_seed(&validator_vote_account, 0)
+        .await;
 
-    let activating_stake_account =
-        get_stake_account_from_seed(&mut context, &validator_vote_account, 1).await;
+    let activating_stake_account = context
+        .get_stake_account_from_seed(&validator_vote_account, 1)
+        .await;
 
     assert!(active_stake_account.is_active());
     assert!(activating_stake_account.is_activating());
@@ -139,8 +121,9 @@ async fn test_merge_stake_combinations() {
     assert_solido_error!(result, LidoError::WrongStakeState);
     advance_epoch(&mut context, &mut current_slot);
 
-    let now_active_stake_account =
-        get_stake_account_from_seed(&mut context, &validator_vote_account, 1).await;
+    let now_active_stake_account = context
+        .get_stake_account_from_seed(&validator_vote_account, 1)
+        .await;
     assert!(active_stake_account.is_active());
     assert!(now_active_stake_account.is_active());
 

--- a/program/tests/tests/mod.rs
+++ b/program/tests/tests/mod.rs
@@ -10,6 +10,7 @@ pub mod maintainers;
 pub mod merge_stake;
 pub mod solana_assumptions;
 pub mod stake_deposit;
+pub mod unstake;
 pub mod update_exchange_rate;
 pub mod withdraw_inactive_stake;
 pub mod withdrawals;

--- a/program/tests/tests/solana_assumptions.rs
+++ b/program/tests/tests/solana_assumptions.rs
@@ -251,7 +251,7 @@ async fn test_stake_accounts() {
     let warp_to_slot = context.get_clock().await.slot + slots_per_epoch;
     context.context.warp_to_slot(warp_to_slot).unwrap();
 
-    // Stake is now deactivating.
+    // Stake is now inactive.
     let deactivated = deactivating;
 
     let deactivated_stake = context.get_stake_state(deactivated).await;

--- a/program/tests/tests/stake_deposit.rs
+++ b/program/tests/tests/stake_deposit.rs
@@ -24,8 +24,8 @@ async fn test_stake_deposit_append() {
     let solido_before = context.get_solido().await;
     let validator_before = &solido_before.validators.entries[0].entry;
     assert_eq!(validator_before.stake_accounts_balance, Lamports(0));
-    assert_eq!(validator_before.stake_seeds.stake_accounts_seed_begin, 0);
-    assert_eq!(validator_before.stake_seeds.stake_accounts_seed_end, 0);
+    assert_eq!(validator_before.stake_seeds.begin, 0);
+    assert_eq!(validator_before.stake_seeds.end, 0);
 
     // Now we make a deposit, and then delegate part of it.
     context.deposit(TEST_DEPOSIT_AMOUNT).await;
@@ -55,8 +55,8 @@ async fn test_stake_deposit_append() {
     );
 
     // This was also the first deposit, so that should have created one stake account.
-    assert_eq!(validator_after.stake_seeds.stake_accounts_seed_begin, 0);
-    assert_eq!(validator_after.stake_seeds.stake_accounts_seed_end, 1);
+    assert_eq!(validator_after.stake_seeds.begin, 0);
+    assert_eq!(validator_after.stake_seeds.end, 1);
 }
 
 #[tokio::test]
@@ -105,8 +105,8 @@ async fn test_stake_deposit_merge() {
     );
 
     // We merged, so only seed 0 should be consumed at this point.
-    assert_eq!(validator_after.stake_seeds.stake_accounts_seed_begin, 0);
-    assert_eq!(validator_after.stake_seeds.stake_accounts_seed_end, 1);
+    assert_eq!(validator_after.stake_seeds.begin, 0);
+    assert_eq!(validator_after.stake_seeds.end, 1);
 
     // Next, we will try to merge stake accounts created in different epochs,
     // which should fail.

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2021 Chorus One AG
+// SPDX-License-Identifier: GPL-3.0
+
+#![cfg(feature = "test-bpf")]
+
+use crate::context::{Context, StakeDeposit};
+use lido::token::Lamports;
+use solana_program::stake::state::StakeState;
+use solana_program_test::tokio;
+const STAKE_AMOUNT: Lamports = Lamports(10_000_000_000);
+
+#[tokio::test]
+async fn test_successful_unstake() {
+    let mut context = Context::new_with_maintainer_and_validator().await;
+    context.deposit(STAKE_AMOUNT).await;
+    let validator = context.validator.take().unwrap();
+    context
+        .stake_deposit(validator.vote_account, StakeDeposit::Append, STAKE_AMOUNT)
+        .await;
+    context.validator = Some(validator);
+
+    let epoch_schedule = context.context.genesis_config().epoch_schedule;
+    let start_slot = epoch_schedule.first_normal_slot;
+
+    context.context.warp_to_slot(start_slot).unwrap();
+    context.update_exchange_rate().await;
+
+    let solido = context.get_solido().await;
+    let val = &solido.validators.entries[0];
+    let stake_account_before = context.get_stake_account_from_seed(&val.pubkey, 0).await;
+    let unstake_lamports = Lamports(1_000_000_000);
+    context.unstake(unstake_lamports).await;
+    let stake_account_after = context.get_stake_account_from_seed(&val.pubkey, 0).await;
+
+    assert_eq!(
+        (stake_account_before.balance.total() - stake_account_after.balance.total()).unwrap(),
+        unstake_lamports
+    );
+
+    let rent = context.get_rent().await;
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<StakeState>());
+
+    let unstake_account = context.get_unstake_account_from_seed(&val.pubkey, 0).await;
+    assert_eq!(
+        unstake_account.balance.deactivating,
+        (unstake_lamports - Lamports(stake_rent)).unwrap()
+    );
+}

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -12,53 +12,42 @@ use solana_program_test::tokio;
 use solana_sdk::signer::Signer;
 const STAKE_AMOUNT: Lamports = Lamports(10_000_000_000);
 
-impl UnstakeContext {
-    async fn new(stake_amount: Lamports) -> Context {
-        let mut context = Context::new_with_maintainer_and_validator().await;
-        context.deposit(stake_amount).await;
-        let validator = context.validator.take().unwrap();
-        context
-            .stake_deposit(validator.vote_account, StakeDeposit::Append, STAKE_AMOUNT)
-            .await;
-        context.validator = Some(validator);
+async fn new_unstake_context(stake_amount: Lamports) -> Context {
+    let mut context = Context::new_with_maintainer_and_validator().await;
+    context.deposit(stake_amount).await;
+    let validator = context.validator.take().unwrap();
+    context
+        .stake_deposit(validator.vote_account, StakeDeposit::Append, STAKE_AMOUNT)
+        .await;
+    context.validator = Some(validator);
 
-        let epoch_schedule = context.context.genesis_config().epoch_schedule;
-        let start_slot = epoch_schedule.first_normal_slot;
+    let epoch_schedule = context.context.genesis_config().epoch_schedule;
+    let start_slot = epoch_schedule.first_normal_slot;
 
-        context.context.warp_to_slot(start_slot).unwrap();
-        context.update_exchange_rate().await;
+    context.context.warp_to_slot(start_slot).unwrap();
+    context.update_exchange_rate().await;
 
-        context
-    }
+    context
 }
 
 #[tokio::test]
 async fn test_successful_unstake() {
-    let mut context = UnstakeContext::new(STAKE_AMOUNT).await;
+    let mut context = new_unstake_context(STAKE_AMOUNT).await;
     let unstake_lamports = Lamports(1_000_000_000);
 
-    let solido = context.context.get_solido().await;
+    let solido = context.get_solido().await;
     let validator = &solido.validators.entries[0];
 
-    let stake_account_before = context
-        .context
-        .get_stake_account_from_seed(&validator, 0)
-        .await;
-    context.context.unstake(unstake_lamports).await;
-    let stake_account_after = context
-        .context
-        .get_stake_account_from_seed(&validator, 0)
-        .await;
+    let stake_account_before = context.get_stake_account_from_seed(&validator, 0).await;
+    context.unstake(unstake_lamports).await;
+    let stake_account_after = context.get_stake_account_from_seed(&validator, 0).await;
     assert_eq!(
         (stake_account_before.balance.total() - stake_account_after.balance.total()).unwrap(),
         unstake_lamports
     );
-    let unstake_account = context
-        .context
-        .get_unstake_account_from_seed(&validator, 0)
-        .await;
+    let unstake_account = context.get_unstake_account_from_seed(&validator, 0).await;
 
-    let rent = context.context.get_rent().await;
+    let rent = context.get_rent().await;
     let stake_rent = rent.minimum_balance(std::mem::size_of::<StakeState>());
     // The rent will not become deactivated.
     assert_eq!(
@@ -69,50 +58,39 @@ async fn test_successful_unstake() {
 
 #[tokio::test]
 async fn test_unstake_balance_combinations() {
-    let mut context = UnstakeContext::new(STAKE_AMOUNT).await;
-    let result = context.context.try_unstake(STAKE_AMOUNT).await;
+    let mut context = new_unstake_context(STAKE_AMOUNT).await;
+    let result = context.try_unstake(STAKE_AMOUNT).await;
     // Should fail, because the validator will have less than the minimum.
     assert_solido_error!(result, LidoError::InvalidAmount);
     // Should fail, because we tried to unstake more than the validator has.
     let result = context
-        .context
         .try_unstake((STAKE_AMOUNT + Lamports(1)).unwrap())
         .await;
     assert!(result.is_err()); // Insufficient funds error from Stake Program.
 
     // Unstaking less than the rent should fail
-    let rent = context.context.get_rent().await;
+    let rent = context.get_rent().await;
     let stake_rent = rent.minimum_balance(std::mem::size_of::<StakeState>());
-    let result = context.context.try_unstake(Lamports(stake_rent - 1)).await;
+    let result = context.try_unstake(Lamports(stake_rent - 1)).await;
     assert!(result.is_err());
 
     // If we unstake so that the validator still has the minimum, it should work.
     context
-        .context
         .unstake((STAKE_AMOUNT - MINIMUM_STAKE_ACCOUNT_BALANCE).unwrap())
         .await;
 }
 
 #[tokio::test]
 async fn test_unstake_with_funded_destination_stake() {
-    let mut context = UnstakeContext::new(STAKE_AMOUNT).await;
-    let validator = &context.context.get_solido().await.validators.entries[0];
-    let (unstake_address, _) = validator.find_unstake_account_address(
-        &crate::context::id(),
-        &context.context.solido.pubkey(),
-        0,
-    );
-    context
-        .context
-        .fund(unstake_address, Lamports(500_000_000))
-        .await;
+    let mut context = new_unstake_context(STAKE_AMOUNT).await;
+    let validator = &context.get_solido().await.validators.entries[0];
+    let (unstake_address, _) =
+        validator.find_unstake_account_address(&crate::context::id(), &context.solido.pubkey(), 0);
+    context.fund(unstake_address, Lamports(500_000_000)).await;
     let unstake_lamports = Lamports(1_000_000_000);
 
-    context.context.unstake(unstake_lamports).await;
-    let unstake_account = context
-        .context
-        .get_unstake_account_from_seed(&validator, 0)
-        .await;
+    context.unstake(unstake_lamports).await;
+    let unstake_account = context.get_unstake_account_from_seed(&validator, 0).await;
     // Since we already had something in the account that paid for the rent, we
     // can unstake all the requested amount.
     assert_eq!(unstake_account.balance.deactivating, unstake_lamports);

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -3,56 +3,115 @@
 
 #![cfg(feature = "test-bpf")]
 
+use crate::assert_solido_error;
 use crate::context::{Context, StakeDeposit};
-use lido::{state::Validator, token::Lamports};
+use lido::MINIMUM_STAKE_ACCOUNT_BALANCE;
+use lido::{error::LidoError, state::Validator, token::Lamports};
+use solana_program::stake::state::StakeState;
 use solana_program_test::tokio;
 use solana_sdk::signer::Signer;
 const STAKE_AMOUNT: Lamports = Lamports(10_000_000_000);
 
+struct UnstakeContext {
+    context: Context,
+}
+
+impl UnstakeContext {
+    async fn new(stake_amount: Lamports) -> UnstakeContext {
+        let mut context = Context::new_with_maintainer_and_validator().await;
+        context.deposit(stake_amount).await;
+        let validator = context.validator.take().unwrap();
+        context
+            .stake_deposit(validator.vote_account, StakeDeposit::Append, STAKE_AMOUNT)
+            .await;
+        context.validator = Some(validator);
+
+        let epoch_schedule = context.context.genesis_config().epoch_schedule;
+        let start_slot = epoch_schedule.first_normal_slot;
+
+        context.context.warp_to_slot(start_slot).unwrap();
+        context.update_exchange_rate().await;
+
+        UnstakeContext { context }
+    }
+}
+
 #[tokio::test]
 async fn test_successful_unstake() {
-    let mut context = Context::new_with_maintainer_and_validator().await;
-    context.deposit(STAKE_AMOUNT).await;
-    let validator = context.validator.take().unwrap();
-    context
-        .stake_deposit(validator.vote_account, StakeDeposit::Append, STAKE_AMOUNT)
-        .await;
-    context.validator = Some(validator);
-
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-
-    context.context.warp_to_slot(start_slot).unwrap();
-    context.update_exchange_rate().await;
-
+    let mut context = UnstakeContext::new(STAKE_AMOUNT).await;
     let unstake_lamports = Lamports(1_000_000_000);
-    context.unstake(unstake_lamports).await;
+
+    let solido = context.context.get_solido().await;
+    let validator = &solido.validators.entries[0];
+
+    let stake_account_before = context
+        .context
+        .get_stake_account_from_seed(&validator.pubkey, 0)
+        .await;
+    context.context.unstake(unstake_lamports).await;
+    let stake_account_after = context
+        .context
+        .get_stake_account_from_seed(&validator.pubkey, 0)
+        .await;
+    assert_eq!(
+        (stake_account_before.balance.total() - stake_account_after.balance.total()).unwrap(),
+        unstake_lamports
+    );
+    let unstake_account = context
+        .context
+        .get_unstake_account_from_seed(&validator.pubkey, 0)
+        .await;
+
+    let rent = context.context.get_rent().await;
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<StakeState>());
+    // The rent will not become deactivated.
+    assert_eq!(
+        unstake_account.balance.deactivating,
+        (unstake_lamports - Lamports(stake_rent)).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_unstake_balance_combinations() {
+    let mut context = UnstakeContext::new(STAKE_AMOUNT).await;
+    let result = context.context.try_unstake(STAKE_AMOUNT).await;
+    // Should fail, because the validator will have less than the minimum.
+    assert_solido_error!(result, LidoError::InvalidAmount);
+    // If we unstake so that the validator still has the minimum, it should work.
+    context
+        .context
+        .unstake((STAKE_AMOUNT - MINIMUM_STAKE_ACCOUNT_BALANCE).unwrap())
+        .await;
+    // Should fail, because we tried to unstake more than the validator has.
+    let result = context
+        .context
+        .try_unstake((STAKE_AMOUNT + Lamports(1)).unwrap())
+        .await;
+    assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn test_unstake_with_funded_destination_stake() {
-    let mut context = Context::new_with_maintainer_and_validator().await;
-    context.deposit(STAKE_AMOUNT).await;
-    let validator = context.validator.take().unwrap();
-    context
-        .stake_deposit(validator.vote_account, StakeDeposit::Append, STAKE_AMOUNT)
-        .await;
-    context.validator = Some(validator);
-
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-
-    context.context.warp_to_slot(start_slot).unwrap();
-    context.update_exchange_rate().await;
-
-    let validator = &context.get_solido().await.validators.entries[0];
+    let mut context = UnstakeContext::new(STAKE_AMOUNT).await;
+    let validator = &context.context.get_solido().await.validators.entries[0];
     let (unstake_address, _) = Validator::find_unstake_account_address(
         &crate::context::id(),
-        &context.solido.pubkey(),
+        &context.context.solido.pubkey(),
         &validator.pubkey,
         0,
     );
-    context.fund(unstake_address, Lamports(500_000_000)).await;
+    context
+        .context
+        .fund(unstake_address, Lamports(500_000_000))
+        .await;
     let unstake_lamports = Lamports(1_000_000_000);
-    context.unstake(unstake_lamports).await;
+
+    context.context.unstake(unstake_lamports).await;
+    let unstake_account = context
+        .context
+        .get_unstake_account_from_seed(&validator.pubkey, 0)
+        .await;
+    // Since we already had something in the account that paid for the rent, we
+    // can unstake all the requested amount.
+    assert_eq!(unstake_account.balance.deactivating, unstake_lamports);
 }

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -12,12 +12,8 @@ use solana_program_test::tokio;
 use solana_sdk::signer::Signer;
 const STAKE_AMOUNT: Lamports = Lamports(10_000_000_000);
 
-struct UnstakeContext {
-    context: Context,
-}
-
 impl UnstakeContext {
-    async fn new(stake_amount: Lamports) -> UnstakeContext {
+    async fn new(stake_amount: Lamports) -> Context {
         let mut context = Context::new_with_maintainer_and_validator().await;
         context.deposit(stake_amount).await;
         let validator = context.validator.take().unwrap();
@@ -32,7 +28,7 @@ impl UnstakeContext {
         context.context.warp_to_slot(start_slot).unwrap();
         context.update_exchange_rate().await;
 
-        UnstakeContext { context }
+        context
     }
 }
 

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -4,9 +4,9 @@
 #![cfg(feature = "test-bpf")]
 
 use crate::context::{Context, StakeDeposit};
-use lido::token::Lamports;
-use solana_program::stake::state::StakeState;
+use lido::{state::Validator, token::Lamports};
 use solana_program_test::tokio;
+use solana_sdk::signer::Signer;
 const STAKE_AMOUNT: Lamports = Lamports(10_000_000_000);
 
 #[tokio::test]
@@ -25,24 +25,34 @@ async fn test_successful_unstake() {
     context.context.warp_to_slot(start_slot).unwrap();
     context.update_exchange_rate().await;
 
-    let solido = context.get_solido().await;
-    let val = &solido.validators.entries[0];
-    let stake_account_before = context.get_stake_account_from_seed(&val.pubkey, 0).await;
     let unstake_lamports = Lamports(1_000_000_000);
     context.unstake(unstake_lamports).await;
-    let stake_account_after = context.get_stake_account_from_seed(&val.pubkey, 0).await;
+}
 
-    assert_eq!(
-        (stake_account_before.balance.total() - stake_account_after.balance.total()).unwrap(),
-        unstake_lamports
+#[tokio::test]
+async fn test_unstake_with_funded_destination_stake() {
+    let mut context = Context::new_with_maintainer_and_validator().await;
+    context.deposit(STAKE_AMOUNT).await;
+    let validator = context.validator.take().unwrap();
+    context
+        .stake_deposit(validator.vote_account, StakeDeposit::Append, STAKE_AMOUNT)
+        .await;
+    context.validator = Some(validator);
+
+    let epoch_schedule = context.context.genesis_config().epoch_schedule;
+    let start_slot = epoch_schedule.first_normal_slot;
+
+    context.context.warp_to_slot(start_slot).unwrap();
+    context.update_exchange_rate().await;
+
+    let validator = &context.get_solido().await.validators.entries[0];
+    let (unstake_address, _) = Validator::find_unstake_account_address(
+        &crate::context::id(),
+        &context.solido.pubkey(),
+        &validator.pubkey,
+        0,
     );
-
-    let rent = context.get_rent().await;
-    let stake_rent = rent.minimum_balance(std::mem::size_of::<StakeState>());
-
-    let unstake_account = context.get_unstake_account_from_seed(&val.pubkey, 0).await;
-    assert_eq!(
-        unstake_account.balance.deactivating,
-        (unstake_lamports - Lamports(stake_rent)).unwrap()
-    );
+    context.fund(unstake_address, Lamports(500_000_000)).await;
+    let unstake_lamports = Lamports(1_000_000_000);
+    context.unstake(unstake_lamports).await;
 }

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -6,7 +6,7 @@
 use crate::assert_solido_error;
 use crate::context::{Context, StakeDeposit};
 use lido::MINIMUM_STAKE_ACCOUNT_BALANCE;
-use lido::{error::LidoError, state::Validator, token::Lamports};
+use lido::{error::LidoError, token::Lamports};
 use solana_program::stake::state::StakeState;
 use solana_program_test::tokio;
 use solana_sdk::signer::Signer;
@@ -46,12 +46,12 @@ async fn test_successful_unstake() {
 
     let stake_account_before = context
         .context
-        .get_stake_account_from_seed(&validator.pubkey, 0)
+        .get_stake_account_from_seed(&validator, 0)
         .await;
     context.context.unstake(unstake_lamports).await;
     let stake_account_after = context
         .context
-        .get_stake_account_from_seed(&validator.pubkey, 0)
+        .get_stake_account_from_seed(&validator, 0)
         .await;
     assert_eq!(
         (stake_account_before.balance.total() - stake_account_after.balance.total()).unwrap(),
@@ -59,7 +59,7 @@ async fn test_successful_unstake() {
     );
     let unstake_account = context
         .context
-        .get_unstake_account_from_seed(&validator.pubkey, 0)
+        .get_unstake_account_from_seed(&validator, 0)
         .await;
 
     let rent = context.context.get_rent().await;
@@ -101,10 +101,9 @@ async fn test_unstake_balance_combinations() {
 async fn test_unstake_with_funded_destination_stake() {
     let mut context = UnstakeContext::new(STAKE_AMOUNT).await;
     let validator = &context.context.get_solido().await.validators.entries[0];
-    let (unstake_address, _) = Validator::find_unstake_account_address(
+    let (unstake_address, _) = validator.find_unstake_account_address(
         &crate::context::id(),
         &context.context.solido.pubkey(),
-        &validator.pubkey,
         0,
     );
     context
@@ -116,7 +115,7 @@ async fn test_unstake_with_funded_destination_stake() {
     context.context.unstake(unstake_lamports).await;
     let unstake_account = context
         .context
-        .get_unstake_account_from_seed(&validator.pubkey, 0)
+        .get_unstake_account_from_seed(&validator, 0)
         .await;
     // Since we already had something in the account that paid for the rent, we
     // can unstake all the requested amount.

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -303,12 +303,12 @@ assert solido_instance['solido']['validators']['entries'][0] == {
         'fee_credit': 0,
         'fee_address': validator_fee_account,
         'stake_seeds': {
-            'stake_accounts_seed_begin': 0,
-            'stake_accounts_seed_end': 0,
+            'begin': 0,
+            'end': 0,
         },
-        'stake_seeds': {
-            'stake_accounts_seed_begin': 0,
-            'stake_accounts_seed_end': 0,
+        'unstake_seeds': {
+            'begin': 0,
+            'end': 0,
         },
         'stake_accounts_balance': 0,
         'active': True,

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -302,8 +302,10 @@ assert solido_instance['solido']['validators']['entries'][0] == {
     'entry': {
         'fee_credit': 0,
         'fee_address': validator_fee_account,
-        'stake_accounts_seed_begin': 0,
-        'stake_accounts_seed_end': 0,
+        'stake_seeds': {
+            'stake_accounts_seed_begin': 0,
+            'stake_accounts_seed_end': 0,
+        },
         'stake_accounts_balance': 0,
         'active': True,
     },

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -311,6 +311,7 @@ assert solido_instance['solido']['validators']['entries'][0] == {
             'end': 0,
         },
         'stake_accounts_balance': 0,
+        'unstake_accounts_balance': 0,
         'active': True,
     },
 }, f'Unexpected validator entry, in {json.dumps(solido_instance, indent=True)}'

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -306,6 +306,10 @@ assert solido_instance['solido']['validators']['entries'][0] == {
             'stake_accounts_seed_begin': 0,
             'stake_accounts_seed_end': 0,
         },
+        'stake_seeds': {
+            'stake_accounts_seed_begin': 0,
+            'stake_accounts_seed_end': 0,
+        },
         'stake_accounts_balance': 0,
         'active': True,
     },


### PR DESCRIPTION
Add a seeds for the unstake accounts and change some variables to cope with the modifications.
Changes:

- Split `VALIDATOR_STAKE_ACCOUNT` in `VALIDATOR_STAKE_ACCOUNT` and `VALIDATOR_UNSTAKE_ACCOUNT`.
- Function to split stake accounts `split_stake_account`, so it can be reused in `process_withdraw` and `process_unstake`.
- Bugfix (please check that): the inactive stake calculation at `StakeAccount::from_delegated_account` was subtracted twice, once from the `activating_lamports` and another for the `deactivating_lamports`. In other words, when the stake is being deactivated, the `activating_lamports` is not subtracted.
- New type `SeedRange` that is reused for `stake_seeds` and `unstake_seeds` for the `Validator`'s state.
- Split `find_stake_account_address` into `find_stake_account_address` and `find_unstake_account_address`. Helpers for finding stake accounts.
- Simple test to unstake.

The ability to retrieve funds from the inactive stake accounts will be implemented on top of this PR. Maybe we can modify the `WithdrawInactiveStake` instruction to do so.