### PR TITLE
Make maintainer pick the validator with less stake

### DIFF
--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -429,10 +429,8 @@ impl SolidoState {
                 .expect("Failed to compute target balance.");
 
         let (validator_index, amount_below_target) =
-            lido::balance::get_validator_furthest_below_target(
-                &self.solido.validators,
-                &targets[..],
-            );
+            lido::balance::get_minimum_stake_validator(&self.solido.validators, &targets[..]);
+
         let validator = &self.solido.validators.entries[validator_index];
 
         let (stake_account_end, _bump_seed_end) = validator.find_stake_account_address(

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -429,7 +429,10 @@ impl SolidoState {
                 .expect("Failed to compute target balance.");
 
         let (validator_index, amount_below_target) =
-            lido::balance::get_minimum_stake_validator(&self.solido.validators, &targets[..]);
+            lido::balance::get_minimum_stake_validator_index_amount(
+                &self.solido.validators,
+                &targets[..],
+            );
 
         let validator = &self.solido.validators.entries[validator_index];
 

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -117,7 +117,7 @@ pub fn get_minimum_stake_validator(
     let mut index = validators
         .iter_entries()
         .position(|v| v.active)
-        .expect("get_validator_furthest_below_target requires at least one active validator.");
+        .expect("get_minimum_stake_validator requires at least one active validator.");
     let mut lowest_balance = validators.entries[index].entry.effective_stake_balance();
     let mut amount = Lamports(
         target_balance[index]

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -121,7 +121,7 @@ pub fn get_minimum_stake_validator_index_amount(
     let mut index = validators
         .iter_entries()
         .position(|v| v.active)
-        .expect("get_minimum_stake_validator requires at least one active validator.");
+        .expect("get_minimum_stake_validator_index_amount requires at least one active validator.");
     let mut lowest_balance = validators.entries[index].entry.effective_stake_balance();
     let mut amount = Lamports(
         target_balance[index]


### PR DESCRIPTION
The maintainer got stuck choosing the validator to stake because not necessarily the furthest from target has less stake. This PR makes the maintainer chose the validator that has less stake for the stake deposit instead of the furthest from the target.
Added a test to check that the validator with the minimum stake got chosen.
Addresses #422