### PR TITLE
Stake/Unstake at the end of the epoch

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -454,6 +454,12 @@ cli_opt_struct! {
         /// claim fees.
         #[clap(long)]
         validator_vote_account : Pubkey => Pubkey::default(),
+
+        /// Try to do stake and unstake operations any time if set to true,
+        /// otherwise will try to stake/unstake only at the end of the epoch.
+        /// Defaults to false.
+        #[clap(long, value_name = "true/false")]
+        stake_unstake_any_time: bool => false,
     }
 }
 
@@ -640,6 +646,12 @@ cli_opt_struct! {
         /// Maximum time to wait in seconds after there was no maintenance to perform, before checking again. Defaults to 30s
         #[clap(long)]
         max_poll_interval_seconds: u64 => 30,
+
+        /// Try to do stake and unstake operations any time if set to true,
+        /// otherwise will try to stake/unstake only at the end of the epoch.
+        /// Defaults to false.
+        #[clap(long, value_name = "true/false")]
+        stake_unstake_any_time: bool => false,
     }
 }
 

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -175,7 +175,12 @@ fn run_maintenance_iteration(
     opts: &RunMaintainerOpts,
 ) -> MaintenanceResult {
     let result = config.with_snapshot(|mut config| {
-        let state = SolidoState::new(&mut config, opts.solido_program_id(), opts.solido_address())?;
+        let state = SolidoState::new(
+            &mut config,
+            opts.solido_program_id(),
+            opts.solido_address(),
+            *opts.stake_unstake_any_time(),
+        )?;
 
         // If it's not our maintainer duty at this time, then don't try to
         // perform maintenance; a different maintainer should be doing it


### PR DESCRIPTION
Adds a flag `stake_unstake_any_time`, if set to true, the maintainer
will try to stake/unstake whenever it's possible, otherwise, stake and
unstake operations will happen only close to the epoch's end.
Defaults to `false`.

To decide if the epoch is finishing, there's a `const
END_OF_EPOCH_THRESHOLD` set to `1/20`, if the remaining ratio for the
epoch's completion is greater than that, the epoch is considered ending
and maintainers will try to stake/unstake.

To verify the conditions, the function
`should_perform_maintenance_at_end_of_epoch` is called whenever there's
a stake/unstake operation in the maintainer.