### PR TITLE
Fix withdraw checks

### DIFF
--- a/program/tests/tests/limits.rs
+++ b/program/tests/tests/limits.rs
@@ -87,9 +87,9 @@ async fn test_max_validators_maintainers() {
         context
             .stake_deposit(validator.vote_account, StakeDeposit::Append, amount)
             .await;
-        let vote_account = validator.vote_account;
-        context.validator = Some(validator);
-        context.unstake(vote_account, Lamports(1_000_000_000)).await;
+        context
+            .unstake(validator.vote_account, Lamports(1_000_000_000))
+            .await;
         // If we get here, then none of the transactions failed.
     }
 }

--- a/program/tests/tests/limits.rs
+++ b/program/tests/tests/limits.rs
@@ -87,8 +87,9 @@ async fn test_max_validators_maintainers() {
         context
             .stake_deposit(validator.vote_account, StakeDeposit::Append, amount)
             .await;
+        let vote_account = validator.vote_account;
         context.validator = Some(validator);
-        context.unstake(Lamports(1_000_000_000)).await;
+        context.unstake(vote_account, Lamports(1_000_000_000)).await;
         // If we get here, then none of the transactions failed.
     }
 }


### PR DESCRIPTION
This fixes an issue discovered by Neodyme, where `process_withdraw` would not consider the unstake account balance when checking that we withdraw from the validator that has the most stake.

Also add a test to catch this. To make the test easier to write, I modified the test context a bit.