### PR TITLE
Test `StakeAccount` and bugfix.

### DIFF
--- a/program/src/stake_account.rs
+++ b/program/src/stake_account.rs
@@ -23,7 +23,7 @@ use solana_program::{instruction::Instruction, stake_history::StakeHistory};
 /// The sum of the four fields is equal to the SOL balance of the stake account.
 /// Note that a stake account can have a portion in `inactive` and a portion in
 /// `active`, with zero being activating or deactivating.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct StakeBalance {
     pub inactive: Lamports,
     pub activating: Lamports,
@@ -31,7 +31,7 @@ pub struct StakeBalance {
     pub deactivating: Lamports,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 
 pub struct StakeAccount {
     pub balance: StakeBalance,
@@ -198,17 +198,19 @@ impl StakeAccount {
         // to true. See also https://github.com/ChorusOne/solido/issues/184#issuecomment-861653316.
         let fix_stake_deactivate = true;
 
-        let (active_lamports, activating_lamports, deactivating_lamports) = stake
+        let (mut active_lamports, activating_lamports, deactivating_lamports) = stake
             .delegation
             .stake_activating_and_deactivating(target_epoch, history, fix_stake_deactivate);
 
-        // Deactivating will be counted in the active lamports
-        let inactive_lamports = account_lamports
-            .0
+        // Deactivating lamports is counted on the active lamports.
+        active_lamports -= deactivating_lamports;
+        let inactive_lamports = account_lamports.0
             .checked_sub(active_lamports)
             .expect("Active stake cannot be larger than stake account balance.")
             .checked_sub(activating_lamports)
-            .expect("Activating stake cannot be larger than stake account balance - active.");
+            .expect("Activating stake cannot be larger than stake account balance - active.")
+            .checked_sub(deactivating_lamports)
+            .expect("Deactivating stake cannot be larger than stake account balance - active - activating.");
 
         StakeAccount {
             balance: StakeBalance {

--- a/program/src/stake_account.rs
+++ b/program/src/stake_account.rs
@@ -23,7 +23,7 @@ use solana_program::{instruction::Instruction, stake_history::StakeHistory};
 /// The sum of the four fields is equal to the SOL balance of the stake account.
 /// Note that a stake account can have a portion in `inactive` and a portion in
 /// `active`, with zero being activating or deactivating.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StakeBalance {
     pub inactive: Lamports,
     pub activating: Lamports,

--- a/program/tests/tests/solana_assumptions.rs
+++ b/program/tests/tests/solana_assumptions.rs
@@ -251,7 +251,7 @@ async fn test_stake_accounts() {
     let warp_to_slot = context.get_clock().await.slot + slots_per_epoch;
     context.context.warp_to_slot(warp_to_slot).unwrap();
 
-    // Stake is now deactivating.
+    // Stake is now inactive.
     let deactivated = deactivating;
 
     let deactivated_stake = context.get_stake_state(deactivated).await;


### PR DESCRIPTION
Previously, `StakeAccount` was wrong, it displayed the number of active Lamports even when some Lamports were deactivating. This adds some tests to safeguard changes in Solana.