### PR TITLE
Expose withdraw stats, Solana stake, and Solana epoch info in `/metrics`

### DIFF
--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -446,6 +446,17 @@ impl fmt::Display for ShowSolidoOutput {
         )?;
         writeln!(
             f,
+            "  Total amount withdrawn:   {}, valued at {} when it was withdrawn",
+            self.solido.metrics.withdraw_amount.total_st_sol_amount,
+            self.solido.metrics.withdraw_amount.total_sol_amount,
+        )?;
+        writeln!(
+            f,
+            "  Number of withdrawals:    {}",
+            self.solido.metrics.withdraw_amount.count,
+        )?;
+        writeln!(
+            f,
             "  Total deposited:          {}",
             self.solido.metrics.deposit_amount.total
         )?;

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -1330,6 +1330,8 @@ mod test {
             reserve_account: Account::default(),
             rent: Rent::default(),
             clock: Clock::default(),
+            epoch_schedule: EpochSchedule::default(),
+            stake_history: StakeHistory::default(),
             maintainer_address: Pubkey::new_unique(),
         };
 

--- a/cli/src/prometheus.rs
+++ b/cli/src/prometheus.rs
@@ -259,9 +259,7 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
             name: "solido_withdraw_count_total",
             help: "Total number of withdrawals done by users.",
             type_: "counter",
-            metrics: vec![
-                Metric::new(metrics.withdraw_amount.count).at(at)
-            ],
+            metrics: vec![Metric::new(metrics.withdraw_amount.count).at(at)],
         },
     )?;
     write_metric(
@@ -270,9 +268,7 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
             name: "solido_withdraw_amount_sol_total",
             help: "Total amount of SOL that we returned to users for withdrawals.",
             type_: "counter",
-            metrics: vec![
-                Metric::new_sol(metrics.withdraw_amount.total_sol_amount).at(at)
-            ],
+            metrics: vec![Metric::new_sol(metrics.withdraw_amount.total_sol_amount).at(at)],
         },
     )?;
     write_metric(
@@ -281,9 +277,7 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
             name: "solido_withdraw_amount_st_sol_total",
             help: "Total amount of stSOL that users returned to us for withdrawals.",
             type_: "counter",
-            metrics: vec![
-                Metric::new_st_sol(metrics.withdraw_amount.total_st_sol_amount).at(at)
-            ],
+            metrics: vec![Metric::new_st_sol(metrics.withdraw_amount.total_st_sol_amount).at(at)],
         },
     )?;
 

--- a/cli/src/prometheus.rs
+++ b/cli/src/prometheus.rs
@@ -257,7 +257,7 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_withdraw_count_total",
-            help: "Total number of withdrawals done by users.",
+            help: "Total number of withdrawals made by users.",
             type_: "counter",
             metrics: vec![Metric::new(metrics.withdraw_amount.count).at(at)],
         },

--- a/cli/src/prometheus.rs
+++ b/cli/src/prometheus.rs
@@ -252,6 +252,41 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
             metrics: solido_histogram_to_metrics(at, &metrics.deposit_amount),
         },
     )?;
+
+    write_metric(
+        out,
+        &MetricFamily {
+            name: "solido_withdraw_count_total",
+            help: "Total number of withdrawals done by users.",
+            type_: "counter",
+            metrics: vec![
+                Metric::new(metrics.withdraw_amount.count).at(at)
+            ],
+        },
+    )?;
+    write_metric(
+        out,
+        &MetricFamily {
+            name: "solido_withdraw_amount_sol_total",
+            help: "Total amount of SOL that we returned to users for withdrawals.",
+            type_: "counter",
+            metrics: vec![
+                Metric::new_sol(metrics.withdraw_amount.total_sol_amount).at(at)
+            ],
+        },
+    )?;
+    write_metric(
+        out,
+        &MetricFamily {
+            name: "solido_withdraw_amount_st_sol_total",
+            help: "Total amount of stSOL that users returned to us for withdrawals.",
+            type_: "counter",
+            metrics: vec![
+                Metric::new_st_sol(metrics.withdraw_amount.total_st_sol_amount).at(at)
+            ],
+        },
+    )?;
+
     Ok(())
 }
 

--- a/cli/src/snapshot.rs
+++ b/cli/src/snapshot.rs
@@ -35,7 +35,8 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_sdk::sysvar::stake_history::StakeHistory;
 use solana_sdk::sysvar::{
-    self, clock::Clock, recent_blockhashes::RecentBlockhashes, rent::Rent, Sysvar,
+    self, clock::Clock, epoch_schedule::EpochSchedule, recent_blockhashes::RecentBlockhashes,
+    rent::Rent, Sysvar,
 };
 use solana_sdk::transaction::Transaction;
 
@@ -215,6 +216,11 @@ impl<'a> Snapshot<'a> {
     /// Read `sysvar::clock`.
     pub fn get_clock(&mut self) -> Result<Clock> {
         self.get_bincode(&sysvar::clock::id())
+    }
+
+    /// Read `sysvar::epoch_schedule`.
+    pub fn get_epoch_schedule(&mut self) -> Result<EpochSchedule> {
+        self.get_bincode(&sysvar::epoch_schedule::id())
     }
 
     /// Read `sysvar::stake_history`.


### PR DESCRIPTION
Expose the following new Prometheus metrics.

* Withdrawal count and amount. We were already tracking these, but we forgot to expose them.
* Amount of stake on Solana. This allows us to compute the fraction of stake controlled by Lido. Unfortunately it doesn’t appear to be possible to get current amount of active stake, but we can get the amount from the previous epoch from the stake history sysvar.
* Solana epoch, epoch start slot, and slots per epoch. With the start slot, slots per epoch, and the block height that we already had, we can estimate the time left until the next epoch.

For withdrawal stats, also print them in `solido show-solido`, next to the deposit stats.