### PR TITLE
Limit unstake accounts, fix amount computations

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -170,6 +170,13 @@ pub enum LidoError {
     /// Tried to remove a validator when it when it was active or had stake accounts.
     #[error("ValidatorShouldHaveNoUnStakeAccounts")]
     ValidatorShouldHaveNoUnstakeAccounts = 43,
+
+    /// The validator already has the maximum number of unstake accounts.
+    ///
+    /// We can't unstake more in this epoch, wait for stake to deactivate, close
+    /// the unstake accounts with `WithdrawInactiveStake`, and retry next epoch.
+    #[error("MaxUnstakeAccountsReached")]
+    MaxUnstakeAccountsReached = 44,
 }
 
 impl From<ArithmeticError> for LidoError {

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -20,7 +20,6 @@ use solana_program_test::{processor, ProgramTest, ProgramTestBanksClientExt, Pro
 use solana_sdk::account::ReadableAccount;
 use solana_sdk::account::{from_account, Account};
 use solana_sdk::account_info::AccountInfo;
-use solana_sdk::clock::Epoch;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::Transaction;
@@ -373,7 +372,10 @@ impl Context {
     }
 
     /// Warp to the given epoch after the first normal slot.
-    pub fn warp_to_epoch(&mut self, epoch: Epoch) {
+    ///
+    /// Note, the epoch number here is not the same as the epoch number of the
+    /// clock sysvar; we start counting from the first "normal" slot.
+    pub fn warp_to_normal_epoch(&mut self, epoch: u64) {
         let epoch_schedule = self.context.genesis_config().epoch_schedule;
         let start_slot = epoch_schedule.first_normal_slot;
         let warp_slot = start_slot + epoch * epoch_schedule.slots_per_epoch;

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -375,7 +375,7 @@ impl Context {
     ///
     /// Note, the epoch number here is not the same as the epoch number of the
     /// clock sysvar; we start counting from the first "normal" slot.
-    pub fn warp_to_normal_epoch(&mut self, epoch: u64) {
+    pub fn advance_to_normal_epoch(&mut self, epoch: u64) {
         let epoch_schedule = self.context.genesis_config().epoch_schedule;
         let start_slot = epoch_schedule.first_normal_slot;
         let warp_slot = start_slot + epoch * epoch_schedule.slots_per_epoch;

--- a/program/tests/context.rs
+++ b/program/tests/context.rs
@@ -20,6 +20,7 @@ use solana_program_test::{processor, ProgramTest, ProgramTestBanksClientExt, Pro
 use solana_sdk::account::ReadableAccount;
 use solana_sdk::account::{from_account, Account};
 use solana_sdk::account_info::AccountInfo;
+use solana_sdk::clock::Epoch;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::Transaction;
@@ -369,6 +370,16 @@ impl Context {
         send_transaction(&mut self.context, &mut self.nonce, &[memo_instr], vec![])
             .await
             .expect("Failed to send memo transaction.")
+    }
+
+    /// Warp to the given epoch after the first normal slot.
+    pub fn warp_to_epoch(&mut self, epoch: Epoch) {
+        let epoch_schedule = self.context.genesis_config().epoch_schedule;
+        let start_slot = epoch_schedule.first_normal_slot;
+        let warp_slot = start_slot + epoch * epoch_schedule.slots_per_epoch;
+        self.context
+            .warp_to_slot(warp_slot)
+            .expect("Failed to warp to epoch.");
     }
 
     /// Initialize a new SPL token mint, return its instance address.

--- a/program/tests/tests/add_remove_validator.rs
+++ b/program/tests/tests/add_remove_validator.rs
@@ -65,19 +65,13 @@ async fn test_remove_validator_with_unclaimed_credits() {
         .increment_vote_account_credits(&validator.vote_account, 1);
 
     // Skip ahead a number of epochs.
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-    let slots_per_epoch = epoch_schedule.slots_per_epoch;
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
     context
         .context
         .increment_vote_account_credits(&validator.vote_account, 1);
 
     context.update_exchange_rate().await;
-    context
-        .context
-        .warp_to_slot(start_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_normal_epoch(1);
     context.update_exchange_rate().await;
     context.collect_validator_fee(validator.vote_account).await;
 

--- a/program/tests/tests/add_remove_validator.rs
+++ b/program/tests/tests/add_remove_validator.rs
@@ -65,13 +65,13 @@ async fn test_remove_validator_with_unclaimed_credits() {
         .increment_vote_account_credits(&validator.vote_account, 1);
 
     // Skip ahead a number of epochs.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
     context
         .context
         .increment_vote_account_credits(&validator.vote_account, 1);
 
     context.update_exchange_rate().await;
-    context.warp_to_normal_epoch(1);
+    context.advance_to_normal_epoch(1);
     context.update_exchange_rate().await;
     context.collect_validator_fee(validator.vote_account).await;
 

--- a/program/tests/tests/collect_validator_fee.rs
+++ b/program/tests/tests/collect_validator_fee.rs
@@ -35,10 +35,7 @@ async fn test_collect_validator_fee() {
     assert_eq!(fees, Lamports(0));
 
     // Skip ahead a number of epochs.
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-    let slots_per_epoch = epoch_schedule.slots_per_epoch;
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
 
     // In this new epoch, we should not be allowed to collect the validator's fee,
     // yet, because we haven’t updated the exchange rate yet.
@@ -73,10 +70,7 @@ async fn test_collect_validator_fee() {
     let solido_before = context.get_solido().await;
     let validator_before = solido_before.validators.entries[0].entry.fee_credit;
 
-    context
-        .context
-        .warp_to_slot(start_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_normal_epoch(1);
     let account = context.get_account(validator.vote_account).await;
     let vote_account_rent = Lamports(context.get_rent().await.minimum_balance(account.data.len()));
     assert_eq!(vote_account_before, vote_account_rent);

--- a/program/tests/tests/collect_validator_fee.rs
+++ b/program/tests/tests/collect_validator_fee.rs
@@ -35,7 +35,7 @@ async fn test_collect_validator_fee() {
     assert_eq!(fees, Lamports(0));
 
     // Skip ahead a number of epochs.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
 
     // In this new epoch, we should not be allowed to collect the validator's fee,
     // yet, because we haven’t updated the exchange rate yet.
@@ -70,7 +70,7 @@ async fn test_collect_validator_fee() {
     let solido_before = context.get_solido().await;
     let validator_before = solido_before.validators.entries[0].entry.fee_credit;
 
-    context.warp_to_normal_epoch(1);
+    context.advance_to_normal_epoch(1);
     let account = context.get_account(validator.vote_account).await;
     let vote_account_rent = Lamports(context.get_rent().await.minimum_balance(account.data.len()));
     assert_eq!(vote_account_before, vote_account_rent);

--- a/program/tests/tests/merge_stake.rs
+++ b/program/tests/tests/merge_stake.rs
@@ -60,13 +60,6 @@ async fn test_successful_merge_activating_stake() {
     );
 }
 
-fn advance_epoch(context: &mut Context, current_slot: &mut u64) {
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let slots_per_epoch = epoch_schedule.slots_per_epoch;
-    *current_slot = *current_slot + slots_per_epoch;
-    context.context.warp_to_slot(*current_slot).unwrap();
-}
-
 // Test merging active to activating: should fail.
 // Test merging two activated stake accounts: should succeed.
 #[tokio::test]
@@ -74,15 +67,15 @@ async fn test_merge_stake_combinations() {
     let stake_deposit_amount = Lamports(2_000_000_000); // 2 Sol
     let mut context = Context::new_with_maintainer_and_validator().await;
 
+    context.warp_to_normal_epoch(0);
+
     let validator = &context.get_solido().await.validators.entries[0];
     context.deposit(Lamports(100_000_000_000)).await;
     context
         .stake_deposit(validator.pubkey, StakeDeposit::Append, stake_deposit_amount)
         .await;
 
-    let mut current_slot = 0;
-    // Skip ahead 1 epoch
-    advance_epoch(&mut context, &mut current_slot);
+    context.warp_to_normal_epoch(1);
 
     // Create an activating stake account.
     context
@@ -98,7 +91,8 @@ async fn test_merge_stake_combinations() {
     let result = context.try_merge_stake(&validator, 0, 1).await;
     // Merging active to activating should fail.
     assert_solido_error!(result, LidoError::WrongStakeState);
-    advance_epoch(&mut context, &mut current_slot);
+
+    context.warp_to_normal_epoch(2);
 
     let now_active_stake_account = context.get_stake_account_from_seed(&validator, 1).await;
     assert!(active_stake_account.is_active());

--- a/program/tests/tests/merge_stake.rs
+++ b/program/tests/tests/merge_stake.rs
@@ -67,7 +67,7 @@ async fn test_merge_stake_combinations() {
     let stake_deposit_amount = Lamports(2_000_000_000); // 2 Sol
     let mut context = Context::new_with_maintainer_and_validator().await;
 
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
 
     let validator = &context.get_solido().await.validators.entries[0];
     context.deposit(Lamports(100_000_000_000)).await;
@@ -75,7 +75,7 @@ async fn test_merge_stake_combinations() {
         .stake_deposit(validator.pubkey, StakeDeposit::Append, stake_deposit_amount)
         .await;
 
-    context.warp_to_normal_epoch(1);
+    context.advance_to_normal_epoch(1);
 
     // Create an activating stake account.
     context
@@ -92,7 +92,7 @@ async fn test_merge_stake_combinations() {
     // Merging active to activating should fail.
     assert_solido_error!(result, LidoError::WrongStakeState);
 
-    context.warp_to_normal_epoch(2);
+    context.advance_to_normal_epoch(2);
 
     let now_active_stake_account = context.get_stake_account_from_seed(&validator, 1).await;
     assert!(active_stake_account.is_active());

--- a/program/tests/tests/solana_assumptions.rs
+++ b/program/tests/tests/solana_assumptions.rs
@@ -91,11 +91,7 @@ async fn measure_staking_rewards(mode: StakeMode) -> Lamports {
     let vote_account = context.validator.as_ref().unwrap().vote_account.clone();
     let authority = context.deterministic_keypair.new_keypair();
 
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let slots_per_epoch = epoch_schedule.slots_per_epoch;
-    let start_slot = epoch_schedule.first_normal_slot;
-
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
 
     // Create a stake account and delegate it to the vote account, which is a
     // 100% commission vote account, so all rewards go to the vote account.
@@ -113,10 +109,7 @@ async fn measure_staking_rewards(mode: StakeMode) -> Lamports {
     }
 
     // Move ahead one epoch so the stake becomes active.
-    context
-        .context
-        .warp_to_slot(start_slot + 1 * slots_per_epoch)
-        .unwrap();
+    context.warp_to_normal_epoch(1);
 
     let balance_t0 = context.get_sol_balance(vote_account).await;
 
@@ -134,10 +127,7 @@ async fn measure_staking_rewards(mode: StakeMode) -> Lamports {
     context
         .context
         .increment_vote_account_credits(&vote_account, 1);
-    context
-        .context
-        .warp_to_slot(start_slot + 2 * slots_per_epoch)
-        .unwrap();
+    context.warp_to_normal_epoch(2);
 
     let balance_t1 = context.get_sol_balance(vote_account).await;
 
@@ -198,11 +188,7 @@ async fn test_stake_accounts() {
         }
     );
 
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let slots_per_epoch = epoch_schedule.slots_per_epoch;
-    let start_slot = epoch_schedule.first_normal_slot;
-
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
 
     // Stake is now active.
     let active = activating;
@@ -248,8 +234,7 @@ async fn test_stake_accounts() {
         }
     );
 
-    let warp_to_slot = context.get_clock().await.slot + slots_per_epoch;
-    context.context.warp_to_slot(warp_to_slot).unwrap();
+    context.warp_to_normal_epoch(1);
 
     // Stake is now inactive.
     let deactivated = deactivating;

--- a/program/tests/tests/solana_assumptions.rs
+++ b/program/tests/tests/solana_assumptions.rs
@@ -91,7 +91,7 @@ async fn measure_staking_rewards(mode: StakeMode) -> Lamports {
     let vote_account = context.validator.as_ref().unwrap().vote_account.clone();
     let authority = context.deterministic_keypair.new_keypair();
 
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
 
     // Create a stake account and delegate it to the vote account, which is a
     // 100% commission vote account, so all rewards go to the vote account.
@@ -109,7 +109,7 @@ async fn measure_staking_rewards(mode: StakeMode) -> Lamports {
     }
 
     // Move ahead one epoch so the stake becomes active.
-    context.warp_to_normal_epoch(1);
+    context.advance_to_normal_epoch(1);
 
     let balance_t0 = context.get_sol_balance(vote_account).await;
 
@@ -127,7 +127,7 @@ async fn measure_staking_rewards(mode: StakeMode) -> Lamports {
     context
         .context
         .increment_vote_account_credits(&vote_account, 1);
-    context.warp_to_normal_epoch(2);
+    context.advance_to_normal_epoch(2);
 
     let balance_t1 = context.get_sol_balance(vote_account).await;
 
@@ -188,7 +188,7 @@ async fn test_stake_accounts() {
         }
     );
 
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
 
     // Stake is now active.
     let active = activating;
@@ -234,7 +234,7 @@ async fn test_stake_accounts() {
         }
     );
 
-    context.warp_to_normal_epoch(1);
+    context.advance_to_normal_epoch(1);
 
     // Stake is now inactive.
     let deactivated = deactivating;

--- a/program/tests/tests/stake_deposit.rs
+++ b/program/tests/tests/stake_deposit.rs
@@ -109,9 +109,7 @@ async fn test_stake_deposit_merge() {
 
     // Next, we will try to merge stake accounts created in different epochs,
     // which should fail.
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
 
     let result = context
         .try_stake_deposit(

--- a/program/tests/tests/stake_deposit.rs
+++ b/program/tests/tests/stake_deposit.rs
@@ -109,7 +109,7 @@ async fn test_stake_deposit_merge() {
 
     // Next, we will try to merge stake accounts created in different epochs,
     // which should fail.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
 
     let result = context
         .try_stake_deposit(

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -230,11 +230,20 @@ async fn test_unstake_allows_at_most_three_unstake_accounts() {
     // Wait for the unstake accounts to deactivate.
     context.advance_to_normal_epoch(1);
 
+    let solido_before = context.get_solido().await;
+    let validator_before = &solido_before.validators.entries[0].entry;
+    assert_eq!(validator_before.unstake_seeds.begin, 0);
+    assert_eq!(validator_before.unstake_seeds.end, 3);
+
     // Withdraw the now-inactive stake accounts to the reserve to free up
     // unstake accounts again.
-    // TODO: Enable this after #393 is merged.
-    // context.withdraw_inactive_stake(vote_account).await;
+    context.withdraw_inactive_stake(vote_account).await;
+
+    let solido_after = context.get_solido().await;
+    let validator_after = &solido_after.validators.entries[0].entry;
+    assert_eq!(validator_after.unstake_seeds.begin, 3);
+    assert_eq!(validator_after.unstake_seeds.end, 3);
 
     // Now we should be allowed to unstake again.
-    // context.unstake(vote_account, unstake_amount).await;
+    context.unstake(vote_account, unstake_amount).await;
 }

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -43,7 +43,7 @@ async fn new_unstake_context(stake_amounts: &[Lamports]) -> Context {
     }
 
     // Wait for the stake to activate.
-    context.warp_to_epoch(0);
+    context.warp_to_normal_epoch(0);
     context.update_exchange_rate().await;
 
     context
@@ -228,7 +228,7 @@ async fn test_unstake_allows_at_most_three_unstake_accounts() {
     assert_solido_error!(result, LidoError::MaxUnstakeAccountsReached);
 
     // Wait for the unstake accounts to deactivate.
-    context.warp_to_epoch(1);
+    context.warp_to_normal_epoch(1);
 
     // Withdraw the now-inactive stake accounts to the reserve to free up
     // unstake accounts again.

--- a/program/tests/tests/unstake.rs
+++ b/program/tests/tests/unstake.rs
@@ -43,7 +43,7 @@ async fn new_unstake_context(stake_amounts: &[Lamports]) -> Context {
     }
 
     // Wait for the stake to activate.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
     context.update_exchange_rate().await;
 
     context
@@ -228,7 +228,7 @@ async fn test_unstake_allows_at_most_three_unstake_accounts() {
     assert_solido_error!(result, LidoError::MaxUnstakeAccountsReached);
 
     // Wait for the unstake accounts to deactivate.
-    context.warp_to_normal_epoch(1);
+    context.advance_to_normal_epoch(1);
 
     // Withdraw the now-inactive stake accounts to the reserve to free up
     // unstake accounts again.

--- a/program/tests/tests/update_exchange_rate.rs
+++ b/program/tests/tests/update_exchange_rate.rs
@@ -17,7 +17,7 @@ async fn test_update_exchange_rate() {
     let mut context = Context::new_with_maintainer().await;
 
     // Move to the next epoch, then update the exchange rate.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
     context.update_exchange_rate().await;
     let start_epoch = context.get_clock().await.epoch;
 
@@ -46,7 +46,7 @@ async fn test_update_exchange_rate() {
     let received_st_sol = context.get_st_sol_balance(recipient).await;
     assert_eq!(received_st_sol, StLamports(DEPOSIT_AMOUNT));
 
-    context.warp_to_normal_epoch(1);
+    context.advance_to_normal_epoch(1);
     context.update_exchange_rate().await;
 
     // There was one deposit, the exchange rate was 1:1, we should now have the
@@ -72,7 +72,7 @@ async fn test_update_exchange_rate() {
         .fund(context.reserve_address, Lamports(3 * DEPOSIT_AMOUNT))
         .await;
 
-    context.warp_to_normal_epoch(2);
+    context.advance_to_normal_epoch(2);
 
     // There is now not as much SOL as stSOL, but for deposits, the rate is still
     // 1:1. Even though we jumped to the next epoch! After all, we did not update

--- a/program/tests/tests/withdraw_inactive_stake.rs
+++ b/program/tests/tests/withdraw_inactive_stake.rs
@@ -40,9 +40,7 @@ async fn test_withdraw_inactive_stake() {
     assert_eq!(solido_before, solido_after);
 
     // Skip ahead a number of epochs.
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
 
     // So after we update the exchange rate, we should be allowed to withdraw the inactive stake.
     context.update_exchange_rate().await;

--- a/program/tests/tests/withdraw_inactive_stake.rs
+++ b/program/tests/tests/withdraw_inactive_stake.rs
@@ -40,7 +40,7 @@ async fn test_withdraw_inactive_stake() {
     assert_eq!(solido_before, solido_after);
 
     // Skip ahead a number of epochs.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
 
     // So after we update the exchange rate, we should be allowed to withdraw the inactive stake.
     context.update_exchange_rate().await;

--- a/program/tests/tests/withdrawals.rs
+++ b/program/tests/tests/withdrawals.rs
@@ -44,7 +44,7 @@ impl WithdrawContext {
             .await;
         context.validator = Some(validator);
 
-        context.warp_to_normal_epoch(0);
+        context.advance_to_normal_epoch(0);
         context.update_exchange_rate().await;
 
         WithdrawContext {
@@ -250,7 +250,7 @@ async fn test_withdraw_fails_if_validator_with_more_stake_exists() {
         .await;
 
     // Wait for the stake accounts to become active.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
     context.update_exchange_rate().await;
 
     // We should not be allowed to withdraw from validator 1, because validator 2 has more stake.
@@ -303,7 +303,7 @@ async fn test_withdraw_enforces_picking_most_stake_validator_in_presence_of_unst
         .await;
 
     // Wait for the stake to become active, so we can withdraw.
-    context.warp_to_normal_epoch(0);
+    context.advance_to_normal_epoch(0);
     context.update_exchange_rate().await;
 
     // Then unstake from validator 1. Now the effective stake is 30 SOL for validator 1,

--- a/program/tests/tests/withdrawals.rs
+++ b/program/tests/tests/withdrawals.rs
@@ -44,10 +44,7 @@ impl WithdrawContext {
             .await;
         context.validator = Some(validator);
 
-        let epoch_schedule = context.context.genesis_config().epoch_schedule;
-        let start_slot = epoch_schedule.first_normal_slot;
-
-        context.context.warp_to_slot(start_slot).unwrap();
+        context.warp_to_normal_epoch(0);
         context.update_exchange_rate().await;
 
         WithdrawContext {
@@ -253,9 +250,7 @@ async fn test_withdraw_fails_if_validator_with_more_stake_exists() {
         .await;
 
     // Wait for the stake accounts to become active.
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
     context.update_exchange_rate().await;
 
     // We should not be allowed to withdraw from validator 1, because validator 2 has more stake.
@@ -308,9 +303,7 @@ async fn test_withdraw_enforces_picking_most_stake_validator_in_presence_of_unst
         .await;
 
     // Wait for the stake to become active, so we can withdraw.
-    let epoch_schedule = context.context.genesis_config().epoch_schedule;
-    let start_slot = epoch_schedule.first_normal_slot;
-    context.context.warp_to_slot(start_slot).unwrap();
+    context.warp_to_normal_epoch(0);
     context.update_exchange_rate().await;
 
     // Then unstake from validator 1. Now the effective stake is 30 SOL for validator 1,


### PR DESCRIPTION
I wanted to put a limit on the number of unstake accounts, to make sure that we don't have so many that `WithdrawInactiveStake` would fail, because we don't merge the unstake accounts.

But while going over this, I noticed some funny things in the amount computations. We should enforce the minimum stake account balance per stake account, not for the validator's overall balance.

Also, when unstaking the full amount from an inactive validator, we should unstake the full stake account, not the full amount, which might be spread over multiple stake accounts. After a merge they should be in a single one and then the difference is not relevant, but still, this was a bit fishy, so fix that.

To do:

* [x] Add tests