### PR TITLE
Simplify target balance computations, take unstake accounts into account

### DIFF
--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -359,10 +359,9 @@ impl SolidoState {
 
     /// If there is a deposit that can be staked, return the instructions to do so.
     pub fn try_stake_deposit(&self) -> Option<(Instruction, MaintenanceOutput)> {
-        // We can only stake if there is an active validator.
-        if self.solido.validators.iter_active().next().is_none() {
-            return None;
-        }
+        // We can only stake if there is an active validator. If there is none,
+        // this will short-circuit and return None.
+        self.solido.validators.iter_active().next()?;
 
         let reserve_balance = self.get_effective_reserve();
 

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -359,12 +359,17 @@ impl SolidoState {
 
     /// If there is a deposit that can be staked, return the instructions to do so.
     pub fn try_stake_deposit(&self) -> Option<(Instruction, MaintenanceOutput)> {
+        // We can only stake if there is an active validator.
+        if self.solido.validators.iter_active().next().is_none() {
+            return None;
+        }
+
         let reserve_balance = self.get_effective_reserve();
 
         // If there is enough reserve, we can make a deposit. To keep the pool
         // balanced, find the validator furthest below its target balance, and
-        // deposit to that validator.
-
+        // deposit to that validator. If we get here there is at least one active
+        // validator, so computing the target balance should not fail.
         let undelegated_lamports = reserve_balance;
         let targets =
             lido::balance::get_target_balance(undelegated_lamports, &self.solido.validators)

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -364,15 +364,11 @@ impl SolidoState {
         // If there is enough reserve, we can make a deposit. To keep the pool
         // balanced, find the validator furthest below its target balance, and
         // deposit to that validator.
-        let mut targets = vec![Lamports(0); self.solido.validators.len()];
 
         let undelegated_lamports = reserve_balance;
-        lido::balance::get_target_balance(
-            undelegated_lamports,
-            &self.solido.validators,
-            &mut targets[..],
-        )
-        .expect("Failed to compute target balance.");
+        let targets =
+            lido::balance::get_target_balance(undelegated_lamports, &self.solido.validators)
+                .expect("Failed to compute target balance.");
 
         let (validator_index, amount_below_target) =
             lido::balance::get_validator_furthest_below_target(

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -104,6 +104,8 @@ pub fn get_target_balance(
 
 /// Given a list of validators and their target balance, return the index of the
 /// one furthest below its target, and the amount by which it is below.
+///
+/// This assumes that there is at least one active validator. Panics otherwise.
 pub fn get_validator_furthest_below_target(
     validators: &Validators,
     target_balance: &[Lamports],
@@ -115,11 +117,11 @@ pub fn get_validator_furthest_below_target(
     );
 
     // Our initial index, that will be returned when no validator is below its target,
-    // is the first active validator, and if no validator is active, just the first validator.
+    // is the first active validator.
     let mut index = validators
         .iter_entries()
         .position(|v| v.active)
-        .unwrap_or(0);
+        .expect("get_validator_furthest_below_target requires at least one active validator.");
     let mut amount = Lamports(0);
 
     for (i, (validator, target)) in validators.iter_entries().zip(target_balance).enumerate() {

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -275,4 +275,22 @@ mod test {
         let result = get_target_balance(undelegated_stake, &validators);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn get_target_balance_no_preference_but_some_inactive() {
+        // Every validator is exactly at its target, no validator is below.
+        // But the validator furthest below target should still be an active one,
+        // not the inactive one.
+        let mut validators = Validators::new_fill_default(2);
+        validators.entries[0].entry.stake_accounts_balance = Lamports(0);
+        validators.entries[1].entry.stake_accounts_balance = Lamports(10);
+        validators.entries[0].entry.active = false;
+
+        let undelegated_stake = Lamports(0);
+        let targets = get_target_balance(undelegated_stake, &validators).unwrap();
+        assert_eq!(
+            get_validator_furthest_below_target(&validators, &targets[..]),
+            (1, Lamports(0)),
+        );
+    }
 }


### PR DESCRIPTION
As reported by Neodyme:

> `get_target_balance` has a weird API design. Why would you reuse an old target_balance array instead of creating a new one? This is an issue if the input is not all-zero and some validators are disabled, since their will not get overwritten. But because of your sanity-check for total_lamports_distributed this will simply cause an assertion failure. Currently, the only place that uses this function uses an all-zero input

I’m not sure why I went with the mutable argument, returning a vec is nicer indeed, this pull request implements that.

Also, as reported by Neodyme:

> `get_validator_furthest_below_target` can return an inactive validator, even if the inactive validator has a target of 0, if it is the first validator and all other validators have reached their target (I think this cannot actually happen right now. But it might be acheivable after you restructure your staking logic.)

This pull request fixes that as well. If there is no active validator, `get_validator_furthest_below_target` will panic, but that’s fine, because `get_target_balance` returns an `Err` when there are no active validators, so we should never get tot a point where `get_validator_furthest_below_target` is called with no active validators.