### PR TITLE
Be more explicit about using "confirmed" commitment level, wait for confirmation

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -325,8 +325,10 @@ fn main() {
         get_signer_from_key(opts.keypair.unwrap())
     };
 
+    // We use finalized here to be sure that we never observe rollbacks. In particular,
+    // this ensures that the maintenance daemon never observes vote credits going down.
     let rpc_client =
-        RpcClient::new_with_commitment(opts.cluster.unwrap(), CommitmentConfig::confirmed());
+        RpcClient::new_with_commitment(opts.cluster.unwrap(), CommitmentConfig::finalized());
     let snapshot_client = SnapshotClient::new(rpc_client);
 
     let output_mode = opts.output_mode.unwrap();

--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -1041,12 +1041,10 @@ impl SolidoState {
             out,
             &MetricFamily {
                 name: "solido_validator_vote_credits_total",
-                help: "Vote credits in the validator's vote account.",
-                // This is a counter due to the way vote credits work in Solana.
-                // The credits only ever go up, they don't reset when a new epoch
-                // starts. Older vote accounts (that have been voting continuously)
-                // will have more vote credits.
-                type_: "counter",
+                help: "Vote credits in the validator's vote account. \
+                       On-chain this value can only increase, but decreases in the observed value can \
+                       happen due to reorgs.",
+                type_: "gauge",
                 metrics: vote_credits_metrics,
             },
         )?;

--- a/cli/src/prometheus.rs
+++ b/cli/src/prometheus.rs
@@ -184,8 +184,10 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_fee_treasury_sol_total",
-            help: "Total fees paid to the treasury, in SOL value before conversion to stSOL.",
-            type_: "counter",
+            help: "Total fees paid to the treasury, in SOL value before conversion to stSOL. \
+                   On-chain this value can only increase, but decreases in the observed value can \
+                   happen due to reorgs.",
+            type_: "gauge",
             metrics: vec![Metric::new_sol(metrics.fee_treasury_sol_total).at(at)],
         },
     )?;
@@ -193,8 +195,10 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_fee_treasury_st_sol_total",
-            help: "Total fees paid to the treasury.",
-            type_: "counter",
+            help: "Total fees paid to the treasury. \
+                   On-chain this value can only increase, but decreases in the observed value can \
+                   happen due to reorgs.",
+            type_: "gauge",
             metrics: vec![Metric::new_st_sol(metrics.fee_treasury_st_sol_total).at(at)],
         },
     )?;
@@ -202,8 +206,10 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_fee_validation_sol_total",
-            help: "Total validation fees paid to validators (excluding commission they took), in SOL value before conversion to stSOL.",
-            type_: "counter",
+            help: "Total validation fees paid to validators (excluding commission they took), \
+                   in SOL value before conversion to stSOL. On-chain this value can only increase, \
+                   but decreases in the observed value can happen due to reorgs.",
+            type_: "gauge",
             metrics: vec![Metric::new_sol(metrics.fee_validation_sol_total).at(at)],
         },
     )?;
@@ -211,8 +217,10 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_fee_validation_st_sol_total",
-            help: "Total validation fees paid to validators as stSOL (excluding commission they took).",
-            type_: "counter",
+            help: "Total validation fees paid to validators as stSOL (excluding commission they took). \
+                   On-chain this value can only increase, but decreases in the observed value can \
+                   happen due to reorgs.",
+            type_: "gauge",
             metrics: vec![Metric::new_st_sol(metrics.fee_validation_st_sol_total).at(at)],
         },
     )?;
@@ -220,8 +228,10 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_fee_developer_sol_total",
-            help: "Total fees paid to the developer, in SOL value before conversion to stSOL.",
-            type_: "counter",
+            help: "Total fees paid to the developer, in SOL value before conversion to stSOL. \
+                   On-chain this value can only increase, but decreases in the observed value can \
+                   happen due to reorgs.",
+            type_: "gauge",
             metrics: vec![Metric::new_sol(metrics.fee_developer_sol_total).at(at)],
         },
     )?;
@@ -229,8 +239,10 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_fee_developer_st_sol_total",
-            help: "Total fees paid to the developer.",
-            type_: "counter",
+            help: "Total fees paid to the developer. \
+                   On-chain this value can only increase, but decreases in the observed value can \
+                   happen due to reorgs.",
+            type_: "gauge",
             metrics: vec![Metric::new_st_sol(metrics.fee_developer_st_sol_total).at(at)],
         },
     )?;
@@ -238,8 +250,10 @@ pub fn write_solido_metrics_as_prometheus<W: io::Write>(
         out,
         &MetricFamily {
             name: "solido_st_sol_appreciation_sol_total",
-            help: "Total SOL that went to benefit stSOL holders, i.e. rewards gained by users.",
-            type_: "counter",
+            help: "Total SOL that went to benefit stSOL holders, i.e. rewards gained by users. \
+                   On-chain this value can only increase, but decreases in the observed value can \
+                   happen due to reorgs.",
+            type_: "gauge",
             metrics: vec![Metric::new_sol(metrics.st_sol_appreciation_sol_total).at(at)],
         },
     )?;

--- a/cli/src/snapshot.rs
+++ b/cli/src/snapshot.rs
@@ -23,13 +23,16 @@
 //! rare, and when they do happen, they shouldn’t happen repeatedly.
 
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 use anchor_lang::AccountDeserialize;
 use solana_client::client_error::{ClientError, ClientErrorKind};
 use solana_client::rpc_client::RpcClient;
+use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_client::rpc_request::RpcError;
 use solana_sdk::account::Account;
 use solana_sdk::borsh::try_from_slice_unchecked;
+use solana_sdk::commitment_config::CommitmentLevel;
 use solana_sdk::program_pack::{IsInitialized, Pack};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
@@ -281,7 +284,46 @@ impl<'a> Snapshot<'a> {
         transaction: &Transaction,
     ) -> solana_client::client_error::Result<Signature> {
         *self.sent_transaction = true;
-        self.rpc_client.send_and_confirm_transaction(transaction)
+        let signature = self.rpc_client.send_transaction_with_config(
+            transaction,
+            // We use commitment level "finalized" for our client, but when we
+            // try to preflight a transaction with the most recent finalized
+            // block hash, we get an error:
+            //
+            //     Transaction simulation failed: Blockhash not found
+            //
+            // To avoid this, preflight the transaction against the latest
+            // confirmed state, which is more recent than the latest finalized
+            // state.
+            RpcSendTransactionConfig {
+                preflight_commitment: Some(CommitmentLevel::Confirmed),
+                ..RpcSendTransactionConfig::default()
+            },
+        )?;
+
+        // Beware of the Solana footgun: `confirm_transaction` is something
+        // completely different from `confirm_transaction_with_spinner`. The
+        // former returns a boolean that indicates whether the transaction is
+        // confirmed, the latter waits until the transaction is confirmed (and
+        // prints the spinner). So here we have to wait manually.
+        for _ in 0..32 {
+            let is_confirmed = self.rpc_client.confirm_transaction(&signature)?;
+            if is_confirmed {
+                return Ok(signature);
+            }
+            // Blocks are finalized after there are 32 blocks on top, so with a
+            // block time of 550ms, waiting 32 seconds should be plenty to wait
+            // for confirmation.
+            std::thread::sleep(Duration::from_secs(1));
+        }
+
+        // RpcError::ForUser is also what `confirm_transaction_with_spinner`
+        // returns if it fails to confirm within a certain time.
+        return Err(RpcError::ForUser(format!(
+            "Failed to confirm transaction {} within 32 seconds.",
+            signature,
+        ))
+        .into());
     }
 
     /// Send a transaction, show a spinner on stdout.
@@ -294,8 +336,20 @@ impl<'a> Snapshot<'a> {
         transaction: &Transaction,
     ) -> solana_client::client_error::Result<Signature> {
         *self.sent_transaction = true;
-        self.rpc_client
-            .send_and_confirm_transaction_with_spinner(transaction)
+        let signature = self.rpc_client.send_transaction_with_config(
+            transaction,
+            // See also the comment in `send_and_confirm_transaction`.
+            RpcSendTransactionConfig {
+                preflight_commitment: Some(CommitmentLevel::Confirmed),
+                ..RpcSendTransactionConfig::default()
+            },
+        )?;
+        self.rpc_client.confirm_transaction_with_spinner(
+            &signature,
+            &transaction.message.recent_blockhash,
+            self.rpc_client.commitment(),
+        )?;
+        Ok(signature)
     }
 }
 

--- a/cli/src/snapshot.rs
+++ b/cli/src/snapshot.rs
@@ -293,10 +293,12 @@ impl<'a> Snapshot<'a> {
             //     Transaction simulation failed: Blockhash not found
             //
             // To avoid this, preflight the transaction against the latest
-            // confirmed state, which is more recent than the latest finalized
-            // state.
+            // known state, which is more recent than the latest finalized
+            // state. We want to preflight against the most recent state anyway,
+            // to be more confident that the transaction does not fail when we
+            // execute it for real.
             RpcSendTransactionConfig {
-                preflight_commitment: Some(CommitmentLevel::Confirmed),
+                preflight_commitment: Some(CommitmentLevel::Processed),
                 ..RpcSendTransactionConfig::default()
             },
         )?;
@@ -340,7 +342,7 @@ impl<'a> Snapshot<'a> {
             transaction,
             // See also the comment in `send_and_confirm_transaction`.
             RpcSendTransactionConfig {
-                preflight_commitment: Some(CommitmentLevel::Confirmed),
+                preflight_commitment: Some(CommitmentLevel::Processed),
                 ..RpcSendTransactionConfig::default()
             },
         )?;

--- a/tests/util.py
+++ b/tests/util.py
@@ -97,7 +97,7 @@ def solana(*args: str) -> str:
     """
     Run 'solana' against network.
     """
-    return run('solana', '--url', get_network(), '--commitment', 'finalized', *args)
+    return run('solana', '--url', get_network(), '--commitment', 'confirmed', *args)
 
 
 def spl_token(*args: str) -> str:

--- a/tests/util.py
+++ b/tests/util.py
@@ -97,7 +97,7 @@ def solana(*args: str) -> str:
     """
     Run 'solana' against network.
     """
-    return run('solana', '--url', get_network(), *args)
+    return run('solana', '--url', get_network(), '--commitment', 'finalized', *args)
 
 
 def spl_token(*args: str) -> str:


### PR DESCRIPTION
**Note**: This description is outdated, see discussion below for the current state of this pull request.

-------

I was running the maintenance daemon to export metrics all day, and I observed the vote credits going *down*. That’s problematic when used with Promtheus's `rate`, because it treats it as a counter restart and suddenly you have double the rate. The vote credits going down should never be possible, the one thing I can think of that would cause this is, is that the RPC node that we queried was following one particular chain where the votes got credited, but then a different fork won out in the end, and so these vote credits were never awarded after all.

If we use commitment level "finalized", this should not happen.