### PR TITLE
Log what we did from deposit and withdraw

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -168,6 +168,15 @@ pub fn process_deposit(
         st_sol_amount,
     )?;
 
+    // Explain what we did in the logs, because block explorers can be an
+    // inscrutable mess of accounts, especially without special parsers for
+    // Solido transactions. With the logs, we can still identify what happened.
+    msg!(
+        "Solido: Deposited {}, minted {} in return.",
+        amount,
+        st_sol_amount
+    );
+
     lido.metrics.deposit_amount.observe(amount)?;
     lido.save(accounts.lido)
 }
@@ -746,6 +755,11 @@ pub fn process_withdraw(
 
     // Give control of the stake to the user.
     transfer_stake_authority(&accounts, lido.stake_authority_bump_seed)?;
+
+    // Explain what we did in the logs, because block explorers can be an
+    // inscrutable mess of accounts, especially without special parsers for
+    // Solido transactions. With the logs, we can still identify what happened.
+    msg!("Solido: Withdrew {} for {}.", amount, sol_to_withdraw);
 
     lido.save(accounts.lido)
 }


### PR DESCRIPTION
Brian mentioned this morning that he did a deposit on devnet, and it worked, but transaction on explorer.solana.com is difficult to
understand. Part of this is just inherent, we need to reference all of those accounts. The way to make this more comprehensible is for block explorers to add special Solido parsers. But there is one thing we can do on our side: log what we did.