### PR TITLE
Introduce maintainer duties

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -634,13 +634,12 @@ cli_opt_struct! {
         #[clap(long)]
         listen: String => "0.0.0.0:8923".to_owned(),
 
-        // The expected wait time is half the max poll interval. A max poll interval
-        // of a few minutes should be plenty fast for a production deployment, but
-        // for testing you can reduce this value to make the daemon more responsive,
+        // A max poll interval of twice a minute should be plenty fast for a production deployment,
+        // but for testing you can reduce this value to make the daemon more responsive,
         // to eliminate some waiting time.
-        /// Maximum time to wait in seconds after there was no maintenance to perform, before checking again. Defaults to 120s
+        /// Maximum time to wait in seconds after there was no maintenance to perform, before checking again. Defaults to 30s
         #[clap(long)]
-        max_poll_interval_seconds: u64 => 120,
+        max_poll_interval_seconds: u64 => 30,
     }
 }
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -356,7 +356,6 @@ impl<'a, 'b> Daemon<'a, 'b> {
                 )
             });
 
-        let is_on_duty = is_on_duty_and_next_duty_slot.map(|(on_duty, _)| on_duty);
         let next_duty_slot = is_on_duty_and_next_duty_slot.and_then(|(_, slot)| slot);
 
         let sleep_time = next_duty_slot
@@ -378,9 +377,9 @@ impl<'a, 'b> Daemon<'a, 'b> {
 
         println!(
             "{}Sleeping until next iteration. Slot: {}, next duty slot: {}, block time: {}, sleep time: {}",
-            match is_on_duty {
-                Some(true) => "ON-DUTY  ",
-                Some(false) => "OFF-DUTY ",
+            match is_on_duty_and_next_duty_slot {
+                Some((true, _)) => "ON-DUTY  ",
+                Some((false, _)) => "OFF-DUTY ",
                 None => "",
             },
             fmt_option(self.block_time_estimator.get_most_recent_slot()),

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -366,13 +366,13 @@ impl<'a, 'b> Daemon<'a, 'b> {
         fn fmt_option<T: std::fmt::Debug>(opt_value: Option<T>) -> String {
             opt_value
                 .map(|x| format!("{:?}", x))
-                .unwrap_or("n/a".to_string())
+                .unwrap_or_else(|| "n/a".to_string())
         }
 
         fn fmt_option_duration(opt_value: Option<Duration>) -> String {
             opt_value
                 .map(|x| format!("{:.3}s", x.as_secs_f32()))
-                .unwrap_or("n/a".to_string())
+                .unwrap_or_else(|| "n/a".to_string())
         }
 
         println!(

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -362,12 +362,18 @@ impl<'a, 'b> Daemon<'a, 'b> {
                 .unwrap_or("n/a".to_string())
         }
 
+        fn fmt_option_duration(opt_value: Option<Duration>) -> String {
+            opt_value
+                .map(|x| format!("{:.3}s", x.as_secs_f32()))
+                .unwrap_or("n/a".to_string())
+        }
+
         println!(
-            "Sleeping until next iteration. Slot: {}, next duty slot: {}, block time: {}, sleep time: {:?}",
+            "Sleeping until next iteration. Slot: {}, next duty slot: {}, block time: {}, sleep time: {}",
             fmt_option(self.block_time_estimator.get_most_recent_slot()),
             fmt_option(next_duty_slot),
-            fmt_option(self.block_time_estimator.get_average_block_time()),
-            sleep_time,
+            fmt_option_duration(self.block_time_estimator.get_average_block_time()),
+            fmt_option_duration(Some(sleep_time)),
         );
 
         std::thread::sleep(sleep_time);

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -16,6 +16,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use rand::{rngs::ThreadRng, Rng};
+use solana_sdk::clock::{Clock, Slot};
 use tiny_http::{Request, Response, Server};
 
 use crate::config::RunMaintainerOpts;
@@ -190,6 +191,56 @@ fn run_maintenance_iteration(
     }
 }
 
+/// Helper to estimate block times based on observed slot values of the clock sysvar.
+///
+/// We keep a number of observations, and from that we compute the average block time.
+struct BlockTimeEstimator {
+    /// Observed values of the slot in the clock sysvar, and the instant at which we observed them.
+    observations: Vec<(Instant, Slot)>,
+}
+
+impl BlockTimeEstimator {
+    const NUM_OBSERVATIONS: usize = 10;
+
+    pub fn new() -> Self {
+        Self {
+            observations: Vec::with_capacity(Self::NUM_OBSERVATIONS),
+        }
+    }
+
+    pub fn observe_clock(&mut self, at: Instant, clock: &Clock) {
+        if self.observations.len() == Self::NUM_OBSERVATIONS {
+            self.observations.remove(0);
+        }
+        self.observations.push((at, clock.slot));
+    }
+
+    pub fn get_most_recent_slot(&self) -> Option<Slot> {
+        Some(self.observations.last()?.1)
+    }
+
+    pub fn get_average_block_time(&self) -> Option<Duration> {
+        let (t0, slot0) = self.observations.first()?;
+        let (t1, slot1) = self.observations.last()?;
+        let slots_elapsed = slot1.saturating_sub(*slot0);
+        let time_elapsed = t1.saturating_duration_since(*t0);
+        match slots_elapsed {
+            0 => None,
+            _ => Some(Duration::from_secs_f32(
+                time_elapsed.as_secs_f32() / slots_elapsed as f32,
+            )),
+        }
+    }
+
+    /// Return how long after the most recently observed clock we expect the given slot to occur.
+    pub fn estimate_time_until_slot(&self, target_slot: Slot) -> Option<Duration> {
+        let (_, slot) = self.observations.last()?;
+        let time_per_slot = self.get_average_block_time()?;
+        let slots_left = target_slot.saturating_sub(*slot) as u32;
+        Some(time_per_slot * slots_left)
+    }
+}
+
 /// Mutex that holds the latest snapshot.
 ///
 /// At startup it holds None, after that it will always hold Some Arc.
@@ -210,6 +261,9 @@ struct Daemon<'a, 'b> {
 
     /// The instant after we successfully queried the on-chain state for the last time.
     last_read_success: Instant,
+
+    /// Block time estimator used to tweak sleep times so we wake up for maintainer duty.
+    block_time_estimator: BlockTimeEstimator,
 
     /// Metrics counters to track status.
     metrics: MaintenanceMetrics,
@@ -237,15 +291,21 @@ impl<'a, 'b> Daemon<'a, 'b> {
             opts,
             rng: rand::thread_rng(),
             last_read_success: Instant::now(),
+            block_time_estimator: BlockTimeEstimator::new(),
             metrics,
             snapshot_mutex: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Publish a new snapshot that from now on will be served by the http server.
+    ///
+    /// This also updates the block time estimator, if applicable.
     fn publish_snapshot(&mut self, solido: Option<SolidoState>) {
-        if solido.is_some() {
-            self.last_read_success = Instant::now();
+        let now = Instant::now();
+
+        if let Some(solido) = solido.as_ref() {
+            self.last_read_success = now;
+            self.block_time_estimator.observe_clock(now, &solido.clock);
         }
 
         let snapshot = Snapshot {
@@ -276,11 +336,40 @@ impl<'a, 'b> Daemon<'a, 'b> {
     }
 
     /// Sleep either for the configured poll interval, or until it is our maintainer duty.
-    ///
-    /// TODO(ruuda): Implement the sleeping until maintainer duty part.
     fn sleep_until_next_iteration(&mut self) {
-        let sleep_time = Duration::from_secs(*self.opts.max_poll_interval_seconds());
-        println!("Sleeping {:?} until next iteration ...", sleep_time);
+        let maintainer = self.config.signer.pubkey();
+        let poll_interval = Duration::from_secs(*self.opts.max_poll_interval_seconds());
+
+        // Find out when our next maintainer duty slice starts (if any), and
+        // estimate how long it will take (after the previous snapshot publish,
+        // but this method should be called right after) until then.
+        let next_duty_slot = self
+            .snapshot_mutex
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|snapshot| snapshot.solido.as_ref())
+            .and_then(|solido| solido.get_next_maintainer_duty_slot(&maintainer));
+
+        let sleep_time = next_duty_slot
+            .and_then(|slot| self.block_time_estimator.estimate_time_until_slot(slot))
+            .unwrap_or(poll_interval)
+            .min(poll_interval);
+
+        fn fmt_option<T: std::fmt::Debug>(opt_value: Option<T>) -> String {
+            opt_value
+                .map(|x| format!("{:?}", x))
+                .unwrap_or("n/a".to_string())
+        }
+
+        println!(
+            "Sleeping until next iteration. Slot: {}, next duty slot: {}, block time: {}, sleep time: {:?}",
+            fmt_option(self.block_time_estimator.get_most_recent_slot()),
+            fmt_option(next_duty_slot),
+            fmt_option(self.block_time_estimator.get_average_block_time()),
+            sleep_time,
+        );
+
         std::thread::sleep(sleep_time);
     }
 
@@ -407,4 +496,81 @@ pub fn main(config: &mut SnapshotClientConfig, opts: &RunMaintainerOpts) {
     let daemon = Daemon::new(config, opts);
     let _http_threads = start_http_server(opts, daemon.snapshot_mutex.clone());
     daemon.run();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn block_time_estimator_computes_block_time_from_two_or_more_observations() {
+        let t0 = Instant::now();
+        let mut estimator = BlockTimeEstimator::new();
+
+        assert_eq!(
+            estimator.get_average_block_time(),
+            None,
+            "With no observations, we can't estimate."
+        );
+
+        let mut clock = Clock::default();
+
+        clock.slot = 100;
+        estimator.observe_clock(t0, &clock);
+        assert_eq!(
+            estimator.get_average_block_time(),
+            None,
+            "With one observation, we can't estimate."
+        );
+
+        // Between t0 and t1, we produce 5 blocks in 10 seconds, so 2s per block.
+        let t1 = t0 + Duration::from_secs(10);
+        clock.slot = 105;
+        estimator.observe_clock(t1, &clock);
+        assert_eq!(
+            estimator.get_average_block_time(),
+            Some(Duration::from_secs(2))
+        );
+
+        // Between t0 and t2, we produce 20 blocks in 20 seconds, so 1s per block.
+        let t2 = t0 + Duration::from_secs(20);
+        clock.slot = 120;
+        estimator.observe_clock(t2, &clock);
+        assert_eq!(
+            estimator.get_average_block_time(),
+            Some(Duration::from_secs(1))
+        );
+
+        // After we add more observations than the max we store, we should find
+        // the average block time of these last observations.
+        for i in 150..200 {
+            clock.slot = i;
+            estimator.observe_clock(t0 + Duration::from_secs(i * 3), &clock);
+        }
+        assert_eq!(
+            estimator.get_average_block_time(),
+            Some(Duration::from_secs(3))
+        );
+    }
+
+    #[test]
+    fn block_time_estimator_estimates_time_until_given_slot() {
+        let t0 = Instant::now();
+        let mut estimator = BlockTimeEstimator::new();
+
+        let mut clock = Clock::default();
+        clock.slot = 100;
+        estimator.observe_clock(t0, &clock);
+        clock.slot = 200;
+        estimator.observe_clock(t0 + Duration::from_secs(100), &clock);
+
+        assert_eq!(
+            estimator.estimate_time_until_slot(210),
+            Some(Duration::from_secs(10))
+        );
+        assert_eq!(
+            estimator.estimate_time_until_slot(190),
+            Some(Duration::from_secs(0))
+        );
+    }
 }

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -1295,16 +1295,20 @@ mod test {
                     .unwrap();
             }
 
-            // Check the next slot in reverse, so the duty start slots do not
-            // all fall in the same cycle.
-            let maintainers: Vec<Pubkey> = state
+            let maintainer_keys: Vec<Pubkey> = state
                 .solido
                 .maintainers
                 .entries
                 .iter()
-                .rev()
                 .map(|p| p.pubkey)
                 .collect();
+
+            // Check the next slot in forward order but also reverse order. With
+            // forward order, the duty start slots all fall in the same cycle,
+            // so by iterating backwards, we also test the other branch.
+            let mut maintainers = Vec::new();
+            maintainers.extend(maintainer_keys.iter().rev());
+            maintainers.extend(maintainer_keys.iter());
 
             // Don't start at slot 0, to avoid wrapping below.
             state.clock.slot = SolidoState::MAINTAINER_DUTY_SLICE_LENGTH;

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -1023,7 +1023,7 @@ impl SolidoState {
     /// block time of 550ms is a little under a minute per maintainer. If only
     /// one maintainer is offline, this means maintenance operations get delayed
     /// by at most ~55s.
-    fn get_current_maintainer_duty(&self) -> Option<Pubkey> {
+    pub fn get_current_maintainer_duty(&self) -> Option<Pubkey> {
         if self.solido.maintainers.entries.is_empty() {
             return None;
         }
@@ -1049,7 +1049,7 @@ impl SolidoState {
     /// next duty slice, not the start of the current duty slice.
     ///
     /// See also [`get_current_maintainer_duty`].
-    fn get_next_maintainer_duty_slot(&self, maintainer: &Pubkey) -> Option<Slot> {
+    pub fn get_next_maintainer_duty_slot(&self, maintainer: &Pubkey) -> Option<Slot> {
         // Compute the start of the current "cycle", where in every cycle, every
         // maintainer has a single duty slice.
         let cycle_length =

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -1050,6 +1050,10 @@ impl SolidoState {
     ///
     /// See also [`get_current_maintainer_duty`].
     pub fn get_next_maintainer_duty_slot(&self, maintainer: &Pubkey) -> Option<Slot> {
+        if self.solido.maintainers.entries.is_empty() {
+            return None;
+        }
+
         // Compute the start of the current "cycle", where in every cycle, every
         // maintainer has a single duty slice.
         let cycle_length =


### PR DESCRIPTION
Fixes #421. Depends on #431.

This pull request introduces *maintainer duties* in order to reduce races between maintainers. We break up time into 100-block “duty slices”, and maintainers take turns for “maintainer duty”.

The maintenance daemon will only submit maintenance transactions if it is on duty in the state snapshot that it is inspecting. This way maintainers will not race to perform the same update. To avoid races at the transition, during the last few slots of the duty slice, no maintainer would submit transactions.

There is one complication: if we would only check whether it’s our duty after we polled, we might be unlucky and poll just before and just after our duty slice. This might happen to the next maintainer as well, etc. To prevent this, keep track of the average block times, and adjust the sleep time so we wake up just in time for our duty. The current implementation is pretty basic (e.g. it doesn’t account for the fact that when you poll, on average you are half-way in the block, so the expected time until the start of the next block is only half the block time). We don't need advanced timing so I think this is fine for now; it seems to work reasonably well in my devnet test:

```
Sleeping until next iteration. Slot: 81445825, next duty slot: 81446000, block time: n/a, sleep time: 30.000s
Sleeping until next iteration. Slot: 81445913, next duty slot: 81446000, block time: 0.407s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81445989, next duty slot: 81446000, block time: 0.405s, sleep time: 4.457s
Sleeping until next iteration. Slot: 81446000, next duty slot: 81446200, block time: 0.406s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446075, next duty slot: 81446200, block time: 0.407s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446151, next duty slot: 81446200, block time: 0.407s, sleep time: 19.945s
Sleeping until next iteration. Slot: 81446200, next duty slot: 81446400, block time: 0.408s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446272, next duty slot: 81446400, block time: 0.410s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446346, next duty slot: 81446400, block time: 0.409s, sleep time: 22.109s
Sleeping until next iteration. Slot: 81446400, next duty slot: 81446600, block time: 0.410s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446475, next duty slot: 81446600, block time: 0.410s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446553, next duty slot: 81446600, block time: 0.409s, sleep time: 19.216s
Sleeping until next iteration. Slot: 81446599, next duty slot: 81446600, block time: 0.410s, sleep time: 0.410s
Sleeping until next iteration. Slot: 81446599, next duty slot: 81446600, block time: 0.411s, sleep time: 0.411s
Sleeping until next iteration. Slot: 81446601, next duty slot: 81446800, block time: 0.411s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446677, next duty slot: 81446800, block time: 0.409s, sleep time: 30.000s
Sleeping until next iteration. Slot: 81446751, next duty slot: 81446800, block time: 0.408s, sleep time: 19.976s
Sleeping until next iteration. Slot: 81446801, next duty slot: 81447000, block time: 0.407s, sleep time: 30.000s
```

(This might be misleading though because devnet has a single validator so the block times are very stable.)