### PR TITLE
Unstake active validators

### DIFF
--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -61,8 +61,8 @@ struct MaintenanceMetrics {
     /// Number of times we performed `RemoveValidator`.
     transactions_remove_validator: u64,
 
-    /// Number of times we performed `Unstake` on a validator for balancing purposes.
-    transactions_unstake_from_validator: u64,
+    /// Number of times we performed `Unstake` on an active validator for balancing purposes.
+    transactions_unstake_from_active_validator: u64,
 }
 
 impl MaintenanceMetrics {
@@ -136,8 +136,8 @@ impl MaintenanceMetrics {
                 self.transactions_unstake_from_inactive_validator += 1
             }
             MaintenanceOutput::RemoveValidator { .. } => self.transactions_remove_validator += 1,
-            MaintenanceOutput::UnstakeFromValidator { .. } => {
-                self.transactions_unstake_from_validator += 1
+            MaintenanceOutput::UnstakeFromActiveValidator { .. } => {
+                self.transactions_unstake_from_active_validator += 1
             }
         }
     }
@@ -291,7 +291,7 @@ impl<'a, 'b> Daemon<'a, 'b> {
             transactions_claim_validator_fee: 0,
             transactions_unstake_from_inactive_validator: 0,
             transactions_remove_validator: 0,
-            transactions_unstake_from_validator: 0,
+            transactions_unstake_from_active_validator: 0,
         };
         Daemon {
             config,

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -107,6 +107,8 @@ impl MaintenanceMetrics {
                         .with_label("operation", "UnstakeFromInactiveValidator".to_string()),
                     Metric::new(self.transactions_remove_validator)
                         .with_label("operation", "RemoveValidator".to_string()),
+                    Metric::new(self.transactions_unstake_from_active_validator)
+                        .with_label("operation", "UnstakeFromActiveValidator".to_string()),
                 ],
             },
         )?;

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -60,6 +60,9 @@ struct MaintenanceMetrics {
 
     /// Number of times we performed `RemoveValidator`.
     transactions_remove_validator: u64,
+
+    /// Number of times we performed `Unstake` on a validator for balancing purposes.
+    transactions_unstake_from_validator: u64,
 }
 
 impl MaintenanceMetrics {
@@ -133,6 +136,9 @@ impl MaintenanceMetrics {
                 self.transactions_unstake_from_inactive_validator += 1
             }
             MaintenanceOutput::RemoveValidator { .. } => self.transactions_remove_validator += 1,
+            MaintenanceOutput::UnstakeFromValidator { .. } => {
+                self.transactions_unstake_from_validator += 1
+            }
         }
     }
 }
@@ -285,6 +291,7 @@ impl<'a, 'b> Daemon<'a, 'b> {
             transactions_claim_validator_fee: 0,
             transactions_unstake_from_inactive_validator: 0,
             transactions_remove_validator: 0,
+            transactions_unstake_from_validator: 0,
         };
         Daemon {
             config,

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -358,7 +358,7 @@ impl SolidoState {
     const MINIMUM_WITHDRAW_AMOUNT: Lamports = Lamports(DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE * 100);
 
     // Threshold that will trigger unstake on validators.
-    // Expressed as a percentage between 0-1.
+    // Expressed as a percentage between 0-100.
     const UNBALANCE_THRESHOLD: u64 = 10;
     /// Read the state from the on-chain data.
     pub fn new(

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -891,16 +891,16 @@ impl SolidoState {
         let validator = &self.solido.validators.entries[validator_index];
         let stake_account = &self.validator_stake_accounts[validator_index][0];
 
-        let maximum_unstake = (validator.entry.effective_stake_balance()
-            - MINIMUM_STAKE_ACCOUNT_BALANCE)
-            .expect("Validator should always have the minimum amount.");
+        let maximum_unstake = (stake_account.1.balance.total() - MINIMUM_STAKE_ACCOUNT_BALANCE)
+            .expect("Stake account should always have the minimum amount.");
         // Get the maximum that can be unstaked from the stake account.  The
-        // minimum amongst the value to be unstaked, how much is in the stake
-        // account and the maximum that can be unstaked from the validator.
-        let amount = unstake_amount
-            .min(stake_account.1.balance.total())
-            .min(maximum_unstake);
-        if amount == Lamports(0) {
+        // minimum amongst the value to be unstaked, and the maximum that can be
+        // unstaked from the validator.
+        let amount = unstake_amount.min(maximum_unstake);
+
+        // If the amount unstaked would leave a stake account with less than
+        // `MINIMUM_STAKE_ACCOUNT_BALANCE` we shouldn't unstake it.
+        if amount < MINIMUM_STAKE_ACCOUNT_BALANCE {
             return None;
         }
 

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -867,7 +867,8 @@ impl SolidoState {
         None
     }
 
-    pub fn try_unstake_to_balance_validators(&self) -> Option<(Instruction, MaintenanceOutput)> {
+    /// Unstake from active validators in order to rebalance validators.
+    pub fn try_unstake_from_active_validators(&self) -> Option<(Instruction, MaintenanceOutput)> {
         // Get the target for each validator. Undelegated stake can be balanced
         // when staking with validators.
         let targets = lido::balance::get_target_balance(Lamports(0), &self.solido.validators)
@@ -890,7 +891,7 @@ impl SolidoState {
             let min_idx = unstake_amounts
                 .iter()
                 .enumerate()
-                .max_by(|(_, a), (_, b)| a.partial_cmp(b).expect("Order always exists"))
+                .max_by(|(_, &a), (_, &b)| a.partial_cmp(b).expect("Order always exists"))
                 .map(|(idx, _)| idx)?;
 
             let validator = &self.solido.validators.entries[min_idx];
@@ -1354,7 +1355,7 @@ pub fn try_perform_maintenance(
         .or_else(|| state.try_collect_validator_fee())
         // Same for updating the validator balance.
         .or_else(|| state.try_withdraw_inactive_stake())
-        .or_else(|| state.try_unstake_to_balance_validators())
+        .or_else(|| state.try_unstake_from_active_validators())
         .or_else(|| state.try_stake_deposit())
         .or_else(|| state.try_claim_validator_fee())
         .or_else(|| state.try_remove_validator());

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -910,31 +910,6 @@ impl SolidoState {
         } else {
             None
         }
-
-        // let mut instruction = None;
-        // for (validator, stake_accounts, unstake_amount) in izip!(
-        //     self.solido.validators.entries.iter(),
-        //     self.validator_stake_accounts.iter(),
-        //     unstake_amounts.iter()
-        // ) {
-        //     if unstake_amount > Lamports(0) {
-        //         instruction = Some(self.get_unstake_instruction(
-        //             validator,
-        //             &stake_accounts[0],
-        //             Lamports(unstake_amount),
-        //         ));
-        //     }
-
-        //     let ratio = (unstake_amount * 100) / validator.entry.effective_stake_balance().0;
-        //     if ratio > SolidoState::UNBALANCE_THRESHOLD {
-        //         rebalance = true;
-        //     }
-        // }
-        // if rebalance {
-        //     todo!()
-        // } else {
-        //     None
-        // }
     }
 
     /// Write metrics about the current Solido instance in Prometheus format.
@@ -1379,6 +1354,7 @@ pub fn try_perform_maintenance(
         .or_else(|| state.try_collect_validator_fee())
         // Same for updating the validator balance.
         .or_else(|| state.try_withdraw_inactive_stake())
+        .or_else(|| state.try_unstake_to_balance_validators())
         .or_else(|| state.try_stake_deposit())
         .or_else(|| state.try_claim_validator_fee())
         .or_else(|| state.try_remove_validator());

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -869,6 +869,9 @@ impl SolidoState {
 
     /// Unstake from active validators in order to rebalance validators.
     pub fn try_unstake_from_active_validators(&self) -> Option<(Instruction, MaintenanceOutput)> {
+        // Return None if there's no active validator to unstake from.
+        self.solido.validators.iter_active().next()?;
+
         // Get the target for each validator. Undelegated Lamports can be
         // sent when staking with validators.
         let targets = lido::balance::get_target_balance(Lamports(0), &self.solido.validators)

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -102,21 +102,45 @@ pub enum MaintenanceOutput {
         to_stake_seed: u64,
     },
 
-    UnstakeFromInactiveValidator {
-        #[serde(serialize_with = "serialize_b58")]
-        validator_vote_account: Pubkey,
-        #[serde(serialize_with = "serialize_b58")]
-        from_stake_account: Pubkey,
-        #[serde(serialize_with = "serialize_b58")]
-        to_unstake_account: Pubkey,
-        from_stake_seed: u64,
-        to_unstake_seed: u64,
-        amount: Lamports,
-    },
+    UnstakeFromInactiveValidator(Unstake),
     RemoveValidator {
         #[serde(serialize_with = "serialize_b58")]
         validator_vote_account: Pubkey,
     },
+    UnstakeFromValidator(Unstake),
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct Unstake {
+    #[serde(serialize_with = "serialize_b58")]
+    validator_vote_account: Pubkey,
+    #[serde(serialize_with = "serialize_b58")]
+    from_stake_account: Pubkey,
+    #[serde(serialize_with = "serialize_b58")]
+    to_unstake_account: Pubkey,
+    from_stake_seed: u64,
+    to_unstake_seed: u64,
+    amount: Lamports,
+}
+
+fn print_unstake(f: &mut fmt::Formatter, unstake: &Unstake) -> fmt::Result {
+    writeln!(
+        f,
+        "  Validator vote account: {}",
+        unstake.validator_vote_account
+    )?;
+    writeln!(
+        f,
+        "  Stake account:               {}, seed: {}",
+        unstake.from_stake_account, unstake.from_stake_seed
+    )?;
+    writeln!(
+        f,
+        "  Unstake account:             {}, seed: {}",
+        unstake.to_unstake_account, unstake.to_unstake_seed
+    )?;
+    writeln!(f, "  Amount:              {}", unstake.amount)?;
+    Ok(())
 }
 
 impl fmt::Display for MaintenanceOutput {
@@ -194,27 +218,13 @@ impl fmt::Display for MaintenanceOutput {
                     to_stake, to_stake_seed
                 )?;
             }
-            MaintenanceOutput::UnstakeFromInactiveValidator {
-                validator_vote_account,
-                from_stake_account,
-                to_unstake_account,
-                from_stake_seed,
-                to_unstake_seed,
-                amount,
-            } => {
+            MaintenanceOutput::UnstakeFromInactiveValidator(unstake) => {
                 writeln!(f, "Unstake from inactive validator")?;
-                writeln!(f, "  Validator vote account: {}", validator_vote_account)?;
-                writeln!(
-                    f,
-                    "  Stake account:               {}, seed: {}",
-                    from_stake_account, from_stake_seed
-                )?;
-                writeln!(
-                    f,
-                    "  Unstake account:             {}, seed: {}",
-                    to_unstake_account, to_unstake_seed
-                )?;
-                writeln!(f, "  Amount:              {}", amount)?;
+                print_unstake(f, unstake)?;
+            }
+            MaintenanceOutput::UnstakeFromValidator(unstake) => {
+                writeln!(f, "Unstake from validator")?;
+                print_unstake(f, unstake)?;
             }
             MaintenanceOutput::RemoveValidator {
                 validator_vote_account,
@@ -346,6 +356,10 @@ impl SolidoState {
     // accounts, the cost of validating signatures seems to dominate the
     // transaction cost.
     const MINIMUM_WITHDRAW_AMOUNT: Lamports = Lamports(DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE * 100);
+
+    // Threshold that will trigger unstake on validators.
+    // Expressed as a percentage between 0-1.
+    const UNBALANCE_THRESHOLD: u64 = 10;
     /// Read the state from the on-chain data.
     pub fn new(
         config: &mut SnapshotConfig,
@@ -531,6 +545,38 @@ impl SolidoState {
         Some((instruction, task))
     }
 
+    /// Returns a tuple with the unstake account address and the instruction to
+    /// unstake `amount` from it.
+    pub fn get_unstake_instruction(
+        &self,
+        validator: &PubkeyAndEntry<Validator>,
+        stake_account: &(Pubkey, StakeAccount),
+        amount: Lamports,
+    ) -> (Pubkey, Instruction) {
+        let (validator_unstake_account, _) = validator.find_stake_account_address(
+            &self.solido_program_id,
+            &self.solido_address,
+            validator.entry.unstake_seeds.end,
+            StakeType::Unstake,
+        );
+        let (stake_account_address, _) = stake_account;
+        (
+            validator_unstake_account,
+            lido::instruction::unstake(
+                &self.solido_program_id,
+                &lido::instruction::UnstakeAccountsMeta {
+                    lido: self.solido_address,
+                    maintainer: self.maintainer_address,
+                    validator_vote_account: validator.pubkey,
+                    source_stake_account: *stake_account_address,
+                    destination_unstake_account: validator_unstake_account,
+                    stake_authority: self.get_stake_authority(),
+                },
+                amount,
+            ),
+        )
+    }
+
     /// If there is a validator being deactivated, try to unstake its funds.
     pub fn try_unstake_from_inactive_validator(&self) -> Option<(Instruction, MaintenanceOutput)> {
         for (validator, stake_accounts) in self
@@ -555,37 +601,22 @@ impl SolidoState {
             if stake_accounts.first().is_none() {
                 continue;
             }
-            let (validator_unstake_account, _) = validator.find_stake_account_address(
-                &self.solido_program_id,
-                &self.solido_address,
-                validator.entry.unstake_seeds.end,
-                StakeType::Unstake,
-            );
             let (stake_account_address, stake_account_balance) = stake_accounts[0];
-            let task = MaintenanceOutput::UnstakeFromInactiveValidator {
+            let (unstake_account, unstake_instruction) = self.get_unstake_instruction(
+                validator,
+                &stake_accounts[0],
+                stake_account_balance.balance.total(),
+            );
+            let task = MaintenanceOutput::UnstakeFromInactiveValidator(Unstake {
                 validator_vote_account: validator.pubkey,
                 from_stake_account: stake_account_address,
-                to_unstake_account: validator_unstake_account,
+                to_unstake_account: unstake_account,
                 from_stake_seed: validator.entry.stake_seeds.begin,
                 to_unstake_seed: validator.entry.unstake_seeds.end,
                 amount: stake_account_balance.balance.total(),
-            };
+            });
 
-            return Some((
-                lido::instruction::unstake(
-                    &self.solido_program_id,
-                    &lido::instruction::UnstakeAccountsMeta {
-                        lido: self.solido_address,
-                        maintainer: self.maintainer_address,
-                        validator_vote_account: validator.pubkey,
-                        source_stake_account: stake_account_address,
-                        destination_unstake_account: validator_unstake_account,
-                        stake_authority: self.get_stake_authority(),
-                    },
-                    stake_account_balance.balance.total(),
-                ),
-                task,
-            ));
+            return Some((unstake_instruction, task));
         }
         None
     }
@@ -834,6 +865,76 @@ impl SolidoState {
         }
 
         None
+    }
+
+    pub fn try_unstake_to_balance_validators(&self) -> Option<(Instruction, MaintenanceOutput)> {
+        // Get the target for each validator. Undelegated stake can be balanced
+        // when staking with validators.
+        let targets = lido::balance::get_target_balance(Lamports(0), &self.solido.validators)
+            .expect("Failed to compute target balance.");
+        let unstake_amounts =
+            lido::balance::get_unstake_to_rebalance(&self.solido.validators, &targets);
+
+        let rebalance = self
+            .solido
+            .validators
+            .entries
+            .iter()
+            .zip(unstake_amounts.iter())
+            .any(|(validator, unstake_amount)| {
+                (unstake_amount.0 * 100) / validator.entry.effective_stake_balance().0
+                    > SolidoState::UNBALANCE_THRESHOLD
+            });
+
+        if rebalance {
+            let min_idx = unstake_amounts
+                .iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| a.partial_cmp(b).expect("Order always exists"))
+                .map(|(idx, _)| idx)?;
+
+            let validator = &self.solido.validators.entries[min_idx];
+            let stake_account = &self.validator_stake_accounts[min_idx][0];
+            let amount = unstake_amounts[min_idx];
+            let (unstake_account, instruction) =
+                self.get_unstake_instruction(validator, stake_account, amount);
+            let task = MaintenanceOutput::UnstakeFromInactiveValidator(Unstake {
+                validator_vote_account: validator.pubkey,
+                from_stake_account: stake_account.0,
+                to_unstake_account: unstake_account,
+                from_stake_seed: validator.entry.stake_seeds.begin,
+                to_unstake_seed: validator.entry.unstake_seeds.end,
+                amount: amount,
+            });
+            Some((instruction, task))
+        } else {
+            None
+        }
+
+        // let mut instruction = None;
+        // for (validator, stake_accounts, unstake_amount) in izip!(
+        //     self.solido.validators.entries.iter(),
+        //     self.validator_stake_accounts.iter(),
+        //     unstake_amounts.iter()
+        // ) {
+        //     if unstake_amount > Lamports(0) {
+        //         instruction = Some(self.get_unstake_instruction(
+        //             validator,
+        //             &stake_accounts[0],
+        //             Lamports(unstake_amount),
+        //         ));
+        //     }
+
+        //     let ratio = (unstake_amount * 100) / validator.entry.effective_stake_balance().0;
+        //     if ratio > SolidoState::UNBALANCE_THRESHOLD {
+        //         rebalance = true;
+        //     }
+        // }
+        // if rebalance {
+        //     todo!()
+        // } else {
+        //     None
+        // }
     }
 
     /// Write metrics about the current Solido instance in Prometheus format.

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -394,7 +394,7 @@ mod test {
                 denominator: 4,
             },
         );
-        assert_eq!(minimum_unstake, Some((&validators.entries[1], Lamports(4))));
+        assert_eq!(minimum_unstake, Some((1, Lamports(4))));
         let minimum_unstake = get_unstake_validator_index(
             &validators,
             &targets,
@@ -403,7 +403,7 @@ mod test {
                 denominator: 5,
             },
         );
-        assert_eq!(minimum_unstake, Some((&validators.entries[1], Lamports(4))));
+        assert_eq!(minimum_unstake, Some((1, Lamports(4))));
     }
 
     #[test]
@@ -445,6 +445,6 @@ mod test {
                 denominator: 1,
             },
         );
-        assert_eq!(minimum_unstake, Some((&validators.entries[0], Lamports(6))))
+        assert_eq!(minimum_unstake, Some((0, Lamports(6))))
     }
 }

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -104,7 +104,7 @@ pub fn get_target_balance(
 
 pub fn get_unstake_to_rebalance(
     validators: &Validators,
-    target_balance: &Vec<Lamports>,
+    target_balance: &[Lamports],
 ) -> Vec<Lamports> {
     let mut unstake_to_rebalance = Vec::new();
     for (validator, target) in validators.entries.iter().zip(target_balance) {
@@ -115,7 +115,7 @@ pub fn get_unstake_to_rebalance(
             .saturating_sub(target.0);
         unstake_to_rebalance.push(Lamports(unstake_amount));
     }
-    return unstake_to_rebalance;
+    unstake_to_rebalance
 }
 
 /// Given a list of validators and their target balance, return the index of the

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -102,6 +102,22 @@ pub fn get_target_balance(
     Ok(target_balance)
 }
 
+pub fn get_unstake_to_rebalance(
+    validators: &Validators,
+    target_balance: &Vec<Lamports>,
+) -> Vec<Lamports> {
+    let mut unstake_to_rebalance = Vec::new();
+    for (validator, target) in validators.entries.iter().zip(target_balance) {
+        let unstake_amount = validator
+            .entry
+            .effective_stake_balance()
+            .0
+            .saturating_sub(target.0);
+        unstake_to_rebalance.push(Lamports(unstake_amount));
+    }
+    return unstake_to_rebalance;
+}
+
 /// Given a list of validators and their target balance, return the index of the
 /// validator that has less stake, and the amount by which it is below its target.
 ///

--- a/program/src/balance.rs
+++ b/program/src/balance.rs
@@ -140,6 +140,9 @@ pub fn get_unstake_validator_index(
                 let target_difference = target
                     .0
                     .saturating_sub(validator.entry.effective_stake_balance().0);
+                if target == &Lamports(0) {
+                    return false;
+                }
                 (target_difference * 100) / target.0 >= threshold
             });
 
@@ -149,7 +152,10 @@ pub fn get_unstake_validator_index(
         .enumerate()
         .zip(unstake_amounts.iter())
         .find_map(|((idx, validator), unstake_amount)| {
-            if ((unstake_amount.0 * 100) / validator.entry.effective_stake_balance().0 >= threshold)
+            if validator.entry.effective_stake_balance() == Lamports(0) {
+                None
+            } else if ((unstake_amount.0 * 100) / validator.entry.effective_stake_balance().0
+                >= threshold)
                 || (unstake_amount > &Lamports(0) && needs_unstake)
             {
                 // If validator needs to be unstaked because if falls above the

--- a/program/src/token.rs
+++ b/program/src/token.rs
@@ -282,6 +282,22 @@ pub mod test {
             denominator: x.denominator,
         };
         assert_eq!(x.partial_cmp(&y), Some(std::cmp::Ordering::Less));
+        assert_eq!(y.partial_cmp(&x), Some(std::cmp::Ordering::Greater));
+    }
+
+    #[test]
+    fn test_equal_cmp() {
+        // Construct x and y such that x < y.
+        let x = Rational {
+            numerator: 1,
+            denominator: 1,
+        };
+        let y = Rational {
+            numerator: 1,
+            denominator: 1,
+        };
+        assert_eq!(x.partial_cmp(&y), Some(std::cmp::Ordering::Equal));
+        assert_eq!(y.partial_cmp(&x), Some(std::cmp::Ordering::Equal));
     }
 
     #[test]
@@ -295,10 +311,12 @@ pub mod test {
             denominator: x.denominator + 1,
         };
         assert_eq!(x.partial_cmp(&y), None);
+        assert_eq!(y.partial_cmp(&x), None);
         let y = Rational {
             numerator: x.numerator,
             denominator: x.denominator,
         };
         assert_eq!(x.partial_cmp(&y), None);
+        assert_eq!(y.partial_cmp(&x), None);
     }
 }

--- a/program/src/token.rs
+++ b/program/src/token.rs
@@ -30,8 +30,13 @@ pub struct Rational {
 
 impl PartialOrd for Rational {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        (self.numerator as f64 / self.denominator as f64)
-            .partial_cmp(&(other.numerator as f64 / other.denominator as f64))
+        if self.denominator == 0 || other.denominator == 0 {
+            None
+        } else {
+            let x = self.numerator as u128 * other.denominator as u128;
+            let y = other.numerator as u128 * self.denominator as u128;
+            Some(x.cmp(&y))
+        }
     }
 }
 
@@ -263,5 +268,37 @@ pub mod test {
 
         // Invalid character.
         assert!(Lamports::from_str("lol, sol").is_err());
+    }
+
+    #[test]
+    fn test_rational_cmp() {
+        // Construct x and y such that x < y.
+        let x = Rational {
+            numerator: 1 << 53,
+            denominator: 1,
+        };
+        let y = Rational {
+            numerator: x.numerator + 1,
+            denominator: x.denominator,
+        };
+        assert_eq!(x.partial_cmp(&y), Some(std::cmp::Ordering::Less));
+    }
+
+    #[test]
+    fn test_division_by_zero_cmp() {
+        let x = Rational {
+            numerator: 1,
+            denominator: 0,
+        };
+        let y = Rational {
+            numerator: x.numerator,
+            denominator: x.denominator + 1,
+        };
+        assert_eq!(x.partial_cmp(&y), None);
+        let y = Rational {
+            numerator: x.numerator,
+            denominator: x.denominator,
+        };
+        assert_eq!(x.partial_cmp(&y), None);
     }
 }

--- a/program/src/token.rs
+++ b/program/src/token.rs
@@ -22,10 +22,17 @@ use std::{
     ops::{Add, Div, Mul, Sub},
 };
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Rational {
     pub numerator: u64,
     pub denominator: u64,
+}
+
+impl PartialOrd for Rational {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        (self.numerator as f64 / self.denominator as f64)
+            .partial_cmp(&(other.numerator as f64 / other.denominator as f64))
+    }
 }
 
 /// Error returned when a calculation in a token type overflows, underflows, or divides by zero.

--- a/tests/test_solido.py
+++ b/tests/test_solido.py
@@ -30,6 +30,8 @@ from util import (
     spl_token,
 )
 
+from typing import Any, NamedTuple, Tuple
+
 # We start by generating an account that we will need later. We put the tests
 # keys in a directory where we can .gitignore them, so they don't litter the
 # working directory so much.
@@ -211,46 +213,66 @@ assert solido_instance['solido']['reward_distribution'] == {
     'st_sol_appreciation': 90,
 }
 
-print('\nAdding a validator ...')
 validator_fee_account_owner = create_test_account(
     'tests/.keys/validator-token-account-key.json'
 )
+
 print(f'> Validator token account owner: {validator_fee_account_owner}')
 
-validator = create_test_account('tests/.keys/validator-account-key.json')
-
-validator_vote_account = create_vote_account(
-    'tests/.keys/validator-vote-account-key.json',
-    validator.keypair_path,
-    solido_instance['rewards_withdraw_authority'],
-)
-print(f'> Creating validator vote account {validator_vote_account}')
-
-print(f'> Creating validator token account with owner {validator_fee_account_owner}')
-
 # Create SPL token
-validator_fee_account = create_spl_token_account(
-    'tests/.keys/validator-token-account-key.json', st_sol_mint_account
+fee_account = create_spl_token_account(
+    f'tests/.keys/validator-token-account-key.json', st_sol_mint_account
 )
-print(f'> Validator stSol token account: {validator_fee_account}')
+print(f'> Validator stSol token account: {fee_account}')
+
+
+class Validator(NamedTuple):
+    account: TestAccount
+    vote_account: TestAccount
+    fee_account: str
+
+
+def add_validator(keypath_account: str, keypath_vote: str) -> Tuple[Validator, Any]:
+    print('\nAdding a validator ...')
+    account = create_test_account(f'tests/.keys/{keypath_account}.json')
+    vote_account = create_vote_account(
+        f'tests/.keys/{keypath_vote}.json',
+        account.keypair_path,
+        solido_instance['rewards_withdraw_authority'],
+    )
+    print(f'> Creating validator vote account {vote_account}')
+    print(
+        f'> Creating validator token account with owner {validator_fee_account_owner}'
+    )
+
+    validator = Validator(
+        account=account, vote_account=vote_account, fee_account=fee_account
+    )
+
+    transaction_result = solido(
+        'add-validator',
+        '--multisig-program-id',
+        multisig_program_id,
+        '--solido-program-id',
+        solido_program_id,
+        '--solido-address',
+        solido_address,
+        '--validator-vote-account',
+        vote_account.pubkey,
+        '--validator-fee-account',
+        fee_account,
+        '--multisig-address',
+        multisig_instance,
+        keypair_path=test_addrs[1].keypair_path,
+    )
+    return (validator, transaction_result)
+
 
 print('> Call function to add validator')
-transaction_result = solido(
-    'add-validator',
-    '--multisig-program-id',
-    multisig_program_id,
-    '--solido-program-id',
-    solido_program_id,
-    '--solido-address',
-    solido_address,
-    '--validator-vote-account',
-    validator_vote_account.pubkey,
-    '--validator-fee-account',
-    validator_fee_account,
-    '--multisig-address',
-    multisig_instance,
-    keypair_path=test_addrs[1].keypair_path,
+(validator, transaction_result) = add_validator(
+    'validator-account-key', 'validator-vote-account-key'
 )
+
 transaction_address = transaction_result['transaction_address']
 transaction_status = multisig(
     'show-transaction',
@@ -298,10 +320,10 @@ solido_instance = solido(
 )
 
 assert solido_instance['solido']['validators']['entries'][0] == {
-    'pubkey': validator_vote_account.pubkey,
+    'pubkey': validator.vote_account.pubkey,
     'entry': {
         'fee_credit': 0,
-        'fee_address': validator_fee_account,
+        'fee_address': validator.fee_account,
         'stake_seeds': {
             'begin': 0,
             'end': 0,
@@ -442,7 +464,7 @@ def deposit(lamports: int, expect_created_token_account: bool = False) -> None:
     )
 
 
-deposit(lamports=1_000_000_000, expect_created_token_account=True)
+deposit(lamports=3_000_000_000, expect_created_token_account=True)
 
 print('\nRunning maintenance ...')
 result = solido(
@@ -455,8 +477,8 @@ result = solido(
 )
 expected_result = {
     'StakeDeposit': {
-        'validator_vote_account': validator_vote_account.pubkey,
-        'amount_lamports': int(1.0e9),
+        'validator_vote_account': validator.vote_account.pubkey,
+        'amount_lamports': int(3.0e9),
     }
 }
 stake_account_address = result['StakeDeposit']['stake_account']
@@ -464,7 +486,7 @@ del result['StakeDeposit'][
     'stake_account'
 ]  # This one we can't easily predict, don't compare it.
 assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
-print(f'> Staked deposit with {validator_vote_account}.')
+print(f'> Staked deposit with {validator.vote_account}.')
 
 print(
     '\nSimulating 0.0005 SOL deposit (too little to stake), then running maintenance ...'
@@ -484,6 +506,45 @@ result = solido(
 assert result is None, f'Huh, perform-maintenance performed {result}'
 print('> There was nothing to do, as expected.')
 
+# Adding another validator
+print('\nAdd another validator')
+(validator_1, transaction_result) = add_validator(
+    'validator-account-key-1',
+    'validator-vote-account-key-1',
+)
+
+transaction_address = transaction_result['transaction_address']
+transaction_status = multisig(
+    'show-transaction',
+    '--multisig-program-id',
+    multisig_program_id,
+    '--solido-program-id',
+    solido_program_id,
+    '--transaction-address',
+    transaction_address,
+)
+approve_and_execute(transaction_address, test_addrs[0])
+
+result = solido(
+    'perform-maintenance',
+    '--solido-address',
+    solido_address,
+    '--solido-program-id',
+    solido_program_id,
+    keypair_path=maintainer.keypair_path,
+)
+
+del result['UnstakeFromActiveValidator']['from_stake_account']
+del result['UnstakeFromActiveValidator']['to_unstake_account']
+expected_result = {
+    'UnstakeFromActiveValidator': {
+        'validator_vote_account': validator.vote_account.pubkey,
+        'from_stake_seed': 0,
+        'to_unstake_seed': 0,
+        'amount': 1500000000,
+    }
+}
+assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
 
 # By donating to the stake account, we trigger maintenance to run WithdrawInactiveStake.
 print(
@@ -500,11 +561,14 @@ result = solido(
     keypair_path=maintainer.keypair_path,
 )
 assert 'WithdrawInactiveStake' in result
-assert result['WithdrawInactiveStake'] == {
-    'validator_vote_account': validator_vote_account.pubkey,
-    'expected_difference_stake_lamports': 100_000_000,  # We donated 0.1 SOL.
-    'unstake_withdrawn_to_reserve_lamports': 0,  # Nothing was unstaked.
+expected_result = {
+    'WithdrawInactiveStake': {
+        'validator_vote_account': validator.vote_account.pubkey,
+        'expected_difference_stake_lamports': 100_000_000,  # We donated 0.1 SOL.
+        'unstake_withdrawn_to_reserve_lamports': 1_500_000_000,  # Half was unstaked for the newcomming validator.
+    }
 }
+assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
 
 print('> Performed WithdrawInactiveStake as expected.')
 
@@ -515,6 +579,48 @@ solana('transfer', '--allow-unfunded-recipient', reserve_account, '1.0')
 print(f'> Funded reserve {reserve_account} with 1.0 SOL')
 
 print('\nRunning maintenance ...')
+
+result = solido(
+    'perform-maintenance',
+    '--solido-address',
+    solido_address,
+    '--solido-program-id',
+    solido_program_id,
+    keypair_path=maintainer.keypair_path,
+)
+
+del result['StakeDeposit']['stake_account']
+expected_result = {
+    'StakeDeposit': {
+        'validator_vote_account': validator_1.vote_account.pubkey,
+        'amount_lamports': 2_050_250_000,
+    }
+}
+assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
+print('> Deposited to the second validator, as expected.')
+
+result = solido(
+    'perform-maintenance',
+    '--solido-address',
+    solido_address,
+    '--solido-program-id',
+    solido_program_id,
+    keypair_path=maintainer.keypair_path,
+)
+del result['UnstakeFromActiveValidator']['from_stake_account']
+del result['UnstakeFromActiveValidator']['to_unstake_account']
+expected_result = {
+    'UnstakeFromActiveValidator': {
+        'validator_vote_account': validator_1.vote_account.pubkey,
+        'from_stake_seed': 0,
+        'to_unstake_seed': 0,
+        'amount': 275_125_000,
+    }
+}
+assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
+print('> Unstaked from second validator, as expected.')
+
+
 result = solido(
     'perform-maintenance',
     '--solido-address',
@@ -524,15 +630,16 @@ result = solido(
     keypair_path=maintainer.keypair_path,
 )
 expected_result = {
-    'StakeDeposit': {
-        'validator_vote_account': validator_vote_account.pubkey,
-        # We have 1.0 SOL from the true deposit, and 1.0 donated.
-        'amount_lamports': int(2.0e9),
+    'WithdrawInactiveStake': {
+        'validator_vote_account': validator_1.vote_account.pubkey,
+        'expected_difference_stake_lamports': 0,
+        'unstake_withdrawn_to_reserve_lamports': 275_125_000,
     }
 }
-print('> Staked as expected.')
+assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
+print('> Withdrew inactive stake from second validator to the reserve, as expected.')
 
-print(f'\nDeactivating validator {validator_vote_account.pubkey} ...')
+print(f'\nDeactivating validator {validator.vote_account.pubkey} ...')
 transaction_result = solido(
     'deactivate-validator',
     '--multisig-program-id',
@@ -544,7 +651,7 @@ transaction_result = solido(
     '--solido-address',
     solido_address,
     '--validator-vote-account',
-    validator_vote_account.pubkey,
+    validator.vote_account.pubkey,
     keypair_path=test_addrs[0].keypair_path,
 )
 transaction_address = transaction_result['transaction_address']
@@ -590,10 +697,10 @@ del result['UnstakeFromInactiveValidator']['from_stake_account']
 del result['UnstakeFromInactiveValidator']['to_unstake_account']
 expected_result = {
     'UnstakeFromInactiveValidator': {
-        'validator_vote_account': validator_vote_account.pubkey,
+        'validator_vote_account': validator.vote_account.pubkey,
         'from_stake_seed': 0,
-        'to_unstake_seed': 0,
-        'amount': 2100500000,
+        'to_unstake_seed': 1,
+        'amount': 1_500_000_000,
     }
 }
 assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
@@ -608,7 +715,8 @@ solido_instance = solido(
 # Should have bumped the validator's `stake_seeds` and `unstake_seeds`.
 val = solido_instance['solido']['validators']['entries'][0]['entry']
 assert val['stake_seeds'] == {'begin': 1, 'end': 1}
-assert val['unstake_seeds'] == {'begin': 0, 'end': 1}
+assert val['unstake_seeds'] == {'begin': 1, 'end': 2}
+
 
 print('\nRunning maintenance (should withdraw from validator\'s unstake account) ...')
 result = solido(
@@ -621,12 +729,29 @@ result = solido(
 )
 expected_result = {
     'WithdrawInactiveStake': {
-        'validator_vote_account': validator_vote_account.pubkey,
+        'validator_vote_account': validator.vote_account.pubkey,
         'expected_difference_stake_lamports': 0,
-        'unstake_withdrawn_to_reserve_lamports': 2100500000,
+        'unstake_withdrawn_to_reserve_lamports': 1_500_000_000,
     }
 }
 assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
+
+print('\nRunning maintenance (should stake deposit to the second validator) ...')
+result = solido(
+    'perform-maintenance',
+    '--solido-address',
+    solido_address,
+    '--solido-program-id',
+    solido_program_id,
+    keypair_path=maintainer.keypair_path,
+)
+del result['StakeDeposit']['stake_account']
+expected_result = {
+    'StakeDeposit': {
+        'validator_vote_account': validator_1.vote_account.pubkey,
+        'amount_lamports': 4100500000,
+    }
+}
 
 print('\nRunning maintenance (should remove the validator) ...')
 result = solido(
@@ -639,7 +764,7 @@ result = solido(
 )
 expected_result = {
     'RemoveValidator': {
-        'validator_vote_account': validator_vote_account.pubkey,
+        'validator_vote_account': validator.vote_account.pubkey,
     }
 }
 assert result == expected_result, f'\nExpected: {expected_result}\nActual:   {result}'
@@ -653,5 +778,5 @@ solido_instance = solido(
 )
 number_validators = len(solido_instance['solido']['validators']['entries'])
 assert (
-    number_validators == 0
+    number_validators == 1
 ), f'\nExpected no validators\nGot: {number_validators} validators'


### PR DESCRIPTION
Adds a function in the maintainer to unstake Lamports from validators if there's the need of a rebalance.

There's a threshold (in %) for when to unstake from validators, the conditions for the unstake are:
- If the amount that should be unstaked is above the threshold.
- If there is some validator which needs to be staked and the amount is above the threshold.
- 
As discussed in #427 with @ruuda this PR implements and tests the unstaking logic.