### PR TITLE
Refactor maintainer

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -184,7 +184,11 @@ impl AsPrettyError for ClientError {
                 println!(" IO error\n\n{:?}", inner);
             }
             ClientErrorKind::Reqwest(inner) => {
-                println!(" \"Reqwest\" error\n\n{:?}", inner);
+                println!(" \"Reqwest\" error");
+                print_key("Message:");
+                println!(" {}", inner);
+                print_key("Raw:");
+                println!(" {:#?}", inner);
             }
             ClientErrorKind::RpcError(inner) => match inner {
                 RpcError::RpcRequestError(message) => {

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -222,7 +222,7 @@ impl fmt::Display for MaintenanceOutput {
 
 /// A snapshot of on-chain accounts relevant to Solido.
 pub struct SolidoState {
-    /// The time at which we finished querying the Solido state.
+    /// The label for the time at which we finished querying the Solido state.
     ///
     /// This is used in metrics to assign a timestamp to metrics that we proxy
     /// from the state and then expose to Prometheus. Because the time at which
@@ -234,6 +234,10 @@ pub struct SolidoState {
     /// that performed the query. However, when you run `solana-test-validator`,
     /// that timestamp goes out of date quickly, so use the actual observed time
     /// instead.
+    ///
+    /// This field holds the current datetime indicated by the OS, which is
+    /// useful for communicating that time externally (to Prometheus), but which
+    /// is not suitable for measuring durations.
     pub produced_at: SystemTime,
 
     pub solido_program_id: Pubkey,


### PR DESCRIPTION
This makes a few changes to how the maintenance daemon is set up:

 * Distinguish between failing to read the on-chain state (which is likely some connectivity problem), and successfully reading the on-chain state, but failing to perform maintenance (possibly because some other transaction raced us).

 * The latter error no longer blocks the on-chain state snapshot from being available in the metrics.

 * In the case of a connectivity problem, retry with exponential backoff with jitter, instead of retrying at the normal poll interval.

 * Don't randomize the poll interval in case of success. This was initially added to break ties when multiple maintainers are running, but we are going to solve that differently with [maintainer duties](https://github.com/ChorusOne/solido/issues/421), so this should no longer be necessary.

Fixes #420.