### PR TITLE
Add script to propose multisig transactions for validators, and to verify these transactions

### DIFF
--- a/scripts/propose_add_validators.py
+++ b/scripts/propose_add_validators.py
@@ -35,11 +35,15 @@ def main() -> None:
                 '--output',
                 'json',
                 'add-validator',
-                '--validator-vote-account', row.vote_account_address,
-                '--validator-fee-account', row.st_sol_account_address,
+                '--validator-vote-account',
+                row.vote_account_address,
+                '--validator-fee-account',
+                row.st_sol_account_address,
             ]
             try:
-                result = subprocess.run(cmd, check=True, capture_output=True, encoding='utf-8')
+                result = subprocess.run(
+                    cmd, check=True, capture_output=True, encoding='utf-8'
+                )
 
             except subprocess.CalledProcessError as exc:
                 print('Command failed:', ' '.join(cmd))
@@ -48,7 +52,9 @@ def main() -> None:
                 sys.exit(1)
 
             transaction_address = json.loads(result.stdout)['transaction_address']
-            transaction_file.write(f'{transaction_address}  # Add {row.validator_name}\n')
+            transaction_file.write(
+                f'{transaction_address}  # Add {row.validator_name}\n'
+            )
             transaction_file.flush()
             print(f'-> {transaction_address}')
 

--- a/scripts/propose_add_validators.py
+++ b/scripts/propose_add_validators.py
@@ -17,38 +17,7 @@ import json
 import subprocess
 import sys
 
-from typing import Iterable, NamedTuple
-
-
-# A type alias to make some things more self-documenting.
-Address = str
-
-
-class ValidatorResponse(NamedTuple):
-    timestamp: str
-    email: str
-    validator_name: str
-    keybase_username: str
-    vote_account_address: Address
-    withdraw_authority_check: Address
-    commission_check: str
-    will_vote_check: str
-    st_sol_account_address: Address
-    st_sol_mint_check: Address
-    added_to_keybase_check: str
-    identity_name: str
-    unused: str = ''
-    maintainer_address: Address = ''
-
-
-def iter_rows_from_stdin() -> Iterable[ValidatorResponse]:
-    """
-    Yield rows from stdin, including header, excluding blank lines.
-    """
-    for line in sys.stdin:
-        if line.strip() == '':
-            continue
-        yield ValidatorResponse(*line.strip().split('\t'))
+from validator_onboarding import iter_rows_from_stdin
 
 
 def main() -> None:
@@ -58,10 +27,6 @@ def main() -> None:
 
     with open(sys.argv[2], 'w', encoding='utf-8') as transaction_file:
         for row in iter_rows_from_stdin():
-            if row.timestamp == 'Timestamp':
-                # This is the header row, skip over it.
-                continue
-
             print(f'Creating transaction to add {row.validator_name} ...')
             cmd = [
                 'target/debug/solido',

--- a/scripts/propose_add_validators.py
+++ b/scripts/propose_add_validators.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 Chorus One AG
+# SPDX-License-Identifier: GPL-3.0
+
+"""
+This script reads the validator onboarding form responses, and calls "solido add-validator"
+to propose adding those validators. It expects you have a Solido config file ready
+with the right signer configured.
+
+Usage:
+
+    scripts/propose_add_validators.py solido_config.json transactions.txt < validators.tsv
+"""
+
+import json
+import subprocess
+import sys
+
+from typing import Iterable, NamedTuple
+
+
+# A type alias to make some things more self-documenting.
+Address = str
+
+
+class ValidatorResponse(NamedTuple):
+    timestamp: str
+    email: str
+    validator_name: str
+    keybase_username: str
+    vote_account_address: Address
+    withdraw_authority_check: Address
+    commission_check: str
+    will_vote_check: str
+    st_sol_account_address: Address
+    st_sol_mint_check: Address
+    added_to_keybase_check: str
+    identity_name: str
+    unused: str = ''
+    maintainer_address: Address = ''
+
+
+def iter_rows_from_stdin() -> Iterable[ValidatorResponse]:
+    """
+    Yield rows from stdin, including header, excluding blank lines.
+    """
+    for line in sys.stdin:
+        if line.strip() == '':
+            continue
+        yield ValidatorResponse(*line.strip().split('\t'))
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+
+    with open(sys.argv[2], 'w', encoding='utf-8') as transaction_file:
+        for row in iter_rows_from_stdin():
+            if row.timestamp == 'Timestamp':
+                # This is the header row, skip over it.
+                continue
+
+            print(f'Creating transaction to add {row.validator_name} ...')
+            cmd = [
+                'target/debug/solido',
+                '--config',
+                sys.argv[1],
+                '--output',
+                'json',
+                'add-validator',
+                '--validator-vote-account', row.vote_account_address,
+                '--validator-fee-account', row.st_sol_account_address,
+            ]
+            try:
+                result = subprocess.run(cmd, check=True, capture_output=True, encoding='utf-8')
+
+            except subprocess.CalledProcessError as exc:
+                print('Command failed:', ' '.join(cmd))
+                print(exc.stdout)
+                print(exc.stderr)
+                sys.exit(1)
+
+            transaction_address = json.loads(result.stdout)['transaction_address']
+            transaction_file.write(f'{transaction_address}  # Add {row.validator_name}\n')
+            transaction_file.flush()
+            print(f'-> {transaction_address}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/validator_onboarding.py
+++ b/scripts/validator_onboarding.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2021 Chorus One AG
+# SPDX-License-Identifier: GPL-3.0
+
+import sys
+
+from typing import Iterable, NamedTuple
+
+Address = str
+
+class ValidatorResponse(NamedTuple):
+    """
+    This struct mirrors the columns in the response sheet of the validator
+    onboarding form.
+    """
+    timestamp: str
+    email: str
+    validator_name: str
+    keybase_username: str
+    vote_account_address: Address
+    withdraw_authority_check: Address
+    commission_check: str
+    will_vote_check: str
+    st_sol_account_address: Address
+    st_sol_mint_check: Address
+    added_to_keybase_check: str
+    identity_name: str
+    unused: str = ''
+    maintainer_address: Address = ''
+
+
+def iter_rows_from_stdin() -> Iterable[ValidatorResponse]:
+    """
+    Yield rows from stdin, excluding header, excluding blank lines.
+    """
+    for line in sys.stdin:
+        if line.strip() == '':
+            continue
+
+        result = ValidatorResponse(*line.strip().split('\t'))
+
+        if result.timestamp == 'Timestamp':
+            # This is the header row
+            continue
+
+        yield result

--- a/scripts/validator_onboarding.py
+++ b/scripts/validator_onboarding.py
@@ -45,3 +45,25 @@ def iter_rows_from_stdin() -> Iterable[ValidatorResponse]:
             continue
 
         yield result
+
+
+def print_color(message: str, *, ansi_color_code: str, end: str = '\n') -> None:
+    # Switch to the given color, print the message, then reset formatting.
+    print(f'\x1b[{ansi_color_code}m{message}\x1b[0m', end=end)
+
+
+def print_error(message: str) -> None:
+    # 31 is red.
+    print_color(f'ERROR {message}', ansi_color_code='31')
+
+
+def print_ok(message: str) -> None:
+    # 32 is green. For OK, we only make the prefix green, not the entire message,
+    # to make validation failures stand out more.
+    print_color(f'OK   ', ansi_color_code='32', end=' ')
+    print(message)
+
+
+def print_warn(message: str) -> None:
+    # 33 is yellow.
+    print_color(f'WARN  {message}', ansi_color_code='33')

--- a/scripts/validator_onboarding.py
+++ b/scripts/validator_onboarding.py
@@ -7,11 +7,13 @@ from typing import Iterable, NamedTuple
 
 Address = str
 
+
 class ValidatorResponse(NamedTuple):
     """
     This struct mirrors the columns in the response sheet of the validator
     onboarding form.
     """
+
     timestamp: str
     email: str
     validator_name: str

--- a/scripts/verify_multisig_transactions.py
+++ b/scripts/verify_multisig_transactions.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 Chorus One AG
+# SPDX-License-Identifier: GPL-3.0
+
+"""
+This script verifies transactions created by `propose_add_validators.py` against
+validator form submissions from on stdin.
+
+Usage:
+
+    scripts/verify_multisig_transactions.py solido_config.json transactions.txt < validators.tsv
+"""
+
+import sys
+import subprocess
+import json
+
+from validator_onboarding import Address, ValidatorResponse, iter_rows_from_stdin
+from validator_onboarding import print_ok, print_error
+from typing import Iterable
+
+
+SOLIDO_ADDRESS = '49Yi1TKkNyYjPAFdR9LBvoHcUjuPX4Df5T5yv39w2XTn'
+
+
+def iter_transaction_addresses() -> Iterable[Address]:
+    with open(sys.argv[2], 'r', encoding='utf-8') as f:
+        for line in f:
+            # The first word on the line is the transaction address,
+            # we ignore any content after that.
+            yield line.split()[0]
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+
+    for form_response, transaction_address in zip(iter_rows_from_stdin(), iter_transaction_addresses()):
+        print(f'\n{form_response.validator_name}:')
+        cmd = [
+            'target/debug/solido',
+            '--config',
+            sys.argv[1],
+            '--output',
+            'json',
+            'multisig',
+            'show-transaction',
+            '--transaction-address',
+            transaction_address,
+        ]
+        result = subprocess.run(
+            cmd, check=True, capture_output=True, encoding='utf-8'
+        )
+        transaction = json.loads(result.stdout)
+        instruction = transaction.get('parsed_instruction', {}).get('SolidoInstruction', {}).get('AddValidator')
+
+        if instruction is None:
+            print_error('Instruction is not an AddValidator instruction.')
+        else:
+            print_ok('Instruction is an AddValidator instruction.')
+
+        if form_response.vote_account_address == instruction['validator_vote_account']:
+            print_ok('Validator vote account in form response matches instruction.')
+        else:
+            print_error('Validator vote account in form response does not match instruction.')
+
+        if form_response.st_sol_account_address == instruction['validator_fee_st_sol_account']:
+            print_ok('Fee stSOL account in form response matches instruction.')
+        else:
+            print_error('Fee stSOL account in form response does not match instruction.')
+
+        if instruction['solido_instance'] == SOLIDO_ADDRESS:
+            print_ok('Solido instance is the mainnet instance.')
+        else:
+            print_error('Solido instance is not the mainnet instance.')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/verify_multisig_transactions.py
+++ b/scripts/verify_multisig_transactions.py
@@ -37,7 +37,9 @@ def main() -> None:
         print(__doc__)
         sys.exit(1)
 
-    for form_response, transaction_address in zip(iter_rows_from_stdin(), iter_transaction_addresses()):
+    for form_response, transaction_address in zip(
+        iter_rows_from_stdin(), iter_transaction_addresses()
+    ):
         print(f'\n{form_response.validator_name}:')
         cmd = [
             'target/debug/solido',
@@ -50,11 +52,13 @@ def main() -> None:
             '--transaction-address',
             transaction_address,
         ]
-        result = subprocess.run(
-            cmd, check=True, capture_output=True, encoding='utf-8'
-        )
+        result = subprocess.run(cmd, check=True, capture_output=True, encoding='utf-8')
         transaction = json.loads(result.stdout)
-        instruction = transaction.get('parsed_instruction', {}).get('SolidoInstruction', {}).get('AddValidator')
+        instruction = (
+            transaction.get('parsed_instruction', {})
+            .get('SolidoInstruction', {})
+            .get('AddValidator')
+        )
 
         if instruction is None:
             print_error('Instruction is not an AddValidator instruction.')
@@ -64,12 +68,19 @@ def main() -> None:
         if form_response.vote_account_address == instruction['validator_vote_account']:
             print_ok('Validator vote account in form response matches instruction.')
         else:
-            print_error('Validator vote account in form response does not match instruction.')
+            print_error(
+                'Validator vote account in form response does not match instruction.'
+            )
 
-        if form_response.st_sol_account_address == instruction['validator_fee_st_sol_account']:
+        if (
+            form_response.st_sol_account_address
+            == instruction['validator_fee_st_sol_account']
+        ):
             print_ok('Fee stSOL account in form response matches instruction.')
         else:
-            print_error('Fee stSOL account in form response does not match instruction.')
+            print_error(
+                'Fee stSOL account in form response does not match instruction.'
+            )
 
         if instruction['solido_instance'] == SOLIDO_ADDRESS:
             print_ok('Solido instance is the mainnet instance.')

--- a/scripts/verify_validator_submissions.py
+++ b/scripts/verify_validator_submissions.py
@@ -6,24 +6,7 @@
 """
 This script verifies details provided by validators that are onboarding.
 
-Takes tab-separated values on stdin with the following columns:
-
- * Timestamp
- * Email address
- * Validator name
- * Keybase account name
- * Vote account
- * (Withdraw authority check, constant)
- * (Commission percentage check, constant)
- * (Vote promise check, constant)
- * stSOL account
- * (stSOL account mint check, constant)
- * (Added public key to keybase check)
- * Identity name as published on identity account
- * (unused column, optional)
- * Maintainer address (if applicable; optional)
-
-This script then verifies:
+Takes tab-separated form responses on stdin. This script then verifies:
 
  * The vote account withdraw authority.
  * The vote account commission.
@@ -43,18 +26,15 @@ the tsv file manually to confirm that no weird Keybase usernames etc. are in the
 
 import json
 import subprocess
-import sys
 
 from typing import Any, Dict, Iterable, NamedTuple, Optional
+from validator_onboarding import Address, ValidatorResponse, iter_rows_from_stdin
 
 
 SOLIDO_AUTHORIZED_WITHDAWER = 'GgrQiJ8s2pfHsfMbEFtNcejnzLegzZ16c9XtJ2X2FpuF'
 ST_SOL_MINT = '7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj'
 VOTE_PROGRAM = 'Vote111111111111111111111111111111111111111'
 SPL_TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-
-# A type alias to make some things more self-documenting.
-Address = str
 
 
 def solana(*args: str) -> Any:
@@ -175,161 +155,136 @@ def print_warn(message: str) -> None:
     print_color(f'WARN  {message}', ansi_color_code='33')
 
 
-class ValidatorResponse(NamedTuple):
-    timestamp: str
-    email: str
-    validator_name: str
-    keybase_username: str
-    vote_account_address: Address
-    withdraw_authority_check: Address
-    commission_check: str
-    will_vote_check: str
-    st_sol_account_address: Address
-    st_sol_mint_check: Address
-    added_to_keybase_check: str
-    identity_name: str
-    unused: str = ''
-    maintainer_address: Address = ''
-
-    def get_vote_account(self) -> Optional[VoteAccount]:
-        try:
-            result = solana(
-                'vote-account', '--output', 'json', self.vote_account_address
-            )
-            return VoteAccount(
-                validator_identity_address=result['validatorIdentity'],
-                authorized_withdrawer=result['authorizedWithdrawer'],
-                commission=result['commission'],
-                num_votes=len(result['votes']),
-            )
-
-        except subprocess.CalledProcessError:
-            return None
-
-    def check(
-        self,
-        validators_by_identity: Dict[Address, ValidatorInfo],
-        vote_accounts: Dict[Address, str],
-        identity_accounts: Dict[Address, str],
-        st_sol_accounts: Dict[Address, str],
-    ) -> None:
-        print('\n' + self.validator_name)
-        vote_account = self.get_vote_account()
-
-        if vote_account is not None:
-            print_ok('Vote account address holds a vote account.')
-        else:
-            print_error('Vote account address does not hold a vote account.')
-            return
-
-        if vote_account.authorized_withdrawer == SOLIDO_AUTHORIZED_WITHDAWER:
-            print_ok('Authorized withdrawer set to Solido.')
-        else:
-            print_error('Wrong authorized withdrawer.')
-
-        if vote_account.num_votes > 0:
-            print_ok('Vote account has votes.')
-        else:
-            print_warn('Vote account has not voted yet.')
-
-        if vote_account.commission == 100:
-            print_ok('Vote account commission is 100%.')
-        else:
-            print_error('Vote account commission is not 100%.')
-
-        validator_info = validators_by_identity.get(
-            vote_account.validator_identity_address
+def get_vote_account(self: ValidatorResponse) -> Optional[VoteAccount]:
+    try:
+        result = solana(
+            'vote-account', '--output', 'json', self.vote_account_address
         )
-        if validator_info is None:
-            print_error('Validator identity does not exist.')
-            return
-        else:
-            print_ok('Validator identity exists.')
-
-        if validator_info.keybase_username == self.keybase_username:
-            print_ok('Keybase username in form matches username in identity account.')
-        else:
-            print_error('Keybase username in identity account does not match the form.')
-
-        if validator_info.name is not None and validator_info.name.startswith(
-            'Lido / '
-        ):
-            print_ok('Validator identity name starts with "Lido / ".')
-        else:
-            print_error('Validator identity name does not start with "Lido / ".')
-
-        if validator_info.name == self.identity_name:
-            print_ok('Name in identity account matches name in form.')
-        else:
-            print_error('Name in identity account does not mach name in form.')
-
-        if check_keybase_has_identity_address(
-            self.keybase_username, vote_account.validator_identity_address
-        ):
-            print_ok(
-                f'Validator identity public key is on Keybase under {self.keybase_username}.'
-            )
-        else:
-            print_error('Could not verify validator identity through Keybase.')
-
-        token_account = get_token_account(self.st_sol_account_address)
-        if token_account is not None:
-            print_ok('Fee account exists.')
-        else:
-            print_error(f'Fee account {self.st_sol_account_address} does not exist.')
-            return
-
-        if token_account.state == "initialized":
-            print_ok('Token account is in an initialized state.')
-        else:
-            print_error('Token account is not initialized state.')
-
-        if token_account.mint_address == ST_SOL_MINT:
-            print_ok('Fee account is an stSOL account (it has the correct mint).')
-        else:
-            print_error('Fee account is not an stSOL account, the mint is wrong.')
-
-        name = vote_accounts.setdefault(self.vote_account_address, self.validator_name)
-        if name != self.validator_name:
-            print_error(f'Vote account is already in use by {name}.')
-        else:
-            print_ok('Vote account address is unique among responses seen so far.')
-
-        name = identity_accounts.setdefault(
-            vote_account.validator_identity_address, self.validator_name
+        return VoteAccount(
+            validator_identity_address=result['validatorIdentity'],
+            authorized_withdrawer=result['authorizedWithdrawer'],
+            commission=result['commission'],
+            num_votes=len(result['votes']),
         )
-        if name != self.validator_name:
-            print_error(f'Identity account is already in use by {name}.')
-        else:
-            print_ok('Identity account is unique among responses seen so far.')
 
-        name = st_sol_accounts.setdefault(
-            self.st_sol_account_address, self.validator_name
+    except subprocess.CalledProcessError:
+        return None
+
+
+def check_validator_response(
+    self: ValidatorResponse,
+    validators_by_identity: Dict[Address, ValidatorInfo],
+    vote_accounts: Dict[Address, str],
+    identity_accounts: Dict[Address, str],
+    st_sol_accounts: Dict[Address, str],
+) -> None:
+    print('\n' + self.validator_name)
+    vote_account = get_vote_account(self)
+
+    if vote_account is not None:
+        print_ok('Vote account address holds a vote account.')
+    else:
+        print_error('Vote account address does not hold a vote account.')
+        return
+
+    if vote_account.authorized_withdrawer == SOLIDO_AUTHORIZED_WITHDAWER:
+        print_ok('Authorized withdrawer set to Solido.')
+    else:
+        print_error('Wrong authorized withdrawer.')
+
+    if vote_account.num_votes > 0:
+        print_ok('Vote account has votes.')
+    else:
+        print_warn('Vote account has not voted yet.')
+
+    if vote_account.commission == 100:
+        print_ok('Vote account commission is 100%.')
+    else:
+        print_error('Vote account commission is not 100%.')
+
+    validator_info = validators_by_identity.get(
+        vote_account.validator_identity_address
+    )
+    if validator_info is None:
+        print_error('Validator identity does not exist.')
+        return
+    else:
+        print_ok('Validator identity exists.')
+
+    if validator_info.keybase_username == self.keybase_username:
+        print_ok('Keybase username in form matches username in identity account.')
+    else:
+        print_error('Keybase username in identity account does not match the form.')
+
+    if validator_info.name is not None and validator_info.name.startswith(
+        'Lido / '
+    ):
+        print_ok('Validator identity name starts with "Lido / ".')
+    else:
+        print_error('Validator identity name does not start with "Lido / ".')
+
+    if validator_info.name == self.identity_name:
+        print_ok('Name in identity account matches name in form.')
+    else:
+        print_error('Name in identity account does not mach name in form.')
+
+    if check_keybase_has_identity_address(
+        self.keybase_username, vote_account.validator_identity_address
+    ):
+        print_ok(
+            f'Validator identity public key is on Keybase under {self.keybase_username}.'
         )
-        if name != self.validator_name:
-            print_error(f'Fee stSOL account is already in use by {name}.')
-        else:
-            print_ok('Fee stSOL account is unique among responses seen so far.')
+    else:
+        print_error('Could not verify validator identity through Keybase.')
 
-        if get_account_owner(self.vote_account_address) == VOTE_PROGRAM:
-            print_ok('Vote account is owned by the vote program.')
-        else:
-            print_error('Vote account is not owned by the vote program.')
+    token_account = get_token_account(self.st_sol_account_address)
+    if token_account is not None:
+        print_ok('Fee account exists.')
+    else:
+        print_error(f'Fee account {self.st_sol_account_address} does not exist.')
+        return
 
-        if get_account_owner(self.st_sol_account_address) == SPL_TOKEN_PROGRAM:
-            print_ok('Fee stSOL account is owned by the SPL token program.')
-        else:
-            print_error('Fee stSOL account is not owned by the SPL token program.')
+    if token_account.state == "initialized":
+        print_ok('Token account is in an initialized state.')
+    else:
+        print_error('Token account is not initialized state.')
 
+    if token_account.mint_address == ST_SOL_MINT:
+        print_ok('Fee account is an stSOL account (it has the correct mint).')
+    else:
+        print_error('Fee account is not an stSOL account, the mint is wrong.')
 
-def iter_rows_from_stdin() -> Iterable[ValidatorResponse]:
-    """
-    Yield rows from stdin, including header, excluding blank lines.
-    """
-    for line in sys.stdin:
-        if line.strip() == '':
-            continue
-        yield ValidatorResponse(*line.strip().split('\t'))
+    name = vote_accounts.setdefault(self.vote_account_address, self.validator_name)
+    if name != self.validator_name:
+        print_error(f'Vote account is already in use by {name}.')
+    else:
+        print_ok('Vote account address is unique among responses seen so far.')
+
+    name = identity_accounts.setdefault(
+        vote_account.validator_identity_address, self.validator_name
+    )
+    if name != self.validator_name:
+        print_error(f'Identity account is already in use by {name}.')
+    else:
+        print_ok('Identity account is unique among responses seen so far.')
+
+    name = st_sol_accounts.setdefault(
+        self.st_sol_account_address, self.validator_name
+    )
+    if name != self.validator_name:
+        print_error(f'Fee stSOL account is already in use by {name}.')
+    else:
+        print_ok('Fee stSOL account is unique among responses seen so far.')
+
+    if get_account_owner(self.vote_account_address) == VOTE_PROGRAM:
+        print_ok('Vote account is owned by the vote program.')
+    else:
+        print_error('Vote account is not owned by the vote program.')
+
+    if get_account_owner(self.st_sol_account_address) == SPL_TOKEN_PROGRAM:
+        print_ok('Fee stSOL account is owned by the SPL token program.')
+    else:
+        print_error('Fee stSOL account is not owned by the SPL token program.')
 
 
 def main() -> None:
@@ -346,12 +301,9 @@ def main() -> None:
     identity_accounts: Dict[str, str] = {}
     st_sol_accounts: Dict[str, str] = {}
 
-    for row in iter_rows_from_stdin():
-        if row.timestamp == 'Timestamp':
-            # This is the header row, skip over it.
-            continue
-
-        row.check(
+    for response in iter_rows_from_stdin():
+        check_validator_response(
+            response,
             validators_by_identity,
             vote_accounts,
             identity_accounts,

--- a/scripts/verify_validator_submissions.py
+++ b/scripts/verify_validator_submissions.py
@@ -29,6 +29,7 @@ import subprocess
 
 from typing import Any, Dict, Iterable, NamedTuple, Optional
 from validator_onboarding import Address, ValidatorResponse, iter_rows_from_stdin
+from validator_onboarding import print_ok, print_warn, print_error
 
 
 SOLIDO_AUTHORIZED_WITHDAWER = 'GgrQiJ8s2pfHsfMbEFtNcejnzLegzZ16c9XtJ2X2FpuF'
@@ -131,28 +132,6 @@ class VoteAccount(NamedTuple):
     authorized_withdrawer: Address
     commission: int
     num_votes: int
-
-
-def print_color(message: str, *, ansi_color_code: str, end: str = '\n') -> None:
-    # Switch to the given color, print the message, then reset formatting.
-    print(f'\x1b[{ansi_color_code}m{message}\x1b[0m', end=end)
-
-
-def print_error(message: str) -> None:
-    # 31 is red.
-    print_color(f'ERROR {message}', ansi_color_code='31')
-
-
-def print_ok(message: str) -> None:
-    # 32 is green. For OK, we only make the prefix green, not the entire message,
-    # to make validation failures stand out more.
-    print_color(f'OK   ', ansi_color_code='32', end=' ')
-    print(message)
-
-
-def print_warn(message: str) -> None:
-    # 33 is yellow.
-    print_color(f'WARN  {message}', ansi_color_code='33')
 
 
 def get_vote_account(self: ValidatorResponse) -> Optional[VoteAccount]:

--- a/scripts/verify_validator_submissions.py
+++ b/scripts/verify_validator_submissions.py
@@ -157,9 +157,7 @@ def print_warn(message: str) -> None:
 
 def get_vote_account(self: ValidatorResponse) -> Optional[VoteAccount]:
     try:
-        result = solana(
-            'vote-account', '--output', 'json', self.vote_account_address
-        )
+        result = solana('vote-account', '--output', 'json', self.vote_account_address)
         return VoteAccount(
             validator_identity_address=result['validatorIdentity'],
             authorized_withdrawer=result['authorizedWithdrawer'],
@@ -202,9 +200,7 @@ def check_validator_response(
     else:
         print_error('Vote account commission is not 100%.')
 
-    validator_info = validators_by_identity.get(
-        vote_account.validator_identity_address
-    )
+    validator_info = validators_by_identity.get(vote_account.validator_identity_address)
     if validator_info is None:
         print_error('Validator identity does not exist.')
         return
@@ -216,9 +212,7 @@ def check_validator_response(
     else:
         print_error('Keybase username in identity account does not match the form.')
 
-    if validator_info.name is not None and validator_info.name.startswith(
-        'Lido / '
-    ):
+    if validator_info.name is not None and validator_info.name.startswith('Lido / '):
         print_ok('Validator identity name starts with "Lido / ".')
     else:
         print_error('Validator identity name does not start with "Lido / ".')
@@ -268,9 +262,7 @@ def check_validator_response(
     else:
         print_ok('Identity account is unique among responses seen so far.')
 
-    name = st_sol_accounts.setdefault(
-        self.st_sol_account_address, self.validator_name
-    )
+    name = st_sol_accounts.setdefault(self.st_sol_account_address, self.validator_name)
     if name != self.validator_name:
         print_error(f'Fee stSOL account is already in use by {name}.')
     else:


### PR DESCRIPTION
## Summary

We need to onboard 15 validators tomorrow. We have their details in a Google Form that we can export as tsv. We have a script to verify the responses (#410). Now there are two more things we need:

* A way for us to easily crease multisig transactions to add these validators.
* A way for multisig members to easily verify that they are approving the right thing.

This pull request adds two scripts that do just that.

## Details

I added a "parser" for the form response tsv in #410, extract it into a module so it can be reused.

* `propose_add_validators.py` iterates the validators and creates multisig transactions. It writes the transaction addresses to a file.
* `verify_multisig_transactions.py` takes the the file with transaction addresses, and also the tsv file of form responses, and checks that the vote account and fee account in the transaction match those in the form response.

After doing the verification, multisig members should be able to use `approve-batch` (#413) to approve the transactions one by one. I need to modify #413 to allow for the extra content after the transaction address.

CC @mkaczanowski we can use `propose_add_validators.py` tomorrow to create the multisig transactions, maybe you can have a look as well?