### PR TITLE
Remove unused accounts from `AddValidator`

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -633,9 +633,6 @@ accounts_struct! {
             is_signer: false,
             is_writable: false,
         },
-        const sysvar_clock = sysvar::clock::id(),
-        const sysvar_stake_history = sysvar::stake_history::id(),
-        const sysvar_stake_program = stake_program::program::id(),
         const sysvar_rent = sysvar::rent::id(),
     }
 }


### PR DESCRIPTION
While working on #388 I discovered that we also had unused accounts in `AddValidator`. These were a leftover from back when we used the SPL stake pool, the accounts are no longer referenced.