### PR TITLE
Rename misleading account creation method

### DIFF
--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -106,11 +106,11 @@ pub struct CreateAccountOptions<'a, 'b> {
 /// Create a new account and fund it from the reserve.
 ///
 /// Unlike `system_instruction::create_account`, this will not fail if the account
-/// already exists. This is important, because if account creation would fail for
+/// is already funded. This is important, because if account creation would fail for
 /// stake accounts, then someone could transfer a small amount to the next stake
 /// account for a validator, and that would prevent us from delegating more stake
 /// to that validator.
-pub fn create_account_overwrite_if_exists<'a, 'b>(
+pub fn create_account_even_if_funded<'a, 'b>(
     solido_address: &Pubkey,
     options: CreateAccountOptions<'a, 'b>,
     reserve: &AccountInfo<'b>,

--- a/program/src/logic.rs
+++ b/program/src/logic.rs
@@ -106,7 +106,7 @@ pub struct CreateAccountOptions<'a, 'b> {
 /// Create a new account and fund it from the reserve.
 ///
 /// Unlike `system_instruction::create_account`, this will not fail if the account
-/// is already funded. This is important, because if account creation would fail for
+/// is already funded. This is important, because if account creation fails for
 /// stake accounts, then someone could transfer a small amount to the next stake
 /// account for a validator, and that would prevent us from delegating more stake
 /// to that validator.

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     logic::{
         burn_st_sol, check_mint, check_rent_exempt, check_unstake_accounts,
-        create_account_overwrite_if_exists, deserialize_lido, distribute_fees,
+        create_account_even_if_funded, deserialize_lido, distribute_fees,
         initialize_stake_account_undelegated, mint_st_sol_to, split_stake_account,
         transfer_stake_authority, CreateAccountOptions, SplitStakeAccounts,
     },
@@ -272,7 +272,7 @@ pub fn process_stake_deposit(
 
     // Create the account that is going to hold the new stake account data.
     // Even if it was already funded.
-    create_account_overwrite_if_exists(
+    create_account_even_if_funded(
         accounts.lido.key,
         CreateAccountOptions {
             fund_amount: amount,


### PR DESCRIPTION
Neodyme pointed out:

> `create_account_overwrite_if_exists` comment is slightly misleading. While it DOES allow creating an account on an address with >0 lamports balance, it does NOT allow overwriting an account which "really" exists (ie has owner or data set). You only use/need it for the first case though, so the code is entirely sane. (except for the options.sign_seeds passed to the transfer instruction, which are unecessary but also don't break anything).

This fixes that.