### PR TITLE
Do not require manager to sign validator removal

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -651,16 +651,10 @@ accounts_struct! {
             is_signer: false,
             is_writable: true,
         },
-        pub manager {
-            is_signer: true,
-            is_writable: false,
-        },
         pub validator_vote_account_to_remove {
             is_signer: false,
             is_writable: false,
         },
-        const sysvar_clock = sysvar::clock::id(),
-        const sysvar_stake_program = stake_program::program::id(),
     }
 }
 

--- a/program/src/process_management.rs
+++ b/program/src/process_management.rs
@@ -70,7 +70,10 @@ pub fn process_add_validator(program_id: &Pubkey, accounts_raw: &[AccountInfo]) 
 
 /// Remove a validator.
 ///
-/// TODO(#365): It should only be possible to remove validators that have no stake.
+/// This instruction is the final cleanup step in the validator removal process,
+/// and it is callable by anybody. Initiation of the removal (`DeactivateValidator`)
+/// is restricted to the manager, but once a validator is inactive, and there is
+/// no more stake delegated to it, removing it from the list can be done by anybody.
 pub fn process_remove_validator(
     program_id: &Pubkey,
     accounts_raw: &[AccountInfo],

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -732,11 +732,10 @@ impl Context {
                 &id(),
                 &lido::instruction::RemoveValidatorMeta {
                     lido: self.solido.pubkey(),
-                    manager: self.manager.pubkey(),
                     validator_vote_account_to_remove: vote_account,
                 },
             )],
-            vec![&self.manager],
+            vec![],
         )
         .await
     }


### PR DESCRIPTION
This was reported by Neodyme.

`RemoveValidator` still required a signature from the manager. We forgot to remove this account when we made `RemoveValidator` world-callable in https://github.com/ChorusOne/solido/pull/377. (I [mentioned](https://github.com/ChorusOne/solido/pull/377#discussion_r693012245) it in my first review but then I missed it after edits.)

Also remove program accounts that are not needed, I think these are a leftover from when we still used the SPL stake pool.