### PR TITLE
Refuse to collect fees from foreign vote accounts

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -835,6 +835,9 @@ pub fn process_collect_validator_fee(
     let clock = Clock::from_account_info(accounts.sysvar_clock)?;
     lido.check_exchange_rate_last_epoch(&clock, "CollectValidatorFee")?;
 
+    // Confirm that the vote account passed in is actually part of the validator set.
+    lido.validators.get(accounts.validator_vote_account.key)?;
+
     let rewards_withdraw_authority = lido.check_rewards_withdraw_authority(
         program_id,
         accounts.lido.key,


### PR DESCRIPTION
This was an issue caught by @joncinque: in `CollectValidatorFee`, we never checked that the validator was part of Solido. While I don’t believe this would have any negative consequences, we should still check this, especially in case we make a change to `CollectValidatorFee` in the future and we don’t realize that we did not check this.

I also added a regression test, and I wrote the test first to confirm that it would have caught the bug.