### PR TITLE
Guard stake deposit

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -162,6 +162,10 @@ pub enum LidoError {
     /// Tried to remove a validator when it when it was active or had stake accounts.
     #[error("ValidatorShouldHaveNoStakeAccounts")]
     ValidatorShouldHaveNoStakeAccounts = 41,
+
+    /// There is a validator that has less stake than the selected one, stake to that one instead.
+    #[error("ValidatorWithLessStakeExists")]
+    ValidatorWithLessStakeExists = 42,
 }
 
 impl From<ArithmeticError> for LidoError {

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -41,6 +41,10 @@ impl Validators {
     pub fn iter_active(&self) -> impl Iterator<Item = &Validator> {
         self.iter_entries().filter(|&v| v.active)
     }
+
+    pub fn iter_active_entries(&self) -> impl Iterator<Item = &PubkeyAndEntry<Validator>> {
+        self.entries.iter().filter(|&v| v.entry.active)
+    }
 }
 pub type Maintainers = AccountSet;
 
@@ -674,6 +678,12 @@ impl Validator {
             fee_address,
             ..Default::default()
         }
+    }
+
+    /// Return the balance in only the stake accounts, excluding the unstake accounts.
+    pub fn effective_stake_balance(&self) -> Lamports {
+        (self.stake_accounts_balance - self.unstake_accounts_balance)
+            .expect("Unstake balance cannot exceed the validator's total stake balance.")
     }
 }
 


### PR DESCRIPTION
Add an additional check in `StakeDeposit` to confirm that no other validator with less stake exists.

* This reduces the power that maintainers have to mess with the stake distribution, which is good because it reduces the amount of trust in them. It is still possible for rogue maintainers to disturb the balance, but not by as much.
* When two maintainers race and produce the same `StakeDeposit` instruction, previously this could lead to one validator having too much stake, but now it will cause one of the two transactions to fail.

This is an alternative to #219, which will be obsolete once this is merged.