### PR TITLE
Fix parsing of `ChangeMultisig` in `multisig show-transaction`

### DIFF
--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -804,7 +804,7 @@ fn show_transaction(
     // hard-code the tag here (it is stable as long as the namespace and
     // function name do not change).
     else if instr.program_id == *multisig_program_id
-        && instr.data[..8] == [122, 49, 168, 177, 231, 28, 167, 204]
+        && instr.data[..8] == [55, 144, 74, 245, 249, 230, 14, 53]
     {
         if let Ok(instr) =
             multisig_instruction::SetOwnersAndChangeThreshold::try_from_slice(&instr.data[8..])

--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 Chorus One AG
 // SPDX-License-Identifier: GPL-3.0
 
-use std::fmt;
 use std::collections::HashSet;
+use std::fmt;
 
 use anchor_lang::prelude::{AccountMeta, ToAccountMetas};
 use anchor_lang::{Discriminator, InstructionData};
@@ -535,7 +535,12 @@ impl fmt::Display for ShowTransactionOutput {
                 writeln!(f, "    Buffer with new program: {}", buffer_address)?;
                 writeln!(f, "    Spill address:           {}", spill_address)?;
             }
-            ParsedInstruction::MultisigChange { old_threshold, old_owners, new_threshold, new_owners } => {
+            ParsedInstruction::MultisigChange {
+                old_threshold,
+                old_owners,
+                new_threshold,
+                new_owners,
+            } => {
                 writeln!(
                     f,
                     "  This is a serum_multisig::set_owners_and_change_threshold instruction."
@@ -748,15 +753,20 @@ fn print_diff_multisig(
     new_owners: &[Pubkey],
 ) -> fmt::Result {
     if (old_threshold, old_owners.len()) == (new_threshold, new_owners.len()) {
-        writeln!(f,
+        writeln!(
+            f,
             "    Threshold (unchanged): {} of {}",
-            new_threshold, new_owners.len(),
+            new_threshold,
+            new_owners.len(),
         )?;
     } else {
-        writeln!(f,
+        writeln!(
+            f,
             "    Threshold (changed): {} of {} -> {} of {}",
-            old_threshold, old_owners.len(),
-            new_threshold, new_owners.len(),
+            old_threshold,
+            old_owners.len(),
+            new_threshold,
+            new_owners.len(),
         )?;
     }
     let old_owners_set: HashSet<_> = old_owners.iter().collect();

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -368,7 +368,7 @@ assert result['parsed_instruction'] == {
         'new_owners': [
             addr1.pubkey,
             addr2.pubkey,
-        ]
+        ],
     }
 }
 print('> Transaction has the required number of signatures.')

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -358,8 +358,14 @@ assert result['signers']['Current']['signers'] == [
 ]
 assert result['parsed_instruction'] == {
     'MultisigChange': {
-        'threshold': 2,
-        'owners': [
+        'old_threshold': 2,
+        'new_threshold': 2,
+        'old_owners': [
+            addr1.pubkey,
+            addr2.pubkey,
+            addr3.pubkey,
+        ],
+        'new_owners': [
             addr1.pubkey,
             addr2.pubkey,
         ]

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -356,6 +356,15 @@ assert result['signers']['Current']['signers'] == [
     {'owner': addr2.pubkey, 'did_sign': False},
     {'owner': addr3.pubkey, 'did_sign': True},
 ]
+assert result['parsed_instruction'] == {
+    'MultisigChange': {
+        'threshold': 2,
+        'owners': [
+            addr1.pubkey,
+            addr2.pubkey,
+        ]
+    }
+}
 print('> Transaction has the required number of signatures.')
 
 


### PR DESCRIPTION
Bugfix:

* Identifying the `ChangeMultisig` transaction relies on a 8-byte magic number derived from the multisig program module name. When we updated the multisig program, the module name changed, and therefore the magic number changed, so we should have changed this. We did not catch this in tests, because we only tested that we could execute the transaction, not that we could parse its details.
* Add a test to test that we can parse the details, to prevent this in the future.
* Fix the magic number to make the test pass.

Feature:

* Instead of displaying only the new multisig owners and threshold, display a diff, to make it easier to understand what you are approving.

New output:

```console
$ solido --config mainnet.json multisig show-transaction --transaction-address C5VLK2EBThXVw6UXmypZePuKkBiMUm3vMXY2BpftmsTk
Multisig: 3cXyJbjoAUNLpQsFrFJTTTp8GD3uPeabYbsCVobkQpD1
Did execute: false

Signers:
  [ ] Cv6GM219kzMrdUUdgDGVJUPW6fGosvrhsFrvmEhz3Mc6
  [ ] ENH1xvwjinUWkwEgw1hKduyAg7CrJMiKvr9nAS7wLHrp
  [ ] 6CawqfAJDviZGfUpHFJgeauq6H9vhKuivMMZULZeGnPw
  [ ] F4VFp4tFTyrQWo9YVjCbPE5eQP27ice2zyGDp2tN2Rkm
  [ ] AnoVUukL1fMAwEp4y2rrZV45BNHLes8ZwWsCRgEwhGH4
  [x] 6S21QCmpAadEhHj3pY2RMbPMGwgYNvS4Pd7zUXoRDMdK
  [ ] 8Lep9addZWUWqBNj3igx4QoHe43GBfvLhGJy18jJgWQa

Instruction:
  Program to call: AAHT26ecV3FEeFmL2gDZW6FfEqjPkghHbAkNZGqwT8Ww
  Accounts:

    * 3cXyJbjoAUNLpQsFrFJTTTp8GD3uPeabYbsCVobkQpD1
      signer: false, writable: true

    * GQ3QPrB1RHPRr4Reen772WrMZkHcFM4DL5q44x1BBTFm
      signer: true, writable: false

  This is a serum_multisig::set_owners_and_change_threshold instruction.
    Threshold (unchanged): 4 of 7
    Owners (changed):
        6CawqfAJDviZGfUpHFJgeauq6H9vhKuivMMZULZeGnPw
        6S21QCmpAadEhHj3pY2RMbPMGwgYNvS4Pd7zUXoRDMdK
        Cv6GM219kzMrdUUdgDGVJUPW6fGosvrhsFrvmEhz3Mc6
        ENH1xvwjinUWkwEgw1hKduyAg7CrJMiKvr9nAS7wLHrp
        AnoVUukL1fMAwEp4y2rrZV45BNHLes8ZwWsCRgEwhGH4
        F4VFp4tFTyrQWo9YVjCbPE5eQP27ice2zyGDp2tN2Rkm
      - 8Lep9addZWUWqBNj3igx4QoHe43GBfvLhGJy18jJgWQa
      + DHLXnJdACTY83yKwnUkeoDjqi4QBbsYGa1v8tJL76ViX
```