### PR TITLE
Rework authorization checks in Anker program

### DIFF
--- a/anker/src/error.rs
+++ b/anker/src/error.rs
@@ -6,22 +6,26 @@ use solana_program::{decode_error::DecodeError, program_error::ProgramError};
 /// Errors that may be returned by the Anker program.
 #[derive(Clone, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum AnkerError {
-    /// We expected an SPL token account that holds bSOL,
-    /// but this was not an SPL token account,
-    /// or its mint did not match.
-    InvalidBSolAccount = 0,
+    /// We failed to deserialize an SPL token account.
+    InvalidTokenAccount = 0,
 
-    /// We expected the BSol account to be owned by the SPL token program.
-    InvalidBSolAccountOwner = 1,
+    /// We expected the SPL token account to be owned by the SPL token program.
+    InvalidTokenAccountOwner = 1,
 
-    /// The provided mint is invalid.
-    InvalidBSolMint = 2,
+    /// The mint of a provided SPL token account does not match the expected mint.
+    InvalidTokenMint = 2,
 
     /// The provided reserve is invalid.
     InvalidReserveAccount = 3,
 
-    /// The provided Lido state is different from the stored one.
-    WrongLidoInstance = 4,
+    /// The provided Solido state is different from the stored one.
+    InvalidSolidoInstance = 4,
+
+    /// The one of the provided accounts does not match the expected derived address.
+    InvalidDerivedAccount = 5,
+
+    /// An account is not owned by the expected owner.
+    InvalidOwner = 6,
 }
 
 // Just reuse the generated Debug impl for Display. It shows the variant names.

--- a/anker/src/instruction.rs
+++ b/anker/src/instruction.rs
@@ -110,12 +110,6 @@ accounts_struct! {
             is_signer: false,
             is_writable: false,
         },
-        // TODO(#449): Store this in the Anker instance instead, we never actually
-        // access the Lido program address for a deposit, only the instance.
-        pub solido_program {
-            is_signer: false,
-            is_writable: false,
-        },
         pub from_account {
             is_signer: false,
             is_writable: true, // We will reduce its balance.

--- a/anker/src/logic.rs
+++ b/anker/src/logic.rs
@@ -21,6 +21,12 @@ use crate::{instruction::InitializeAccountsInfo, state::Anker};
 /// * The mint address should match the address stored in Anker.
 /// * The mint authority should match the address derived from Anker.
 /// * The reserve authority should match the address derived from Anker.
+///
+/// Note, the address of the Anker instance is a program-derived address that
+/// derived from the Anker program address, and the Solido instance address of
+/// the Solido instance that this Anker instance belongs to. This ensures that
+/// for a given deployment of the Anker program, there exists a unique Anker
+/// instance address per Solido instance.
 pub fn deserialize_anker(
     anker_program_id: &Pubkey,
     anker_account: &AccountInfo,

--- a/anker/src/logic.rs
+++ b/anker/src/logic.rs
@@ -1,5 +1,5 @@
 use crate::{error::AnkerError, token::BLamports, ANKER_MINT_AUTHORITY};
-use lido::{token::Lamports, state::Lido};
+use lido::{state::Lido, token::Lamports};
 use solana_program::{
     account_info::AccountInfo, borsh::try_from_slice_unchecked, entrypoint::ProgramResult, msg,
     program::invoke_signed, program_error::ProgramError, pubkey::Pubkey, rent::Rent,
@@ -58,10 +58,7 @@ pub fn deserialize_anker(
         return Err(AnkerError::InvalidSolidoInstance.into());
     }
 
-    let solido = Lido::deserialize_lido(
-        &anker.solido_program_id,
-        solido_account,
-    )?;
+    let solido = Lido::deserialize_lido(&anker.solido_program_id, solido_account)?;
 
     anker.check_reserve_address(anker_program_id, anker_account.key, reserve_account)?;
     anker.check_is_st_sol_account(&solido, reserve_account)?;

--- a/anker/src/logic.rs
+++ b/anker/src/logic.rs
@@ -74,6 +74,7 @@ pub fn deserialize_anker(
 
 /// Mint the given amount of bSOL and put it in the recipient's account.
 pub fn mint_b_sol_to<'a>(
+    anker_program_id: &Pubkey,
     anker: &Anker,
     anker_address: &Pubkey,
     spl_token_program: &AccountInfo<'a>,
@@ -82,6 +83,10 @@ pub fn mint_b_sol_to<'a>(
     recipient: &AccountInfo<'a>,
     amount: BLamports,
 ) -> ProgramResult {
+    // Check if the mint account is the same as the one stored in Anker.
+    anker.check_mint(b_sol_mint)?;
+    anker.check_mint_authority(anker_program_id, anker_address, mint_authority)?;
+
     anker.check_is_b_sol_account(recipient)?;
 
     let authority_signature_seeds = [

--- a/anker/src/processor.rs
+++ b/anker/src/processor.rs
@@ -124,14 +124,6 @@ fn process_deposit(
         accounts.to_reserve_account,
     )?;
 
-    // Check if the mint account is the same as the one stored in Anker.
-    anker.check_mint(accounts.b_sol_mint)?;
-    anker.check_mint_authority(
-        program_id,
-        accounts.anker.key,
-        accounts.b_sol_mint_authority,
-    )?;
-
     // Transfer `amount` StLamports to the reserve.
     invoke(
         &spl_token::instruction::transfer(
@@ -156,6 +148,7 @@ fn process_deposit(
     let b_sol_amount = BLamports(sol_value.0);
 
     mint_b_sol_to(
+        program_id,
         &anker,
         accounts.anker.key,
         accounts.spl_token,

--- a/anker/src/processor.rs
+++ b/anker/src/processor.rs
@@ -111,7 +111,11 @@ fn process_deposit(
 
     // Check if the mint account is the same as the one stored in Anker.
     anker.check_mint(accounts.b_sol_mint)?;
-    anker.check_mint_authority(program_id, accounts.anker.key, accounts.b_sol_mint_authority)?;
+    anker.check_mint_authority(
+        program_id,
+        accounts.anker.key,
+        accounts.b_sol_mint_authority,
+    )?;
 
     // Transfer `amount` StLamports to the reserve.
     invoke(

--- a/anker/src/state.rs
+++ b/anker/src/state.rs
@@ -1,7 +1,9 @@
-use crate::{error::AnkerError, ANKER_RESERVE_ACCOUNT, ANKER_RESERVE_AUTHORITY, ANKER_MINT_AUTHORITY};
+use crate::{
+    error::AnkerError, ANKER_MINT_AUTHORITY, ANKER_RESERVE_ACCOUNT, ANKER_RESERVE_AUTHORITY,
+};
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use lido::util::serialize_b58;
 use lido::state::Lido;
+use lido::util::serialize_b58;
 use serde::Serialize;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program_pack::Pack, pubkey::Pubkey,
@@ -51,14 +53,16 @@ impl Anker {
     }
 
     /// Confirm that the account address is the derived address where Anker instance should live.
-    pub fn check_self_address(&self, anker_program_id: &Pubkey, account_info: &AccountInfo) -> ProgramResult {
+    pub fn check_self_address(
+        &self,
+        anker_program_id: &Pubkey,
+        account_info: &AccountInfo,
+    ) -> ProgramResult {
         let address = Pubkey::create_program_address(
-            &[
-                self.solido.as_ref(),
-                &[self.self_bump_seed],
-            ],
+            &[self.solido.as_ref(), &[self.self_bump_seed]],
             anker_program_id,
-        ).expect("Depends only on Anker-controlled values, should not fail.");
+        )
+        .expect("Depends only on Anker-controlled values, should not fail.");
 
         if *account_info.key != address {
             msg!(
@@ -73,15 +77,20 @@ impl Anker {
     }
 
     /// Confirm that the derived account address matches the `account_info` adddress.
-    fn check_derived_account_address(&self, name: &'static str, seed: &'static [u8], bump_seed: u8, anker_program_id: &Pubkey, anker_instance: &Pubkey, account_info: &AccountInfo) -> ProgramResult {
+    fn check_derived_account_address(
+        &self,
+        name: &'static str,
+        seed: &'static [u8],
+        bump_seed: u8,
+        anker_program_id: &Pubkey,
+        anker_instance: &Pubkey,
+        account_info: &AccountInfo,
+    ) -> ProgramResult {
         let address = Pubkey::create_program_address(
-            &[
-                anker_instance.as_ref(),
-                seed,
-                &[bump_seed],
-            ],
+            &[anker_instance.as_ref(), seed, &[bump_seed]],
             anker_program_id,
-        ).expect("Depends only on Anker-controlled values, should not fail.");
+        )
+        .expect("Depends only on Anker-controlled values, should not fail.");
 
         if *account_info.key != address {
             msg!(
@@ -98,7 +107,12 @@ impl Anker {
     /// Confirm that the provided reserve account is the one that belongs to this instance.
     ///
     /// This does not check that the reserve is an stSOL account.
-    pub fn check_reserve_address(&self, anker_program_id: &Pubkey, anker_instance: &Pubkey, reserve_account_info: &AccountInfo) -> ProgramResult {
+    pub fn check_reserve_address(
+        &self,
+        anker_program_id: &Pubkey,
+        anker_instance: &Pubkey,
+        reserve_account_info: &AccountInfo,
+    ) -> ProgramResult {
         self.check_derived_account_address(
             "the reserve account",
             ANKER_RESERVE_ACCOUNT,
@@ -110,7 +124,12 @@ impl Anker {
     }
 
     /// Confirm that the provided reserve authority is the one that belongs to this instance.
-    pub fn check_reserve_authority(&self, anker_program_id: &Pubkey, anker_instance: &Pubkey, reserve_authority_info: &AccountInfo) -> ProgramResult {
+    pub fn check_reserve_authority(
+        &self,
+        anker_program_id: &Pubkey,
+        anker_instance: &Pubkey,
+        reserve_authority_info: &AccountInfo,
+    ) -> ProgramResult {
         self.check_derived_account_address(
             "the reserve authority",
             ANKER_RESERVE_AUTHORITY,
@@ -122,7 +141,12 @@ impl Anker {
     }
 
     /// Confirm that the provided bSOL mint authority is the one that belongs to this instance.
-    pub fn check_mint_authority(&self, anker_program_id: &Pubkey, anker_instance: &Pubkey, mint_authority_info: &AccountInfo) -> ProgramResult {
+    pub fn check_mint_authority(
+        &self,
+        anker_program_id: &Pubkey,
+        anker_instance: &Pubkey,
+        mint_authority_info: &AccountInfo,
+    ) -> ProgramResult {
         self.check_derived_account_address(
             "the bSOL mint authority",
             ANKER_MINT_AUTHORITY,
@@ -197,20 +221,16 @@ impl Anker {
 
     /// Confirm that the account is an SPL token account that holds bSOL.
     pub fn check_is_b_sol_account(&self, token_account_info: &AccountInfo) -> ProgramResult {
-        Anker::check_is_spl_token_account(
-            "our bSOL",
-            &self.b_sol_mint,
-            token_account_info,
-        )
+        Anker::check_is_spl_token_account("our bSOL", &self.b_sol_mint, token_account_info)
     }
 
     /// Confirm that the account is an SPL token account that holds stSOL.
-    pub fn check_is_st_sol_account(&self, solido: &Lido, token_account_info: &AccountInfo) -> ProgramResult {
-        Anker::check_is_spl_token_account(
-            "Solido's stSOL",
-            &solido.st_sol_mint,
-            token_account_info,
-        )
+    pub fn check_is_st_sol_account(
+        &self,
+        solido: &Lido,
+        token_account_info: &AccountInfo,
+    ) -> ProgramResult {
+        Anker::check_is_spl_token_account("Solido's stSOL", &solido.st_sol_mint, token_account_info)
     }
 }
 

--- a/anker/src/state.rs
+++ b/anker/src/state.rs
@@ -1,34 +1,42 @@
-use crate::{error::AnkerError, ANKER_RESERVE_ACCOUNT};
+use crate::{error::AnkerError, ANKER_RESERVE_ACCOUNT, ANKER_RESERVE_AUTHORITY, ANKER_MINT_AUTHORITY};
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use lido::util::serialize_b58;
+use lido::state::Lido;
 use serde::Serialize;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program_pack::Pack, pubkey::Pubkey,
 };
 
 /// Size of the serialized [`Anker`] struct, in bytes.
-pub const ANKER_LEN: usize = 99;
+pub const ANKER_LEN: usize = 100;
 
 #[repr(C)]
 #[derive(
     Clone, Debug, Default, BorshDeserialize, BorshSerialize, BorshSchema, Eq, PartialEq, Serialize,
 )]
 pub struct Anker {
+    /// The Solido program that owns the `solido` instance.
+    #[serde(serialize_with = "serialize_b58")]
+    pub solido_program_id: Pubkey,
+
+    /// The associated Solido instance address.
+    #[serde(serialize_with = "serialize_b58")]
+    pub solido: Pubkey,
+
     /// The SPL Token mint address for bSOL.
     #[serde(serialize_with = "serialize_b58")]
-    pub bsol_mint: Pubkey,
+    pub b_sol_mint: Pubkey,
 
-    /// Reserve authority for `reserve_account`.
-    #[serde(serialize_with = "serialize_b58")]
-    pub reserve_authority: Pubkey,
+    /// Bump seed for the derived address that this Anker instance should live at.
+    pub self_bump_seed: u8,
 
-    /// The associated LIDO state address.
-    #[serde(serialize_with = "serialize_b58")]
-    pub lido: Pubkey,
-
-    /// Bump seeds for signing messages on behalf of the authority.
+    /// Bump seed for the mint authority derived address.
     pub mint_authority_bump_seed: u8,
+
+    /// Bump seed for the reserve authority (owner of the reserve account) derived address.
     pub reserve_authority_bump_seed: u8,
+
+    /// Bump seed for the reserve account (SPL token account that holds stSOL).
     pub reserve_account_bump_seed: u8,
 }
 
@@ -42,15 +50,125 @@ impl Anker {
         Ok(())
     }
 
-    pub fn check_is_b_sol_account(&self, token_account_info: &AccountInfo) -> ProgramResult {
+    /// Confirm that the account address is the derived address where Anker instance should live.
+    pub fn check_self_address(&self, anker_program_id: &Pubkey, account_info: &AccountInfo) -> ProgramResult {
+        let address = Pubkey::create_program_address(
+            &[
+                self.solido.as_ref(),
+                &[self.self_bump_seed],
+            ],
+            anker_program_id,
+        ).expect("Depends only on Anker-controlled values, should not fail.");
+
+        if *account_info.key != address {
+            msg!(
+                "Expected Anker instance for Solido instance {} to be {}, but found {} instead.",
+                self.solido,
+                address,
+                account_info.key,
+            );
+            return Err(AnkerError::InvalidDerivedAccount.into());
+        }
+        Ok(())
+    }
+
+    /// Confirm that the derived account address matches the `account_info` adddress.
+    fn check_derived_account_address(&self, name: &'static str, seed: &'static [u8], bump_seed: u8, anker_program_id: &Pubkey, anker_instance: &Pubkey, account_info: &AccountInfo) -> ProgramResult {
+        let address = Pubkey::create_program_address(
+            &[
+                anker_instance.as_ref(),
+                seed,
+                &[bump_seed],
+            ],
+            anker_program_id,
+        ).expect("Depends only on Anker-controlled values, should not fail.");
+
+        if *account_info.key != address {
+            msg!(
+                "Expected {} to be {}, but found {} instead.",
+                name,
+                address,
+                account_info.key,
+            );
+            return Err(AnkerError::InvalidDerivedAccount.into());
+        }
+        Ok(())
+    }
+
+    /// Confirm that the provided reserve account is the one that belongs to this instance.
+    ///
+    /// This does not check that the reserve is an stSOL account.
+    pub fn check_reserve_address(&self, anker_program_id: &Pubkey, anker_instance: &Pubkey, reserve_account_info: &AccountInfo) -> ProgramResult {
+        self.check_derived_account_address(
+            "the reserve account",
+            ANKER_RESERVE_ACCOUNT,
+            self.reserve_account_bump_seed,
+            anker_program_id,
+            anker_instance,
+            reserve_account_info,
+        )
+    }
+
+    /// Confirm that the provided reserve authority is the one that belongs to this instance.
+    pub fn check_reserve_authority(&self, anker_program_id: &Pubkey, anker_instance: &Pubkey, reserve_authority_info: &AccountInfo) -> ProgramResult {
+        self.check_derived_account_address(
+            "the reserve authority",
+            ANKER_RESERVE_AUTHORITY,
+            self.reserve_authority_bump_seed,
+            anker_program_id,
+            anker_instance,
+            reserve_authority_info,
+        )
+    }
+
+    /// Confirm that the provided bSOL mint authority is the one that belongs to this instance.
+    pub fn check_mint_authority(&self, anker_program_id: &Pubkey, anker_instance: &Pubkey, mint_authority_info: &AccountInfo) -> ProgramResult {
+        self.check_derived_account_address(
+            "the bSOL mint authority",
+            ANKER_MINT_AUTHORITY,
+            self.mint_authority_bump_seed,
+            anker_program_id,
+            anker_instance,
+            mint_authority_info,
+        )
+    }
+
+    /// Confirm that the provided mint account is the one stored in this instance.
+    pub fn check_mint(&self, provided_mint: &AccountInfo) -> ProgramResult {
+        if *provided_mint.owner != spl_token::id() {
+            msg!(
+                "Expected bSOL mint to be owned by the SPL token program ({}), but found {}.",
+                spl_token::id(),
+                provided_mint.owner,
+            );
+            return Err(AnkerError::InvalidTokenMint.into());
+        }
+
+        if self.b_sol_mint != *provided_mint.key {
+            msg!(
+                "Invalid mint account, expected {}, but found {}.",
+                self.b_sol_mint,
+                provided_mint.key,
+            );
+            return Err(AnkerError::InvalidTokenMint.into());
+        }
+        Ok(())
+    }
+
+    fn check_is_spl_token_account(
+        mint_name: &'static str,
+        mint_address: &Pubkey,
+        token_account_info: &AccountInfo,
+    ) -> ProgramResult {
         if token_account_info.owner != &spl_token::id() {
             msg!(
                 "Expected SPL token account to be owned by {}, but it's owned by {} instead.",
                 spl_token::id(),
                 token_account_info.owner
             );
-            return Err(AnkerError::InvalidBSolAccountOwner.into());
+            return Err(AnkerError::InvalidTokenAccountOwner.into());
         }
+
         let token_account =
             match spl_token::state::Account::unpack_from_slice(&token_account_info.data.borrow()) {
                 Ok(account) => account,
@@ -59,70 +177,40 @@ impl Anker {
                         "Expected an SPL token account at {}.",
                         token_account_info.key
                     );
-                    return Err(AnkerError::InvalidBSolAccount.into());
+                    return Err(AnkerError::InvalidTokenAccount.into());
                 }
             };
 
-        if token_account.mint != self.bsol_mint {
+        if token_account.mint != *mint_address {
             msg!(
-                "Expected mint of {} to be our bSOL mint ({}), but found {}.",
+                "Expected mint of {} to be {} mint ({}), but found {}.",
                 token_account_info.key,
-                self.bsol_mint,
+                mint_name,
+                mint_address,
                 token_account.mint,
             );
-            return Err(AnkerError::InvalidBSolMint.into());
+            return Err(AnkerError::InvalidTokenMint.into());
         }
+
         Ok(())
     }
 
-    pub fn check_reserve_account(
-        &self,
-        program_id: &Pubkey,
-        anker_state: &Pubkey,
-        provided_reserve: &Pubkey,
-    ) -> ProgramResult {
-        let reserve_account = Pubkey::create_program_address(
-            &[
-                &anker_state.to_bytes(),
-                ANKER_RESERVE_ACCOUNT,
-                &[self.reserve_account_bump_seed],
-            ],
-            program_id,
-        )?;
-
-        if &reserve_account != provided_reserve {
-            msg!(
-                "Invalid reserve account, expected {}, but found {}.",
-                reserve_account,
-                provided_reserve,
-            );
-            return Err(AnkerError::InvalidReserveAccount.into());
-        }
-        Ok(())
+    /// Confirm that the account is an SPL token account that holds bSOL.
+    pub fn check_is_b_sol_account(&self, token_account_info: &AccountInfo) -> ProgramResult {
+        Anker::check_is_spl_token_account(
+            "our bSOL",
+            &self.b_sol_mint,
+            token_account_info,
+        )
     }
 
-    pub fn check_mint(&self, provided_mint: &Pubkey) -> ProgramResult {
-        if &self.bsol_mint != provided_mint {
-            msg!(
-                "Invalid mint account, expected {}, but found {}.",
-                self.bsol_mint,
-                provided_mint,
-            );
-            return Err(AnkerError::InvalidBSolMint.into());
-        }
-        Ok(())
-    }
-
-    pub fn check_lido(&self, provided_lido: &Pubkey) -> ProgramResult {
-        if &self.lido != provided_lido {
-            msg!(
-                "Invalid Lido account, expected {}, but found {}.",
-                self.lido,
-                provided_lido,
-            );
-            return Err(AnkerError::WrongLidoInstance.into());
-        }
-        Ok(())
+    /// Confirm that the account is an SPL token account that holds stSOL.
+    pub fn check_is_st_sol_account(&self, solido: &Lido, token_account_info: &AccountInfo) -> ProgramResult {
+        Anker::check_is_spl_token_account(
+            "Solido's stSOL",
+            &solido.st_sol_mint,
+            token_account_info,
+        )
     }
 }
 

--- a/anker/src/state.rs
+++ b/anker/src/state.rs
@@ -52,7 +52,7 @@ impl Anker {
         Ok(())
     }
 
-    /// Confirm that the account address is the derived address where Anker instance should live.
+    /// Confirm that the account address is the derived address where the Anker instance should live.
     pub fn check_self_address(
         &self,
         anker_program_id: &Pubkey,

--- a/testlib/src/anker_context.rs
+++ b/testlib/src/anker_context.rs
@@ -113,7 +113,6 @@ impl Context {
                 &instruction::DepositAccountsMeta {
                     anker: self.anker,
                     solido: self.solido_context.solido.pubkey(),
-                    solido_program: solido_context::id(),
                     from_account: from_st_sol,
                     user_authority: user.pubkey(),
                     to_reserve_account: self.reserve,


### PR DESCRIPTION
* Add some missing authorization checks, move some others to make them more obvious.
* Don't store derived addresses, in the state, compute them instead.
* Do store the Solido program id in the state, so we don't have to pass it in in transactions (because we never call it).

Please review very carefully!