### PR TITLE
Pin cargo-binutils version on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,21 +205,21 @@ jobs:
           sudo apt update
           sudo apt-get install -y libudev-dev
           rustup component add llvm-tools-preview
-          rustup toolchain install nightly-2021-06-25
-          export RUSTUP_TOOLCHAIN="nightly-2021-06-25"
+          rustup toolchain install nightly-2021-11-18
+          export RUSTUP_TOOLCHAIN="nightly-2021-11-18"
           cargo install rustfilt --version 0.2.1
-          cargo install cargo-binutils --version 0.3.3
+          cargo install cargo-binutils --version 0.3.4
           sh -c "$(curl -sSfL https://release.solana.com/v1.7.8/install)"
 
       - name: Build on-chain programs (without coverage)
         run: |
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
-          cargo +nightly-2021-06-25 build-bpf
+          cargo +nightly-2021-11-18 build-bpf
 
       - name: Collect coverage
         run: |
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
-          export RUSTUP_TOOLCHAIN="nightly-2021-06-25"
+          export RUSTUP_TOOLCHAIN="nightly-2021-11-18"
           validator=$(tests/start_test_validator.py)
 
           # Perform initial Solana setup.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,8 +197,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: coverage-1.7.8-v1-${{ hashFiles('Cargo.lock') }}
-          restore-keys: coverage-1.7.8-v1
+          key: coverage-1.7.8-v2-${{ hashFiles('Cargo.lock') }}
+          restore-keys: coverage-1.7.8-v2
 
       - name: Install development tools
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,8 @@ jobs:
           sudo apt-get install -y libudev-dev
           rustup component add llvm-tools-preview
           rustup toolchain install nightly-2021-06-25
-          cargo install rustfilt cargo-binutils
+          cargo install rustfilt --version 0.2.1
+          cargo install cargo-binutils --version 0.3.3
           sh -c "$(curl -sSfL https://release.solana.com/v1.7.8/install)"
 
       - name: Build on-chain programs (without coverage)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,7 @@ jobs:
           sudo apt-get install -y libudev-dev
           rustup component add llvm-tools-preview
           rustup toolchain install nightly-2021-06-25
+          export RUSTUP_TOOLCHAIN="nightly-2021-06-25"
           cargo install rustfilt --version 0.2.1
           cargo install cargo-binutils --version 0.3.3
           sh -c "$(curl -sSfL https://release.solana.com/v1.7.8/install)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,7 @@ jobs:
       - name: Collect coverage
         run: |
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
+          export RUSTUP_TOOLCHAIN="nightly-2021-06-25"
           validator=$(tests/start_test_validator.py)
 
           # Perform initial Solana setup.

--- a/tests/coverage.py
+++ b/tests/coverage.py
@@ -27,7 +27,7 @@ from typing import List, Iterable
 # Using -Z instrument-coverage requires a nightly rustc. Passing
 # except-unused-generics to it requires a fairly recent nightly
 # (2021-05 was too old).
-NIGHTLY = '+nightly-2021-06-25'
+NIGHTLY = '+nightly-2021-11-18'
 
 
 def build_binaries(command: List[str]) -> Iterable[str]:

--- a/tests/coverage.py
+++ b/tests/coverage.py
@@ -67,7 +67,7 @@ def merge_profdata() -> None:
         'profdata',
         '--',
         'merge',
-        '-output',
+        '--output',
         'coverage/tests.profdata',
     ]
     for fname in os.listdir('coverage'):


### PR DESCRIPTION
Version 0.3.3 works fine. Version 0.3.4 breaks. We were installing the latest version, then we got

    warning: coverage/test-4576654162861138612_0.profraw: unsupported instrumentation profile format version
    warning: coverage/test-13711470682246040593_0.profraw: unsupported instrumentation profile format version
    warning: coverage/test-16191544375763750091_0.profraw: unsupported instrumentation profile format version
    warning: coverage/test-253906023697167524_0.profraw: unsupported instrumentation profile format version
    warning: coverage/test-12081129809678533700_0.profraw: unsupported instrumentation profile format version
    warning: coverage/test-3327360644137008983_0.profraw: unsupported instrumentation profile format version
    (...)
    command '[
      'cargo', 'profdata', '--', 'merge', '-output',
      'coverage/tests.profdata',
      'coverage/test-4576654162861138612_0.profraw',
      'coverage/test-253906023697167524_0.profraw',
      'coverage/test-13711470682246040593_0.profraw',
      'coverage/test-3327360644137008983_0.profraw',
      'coverage/test-16191544375763750091_0.profraw',
      'coverage/test-12081129809678533700_0.profraw'
    ]' returned non-zero exit status 1

I don't want to figure out what changed in 0.3.4 right now, let's just pin it to 0.3.3 and hopefully that will make it build again.