### PR TITLE
Add more tests for Anker deposits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,7 +1776,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "solana-vote-program",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token",
  "testlib",
 ]
@@ -2997,9 +2997,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-config-program",
+ "solana-config-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
- "solana-vote-program",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token",
  "thiserror",
  "zstd",
@@ -3008,8 +3008,6 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51c83e33eb5fc2a688db5e7e19a8c5b481385e1d9f30b012962e9bcdb002629"
 dependencies = [
  "bincode",
  "borsh",
@@ -3027,8 +3025,6 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73a34a243df509dfde8fe42129aa34a3db9913e90b7c7eb290f597361016268"
 dependencies = [
  "mio 0.7.13",
  "serde",
@@ -3039,16 +3035,14 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929ed2f73a4a9c80ddff4b1b49ecc81fa6e8689ca475e9e625034aaebc22516"
 dependencies = [
  "bincode",
  "futures 0.3.16",
  "log",
  "mio 0.7.13",
  "solana-banks-interface",
- "solana-metrics",
- "solana-runtime",
+ "solana-metrics 1.7.8",
+ "solana-runtime 1.7.8",
  "solana-sdk",
  "tarpc",
  "tokio 1.9.0",
@@ -3059,8 +3053,6 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d848ee15b984d2703750a52e3cbe23024256184b11426a1677bc98934087f8c7"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3070,8 +3062,8 @@ dependencies = [
  "num-traits",
  "rand_core 0.6.3",
  "sha3",
- "solana-measure",
- "solana-runtime",
+ "solana-measure 1.7.8",
+ "solana-runtime 1.7.8",
  "solana-sdk",
  "solana_rbpf",
  "thiserror",
@@ -3135,11 +3127,24 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "solana-vote-program",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio 1.9.0",
  "tungstenite",
  "url",
+]
+
+[[package]]
+name = "solana-config-program"
+version = "1.7.8"
+dependencies = [
+ "bincode",
+ "chrono",
+ "log",
+ "rand_core 0.6.3",
+ "serde",
+ "serde_derive",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -3160,8 +3165,6 @@ dependencies = [
 [[package]]
 name = "solana-crate-features"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9b446eea7a5af7d4631ce3fd0625439fdc68eda4557223233f1c6bba3e847a"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -3196,8 +3199,8 @@ dependencies = [
  "serde_derive",
  "solana-clap-utils",
  "solana-cli-config",
- "solana-logger",
- "solana-metrics",
+ "solana-logger 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
  "solana-version",
  "spl-memo",
@@ -3208,8 +3211,6 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6760c1dd139c202ef6df28bff467c904aa35b1aa1a59be268c47aec8bc6c0"
 dependencies = [
  "bs58 0.3.1",
  "bv",
@@ -3221,20 +3222,27 @@ dependencies = [
  "serde_derive",
  "sha2",
  "solana-frozen-abi-macro",
- "solana-logger",
+ "solana-logger 1.7.8",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dbe296c16dec41e8e6f4e6c2694c6224820d34c0ab11a2d3ff9683f44878ef"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "rustc_version",
  "syn 1.0.74",
+]
+
+[[package]]
+name = "solana-logger"
+version = "1.7.8"
+dependencies = [
+ "env_logger",
+ "lazy_static",
+ "log",
 ]
 
 [[package]]
@@ -3251,11 +3259,32 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.7.8"
+dependencies = [
+ "log",
+ "solana-metrics 1.7.8",
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-measure"
+version = "1.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2915d20f35948b35deffa8624cb189385f13758bd171d8d4a966ae8bf360a4"
 dependencies = [
  "log",
- "solana-metrics",
+ "solana-metrics 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-metrics"
+version = "1.7.8"
+dependencies = [
+ "env_logger",
+ "gethostname",
+ "lazy_static",
+ "log",
+ "reqwest",
  "solana-sdk",
 ]
 
@@ -3288,7 +3317,7 @@ dependencies = [
  "serde_derive",
  "socket2 0.3.19",
  "solana-clap-utils",
- "solana-logger",
+ "solana-logger 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
  "solana-version",
  "tokio 1.9.0",
@@ -3298,8 +3327,6 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5e5dd99d642b5e89eeb20457310c3c23f20dbf44e67c64e473a02fbc50d646"
 dependencies = [
  "bincode",
  "blake3",
@@ -3325,7 +3352,7 @@ dependencies = [
  "sha3",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
+ "solana-logger 1.7.8",
  "solana-sdk-macro",
  "thiserror",
 ]
@@ -3333,8 +3360,6 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a2961354afb2ef3ed35ec477961f1f6f0113291c83b993a30382180c496d96"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3348,12 +3373,20 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger",
- "solana-runtime",
+ "solana-logger 1.7.8",
+ "solana-runtime 1.7.8",
  "solana-sdk",
- "solana-vote-program",
+ "solana-vote-program 1.7.8",
  "thiserror",
  "tokio 1.9.0",
+]
+
+[[package]]
+name = "solana-rayon-threadlimit"
+version = "1.7.8"
+dependencies = [
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -3390,6 +3423,55 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "1.7.8"
+dependencies = [
+ "arrayref",
+ "bincode",
+ "blake3",
+ "bv",
+ "byteorder",
+ "bzip2",
+ "crossbeam-channel 0.4.4",
+ "dashmap",
+ "dir-diff",
+ "flate2",
+ "fnv",
+ "itertools 0.9.0",
+ "lazy_static",
+ "libc",
+ "libloading",
+ "log",
+ "memmap2",
+ "num-derive",
+ "num-traits",
+ "num_cpus",
+ "ouroboros",
+ "rand 0.7.3",
+ "rayon",
+ "regex",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-config-program 1.7.8",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger 1.7.8",
+ "solana-measure 1.7.8",
+ "solana-metrics 1.7.8",
+ "solana-rayon-threadlimit 1.7.8",
+ "solana-sdk",
+ "solana-secp256k1-program 1.7.8",
+ "solana-stake-program 1.7.8",
+ "solana-vote-program 1.7.8",
+ "symlink",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
+name = "solana-runtime"
+version = "1.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f047727075c3434f17d33467bd26033fea3b4e71e7c23caa261015507b162581"
 dependencies = [
@@ -3420,17 +3502,17 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-config-program",
+ "solana-config-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
- "solana-measure",
- "solana-metrics",
- "solana-rayon-threadlimit",
+ "solana-logger 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-measure 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rayon-threadlimit 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
- "solana-secp256k1-program",
- "solana-stake-program",
- "solana-vote-program",
+ "solana-secp256k1-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-stake-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "symlink",
  "tar",
  "tempfile",
@@ -3441,8 +3523,6 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0048d346fdf3629dca2bccc2ed63320da9d0291c32b816911ed63d34c65286a5"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3480,7 +3560,7 @@ dependencies = [
  "solana-crate-features",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
+ "solana-logger 1.7.8",
  "solana-program",
  "solana-sdk-macro",
  "thiserror",
@@ -3490,8 +3570,6 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee909dcddb5b4d349b3e5e1ae92f6660cd2f783dea392ae2e73210776aadc9b"
 dependencies = [
  "bs58 0.3.1",
  "proc-macro2 1.0.28",
@@ -3503,10 +3581,37 @@ dependencies = [
 [[package]]
 name = "solana-secp256k1-program"
 version = "1.7.8"
+dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-secp256k1-program"
+version = "1.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd4c29c6b269800898610da38de45d28fd56b24cb4030c588ffd6acc11a7443"
 dependencies = [
  "solana-sdk",
+]
+
+[[package]]
+name = "solana-stake-program"
+version = "1.7.8"
+dependencies = [
+ "bincode",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-config-program 1.7.8",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-metrics 1.7.8",
+ "solana-sdk",
+ "solana-vote-program 1.7.8",
+ "thiserror",
 ]
 
 [[package]]
@@ -3522,12 +3627,12 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-config-program",
+ "solana-config-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-metrics",
+ "solana-metrics 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
- "solana-vote-program",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -3546,9 +3651,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
- "solana-runtime",
+ "solana-runtime 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
- "solana-vote-program",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
@@ -3567,8 +3672,27 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
+ "solana-logger 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
+]
+
+[[package]]
+name = "solana-vote-program"
+version = "1.7.8"
+dependencies = [
+ "bincode",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger 1.7.8",
+ "solana-metrics 1.7.8",
+ "solana-sdk",
+ "thiserror",
 ]
 
 [[package]]
@@ -3586,8 +3710,8 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
- "solana-metrics",
+ "solana-logger 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
  "thiserror",
 ]
@@ -3633,13 +3757,13 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
- "solana-config-program",
- "solana-logger",
+ "solana-config-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "solana-stake-program",
- "solana-vote-program",
+ "solana-stake-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-associated-token-account",
  "spl-token",
  "tiny_http",
@@ -3855,7 +3979,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "solana-vote-program",
+ "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo",
  "spl-token",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "bincode",
  "borsh",
@@ -3025,6 +3026,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "mio 0.7.13",
  "serde",
@@ -3035,14 +3037,15 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "bincode",
  "futures 0.3.16",
  "log",
  "mio 0.7.13",
  "solana-banks-interface",
- "solana-metrics 1.7.8",
- "solana-runtime 1.7.8",
+ "solana-metrics 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-runtime 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "solana-sdk",
  "tarpc",
  "tokio 1.9.0",
@@ -3053,6 +3056,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3062,8 +3066,8 @@ dependencies = [
  "num-traits",
  "rand_core 0.6.3",
  "sha3",
- "solana-measure 1.7.8",
- "solana-runtime 1.7.8",
+ "solana-measure 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-runtime 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "solana-sdk",
  "solana_rbpf",
  "thiserror",
@@ -3137,19 +3141,6 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.7.8"
-dependencies = [
- "bincode",
- "chrono",
- "log",
- "rand_core 0.6.3",
- "serde",
- "serde_derive",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-config-program"
-version = "1.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b5348055cf52ab01efc1578d4159ec40bb39c3913df4365787c3e1382c101c1"
 dependencies = [
@@ -3163,8 +3154,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-config-program"
+version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
+dependencies = [
+ "bincode",
+ "chrono",
+ "log",
+ "rand_core 0.6.3",
+ "serde",
+ "serde_derive",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-crate-features"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -3211,6 +3217,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "bs58 0.3.1",
  "bv",
@@ -3222,27 +3229,19 @@ dependencies = [
  "serde_derive",
  "sha2",
  "solana-frozen-abi-macro",
- "solana-logger 1.7.8",
+ "solana-logger 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "rustc_version",
  "syn 1.0.74",
-]
-
-[[package]]
-name = "solana-logger"
-version = "1.7.8"
-dependencies = [
- "env_logger",
- "lazy_static",
- "log",
 ]
 
 [[package]]
@@ -3257,12 +3256,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-measure"
+name = "solana-logger"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
+ "env_logger",
+ "lazy_static",
  "log",
- "solana-metrics 1.7.8",
- "solana-sdk",
 ]
 
 [[package]]
@@ -3277,8 +3277,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-measure"
+version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
+dependencies = [
+ "log",
+ "solana-metrics 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-metrics"
 version = "1.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d87867f1f9e399274e08902eb72c9158bef5399e2566161dbe831abeaaa7d14"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -3291,8 +3303,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d87867f1f9e399274e08902eb72c9158bef5399e2566161dbe831abeaaa7d14"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -3327,6 +3338,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "bincode",
  "blake3",
@@ -3352,7 +3364,7 @@ dependencies = [
  "sha3",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger 1.7.8",
+ "solana-logger 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "solana-sdk-macro",
  "thiserror",
 ]
@@ -3360,6 +3372,7 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3373,10 +3386,10 @@ dependencies = [
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.7.8",
- "solana-runtime 1.7.8",
+ "solana-logger 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-runtime 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "solana-sdk",
- "solana-vote-program 1.7.8",
+ "solana-vote-program 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "thiserror",
  "tokio 1.9.0",
 ]
@@ -3384,6 +3397,8 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c3a0037afa0b03e0aad9f8fb451d1008d5538023919835cf86c9833bc93103"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3392,8 +3407,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c3a0037afa0b03e0aad9f8fb451d1008d5538023919835cf86c9833bc93103"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3418,55 +3432,6 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "uriparse",
-]
-
-[[package]]
-name = "solana-runtime"
-version = "1.7.8"
-dependencies = [
- "arrayref",
- "bincode",
- "blake3",
- "bv",
- "byteorder",
- "bzip2",
- "crossbeam-channel 0.4.4",
- "dashmap",
- "dir-diff",
- "flate2",
- "fnv",
- "itertools 0.9.0",
- "lazy_static",
- "libc",
- "libloading",
- "log",
- "memmap2",
- "num-derive",
- "num-traits",
- "num_cpus",
- "ouroboros",
- "rand 0.7.3",
- "rayon",
- "regex",
- "rustc_version",
- "serde",
- "serde_derive",
- "solana-config-program 1.7.8",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-logger 1.7.8",
- "solana-measure 1.7.8",
- "solana-metrics 1.7.8",
- "solana-rayon-threadlimit 1.7.8",
- "solana-sdk",
- "solana-secp256k1-program 1.7.8",
- "solana-stake-program 1.7.8",
- "solana-vote-program 1.7.8",
- "symlink",
- "tar",
- "tempfile",
- "thiserror",
- "zstd",
 ]
 
 [[package]]
@@ -3521,8 +3486,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-runtime"
+version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
+dependencies = [
+ "arrayref",
+ "bincode",
+ "blake3",
+ "bv",
+ "byteorder",
+ "bzip2",
+ "crossbeam-channel 0.4.4",
+ "dashmap",
+ "dir-diff",
+ "flate2",
+ "fnv",
+ "itertools 0.9.0",
+ "lazy_static",
+ "libc",
+ "libloading",
+ "log",
+ "memmap2",
+ "num-derive",
+ "num-traits",
+ "num_cpus",
+ "ouroboros",
+ "rand 0.7.3",
+ "rayon",
+ "regex",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-config-program 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-measure 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-metrics 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-rayon-threadlimit 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-sdk",
+ "solana-secp256k1-program 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-stake-program 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-vote-program 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "symlink",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
 name = "solana-sdk"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3560,7 +3576,7 @@ dependencies = [
  "solana-crate-features",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger 1.7.8",
+ "solana-logger 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "solana-program",
  "solana-sdk-macro",
  "thiserror",
@@ -3570,19 +3586,13 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
  "bs58 0.3.1",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "rustversion",
  "syn 1.0.74",
-]
-
-[[package]]
-name = "solana-secp256k1-program"
-version = "1.7.8"
-dependencies = [
- "solana-sdk",
 ]
 
 [[package]]
@@ -3595,23 +3605,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-stake-program"
+name = "solana-secp256k1-program"
 version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
 dependencies = [
- "bincode",
- "log",
- "num-derive",
- "num-traits",
- "rustc_version",
- "serde",
- "serde_derive",
- "solana-config-program 1.7.8",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-metrics 1.7.8",
  "solana-sdk",
- "solana-vote-program 1.7.8",
- "thiserror",
 ]
 
 [[package]]
@@ -3633,6 +3631,27 @@ dependencies = [
  "solana-metrics 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk",
  "solana-vote-program 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-stake-program"
+version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
+dependencies = [
+ "bincode",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-config-program 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-metrics 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-sdk",
+ "solana-vote-program 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "thiserror",
 ]
 
@@ -3679,25 +3698,6 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.7.8"
-dependencies = [
- "bincode",
- "log",
- "num-derive",
- "num-traits",
- "rustc_version",
- "serde",
- "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-logger 1.7.8",
- "solana-metrics 1.7.8",
- "solana-sdk",
- "thiserror",
-]
-
-[[package]]
-name = "solana-vote-program"
-version = "1.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "506df67749a343d9f9a48b7b5566faf2bc43d0611b520467664a58cd78d4b1be"
 dependencies = [
@@ -3712,6 +3712,26 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-logger 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-metrics 1.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-vote-program"
+version = "1.7.8"
+source = "git+https://github.com/ChorusOne/solana?branch=program-test-178#af358e1a526f428ea35462647f2b9b8b31a2eaf4"
+dependencies = [
+ "bincode",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
+ "solana-metrics 1.7.8 (git+https://github.com/ChorusOne/solana?branch=program-test-178)",
  "solana-sdk",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,15 @@ panic = "abort"
 [profile.release]
 panic = "abort"
 
+# We take our fork of Solana 1.7.8, which has one patch applied:
+# https://github.com/solana-labs/solana/pull/21415.
+# This patch enables testing more situations using solana-program-test.
+# We need to override the other Solana packages as well because they are interdependent,
+# and if we don’t override them, Cargo will include two incompatible versions of those
+# packages (one from crates.io and one from the fork).
 [patch.crates-io]
-solana-program-test = { path = "../solana/program-test" }
-solana-sdk = { path = "../solana/sdk" }
-solana-program = { path = "../solana/sdk/program" }
-solana-frozen-abi-macro = { path = "../solana/frozen-abi/macro" }
-solana-frozen-abi = { path = "../solana/frozen-abi" }
+solana-frozen-abi = { git = "https://github.com/ChorusOne/solana", branch = "program-test-178" }
+solana-frozen-abi-macro = { git = "https://github.com/ChorusOne/solana", branch = "program-test-178" }
+solana-program = { git = "https://github.com/ChorusOne/solana", branch = "program-test-178" }
+solana-program-test = { git = "https://github.com/ChorusOne/solana", branch = "program-test-178" }
+solana-sdk = { git = "https://github.com/ChorusOne/solana", branch = "program-test-178" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+
+[patch.crates-io]
+solana-program-test = { path = "../solana/program-test" }
+solana-sdk = { path = "../solana/sdk" }
+solana-program = { path = "../solana/sdk/program" }
+solana-frozen-abi-macro = { path = "../solana/frozen-abi/macro" }
+solana-frozen-abi = { path = "../solana/frozen-abi" }

--- a/anker/tests/tests/deposit.rs
+++ b/anker/tests/tests/deposit.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 Chorus One AG
 // SPDX-License-Identifier: GPL-3.0
 
-use anker::token::BLamports;
 use anker::error::AnkerError;
+use anker::token::BLamports;
 use lido::token::{Lamports, StLamports};
 use solana_program_test::tokio;
 use solana_sdk::account::WritableAccount;
@@ -73,7 +73,10 @@ async fn test_deposit_fails_with_wrong_instance_address() {
     );
     fake_account_shared.set_rent_epoch(real_account.rent_epoch);
     fake_account_shared.set_data(real_account.data.clone());
-    context.solido_context.context.set_account(&fake_addr.pubkey(), &fake_account_shared);
+    context
+        .solido_context
+        .context
+        .set_account(&fake_addr.pubkey(), &fake_account_shared);
 
     // Confirm that we succeeded to make a copy. Only the addresses should differ.
     let fake_account = context.solido_context.get_account(fake_addr.pubkey()).await;

--- a/anker/tests/tests/deposit.rs
+++ b/anker/tests/tests/deposit.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use anker::token::BLamports;
+use anker::error::AnkerError;
 use lido::token::{Lamports, StLamports};
 use solana_program_test::tokio;
+use solana_sdk::signer::Signer;
 use testlib::anker_context::Context;
+use testlib::assert_solido_error;
 
 const TEST_DEPOSIT_AMOUNT: StLamports = StLamports(1_000_000_000);
 
@@ -37,4 +40,19 @@ async fn test_successful_deposit_different_exchange_rate() {
     // The exchange rate is now 1:2.
     assert_eq!(reserve_balance, StLamports(500_000_000));
     assert_eq!(recipient_balance, BLamports(TEST_DEPOSIT_AMOUNT.0));
+}
+
+#[tokio::test]
+async fn test_deposit_fails_with_wrong_reserve() {
+    let mut context = Context::new().await;
+
+    let fake_reserve = context.solido_context.deterministic_keypair.new_keypair();
+    context.reserve = fake_reserve.pubkey();
+
+    // The program should confirm that the reserve we use is the reserve of the
+    // instance, and fail the transaction if it's a different account. Otherwise
+    // we could pass in a reserve controlled by us (where we are an attacker), and
+    // get bSOL while also retaining the stSOL.
+    let result = context.try_deposit(Lamports(TEST_DEPOSIT_AMOUNT.0)).await;
+    assert_solido_error!(result, AnkerError::InvalidDerivedAccount);
 }

--- a/anker/tests/tests/withdraw.rs
+++ b/anker/tests/tests/withdraw.rs
@@ -3,8 +3,13 @@
 
 use anker::error::AnkerError;
 use anker::token::BLamports;
+use borsh::BorshSerialize;
 use lido::token::{Lamports, StLamports};
+use lido::state::Lido;
+use solana_program::{borsh::try_from_slice_unchecked};
 use solana_program_test::tokio;
+use solana_sdk::account::WritableAccount;
+use solana_sdk::signer::Signer;
 use testlib::anker_context::Context;
 use testlib::assert_solido_error;
 
@@ -125,4 +130,56 @@ async fn test_withdraw_wrong_token_mint() {
     context
         .withdraw(&owner, b_sol_account, BLamports(250_000_000))
         .await;
+}
+
+#[tokio::test]
+async fn test_withdraw_after_st_sol_price_decrease() {
+    let mut context = Context::new().await;
+
+    // Deposit some SOL into Solido, then put that in Anker.
+    let (owner, b_sol_recipient) = context.deposit(TEST_DEPOSIT_AMOUNT).await;
+    let b_sol_balance = context.get_b_sol_balance(b_sol_recipient).await;
+
+    // Mutate the Solido instance and sabotage its exchange rate to make the
+    // value of stSOL go down. Normally this cannot happen, but if Solana would
+    // introduce slashing in the future, then it might.
+    context.solido_context.advance_to_normal_epoch(1);
+    context.solido_context.update_exchange_rate().await;
+    let mut solido_account = context.solido_context.get_account(context.solido_context.solido.pubkey()).await;
+    let mut solido = try_from_slice_unchecked::<Lido>(solido_account.data.as_slice()).unwrap();
+    // Set 1 stSOL = 0.5 SOL.
+    solido.exchange_rate.sol_balance = Lamports(1_000_000_000);
+    solido.exchange_rate.st_sol_supply = StLamports(2_000_000_000);
+    solido_account.data = BorshSerialize::try_to_vec(&solido).unwrap();
+    let mut solido_account_shared = solana_sdk::account::AccountSharedData::new(
+        solido_account.lamports,
+        solido_account.data.len(),
+        &solido_account.owner,
+    );
+    solido_account_shared.set_rent_epoch(solido_account.rent_epoch);
+    solido_account_shared.set_data(solido_account.data);
+    context.solido_context.context.set_account(&context.solido_context.solido.pubkey(), &solido_account_shared);
+
+    assert_eq!(b_sol_balance, BLamports(1_000_000_000));
+
+    // Withdraw 0.1 bSOL.
+    let st_sol_recipient = context
+        .withdraw(&owner, b_sol_recipient, BLamports(100_000_000))
+        .await;
+
+    // We put in 1 SOL, converted it to stSOL, then to bSOL.
+    // Then the value of stSOL went down by 50%. This breaks the peg, even though
+    // we have 1 bSOL, we can at best withdraw 0.5 SOL now. To make the test
+    // more interesting, if we tried to withdraw the full 1 bSOL and we forgot
+    // to use the right exchange rate, there is not enough stSOL in existence
+    // and the transaction would fail, but if we only withdraw 0.1 bSOL, then
+    // if we used the wrong exchange rate, we would get 0.2 stSOL, which we have.
+    let st_sol_balance = context
+        .solido_context
+        .get_st_sol_balance(st_sol_recipient)
+        .await;
+    // The SOL value of our withdraw is half of the bSOL amount, because the peg
+    // is broken.
+    let sol_value = context.exchange_st_sol(st_sol_balance).await;
+    assert_eq!(sol_value, Lamports(50_000_000));
 }

--- a/anker/tests/tests/withdraw.rs
+++ b/anker/tests/tests/withdraw.rs
@@ -4,9 +4,9 @@
 use anker::error::AnkerError;
 use anker::token::BLamports;
 use borsh::BorshSerialize;
-use lido::token::{Lamports, StLamports};
 use lido::state::Lido;
-use solana_program::{borsh::try_from_slice_unchecked};
+use lido::token::{Lamports, StLamports};
+use solana_program::borsh::try_from_slice_unchecked;
 use solana_program_test::tokio;
 use solana_sdk::account::WritableAccount;
 use solana_sdk::signer::Signer;
@@ -145,7 +145,10 @@ async fn test_withdraw_after_st_sol_price_decrease() {
     // introduce slashing in the future, then it might.
     context.solido_context.advance_to_normal_epoch(1);
     context.solido_context.update_exchange_rate().await;
-    let mut solido_account = context.solido_context.get_account(context.solido_context.solido.pubkey()).await;
+    let mut solido_account = context
+        .solido_context
+        .get_account(context.solido_context.solido.pubkey())
+        .await;
     let mut solido = try_from_slice_unchecked::<Lido>(solido_account.data.as_slice()).unwrap();
     // Set 1 stSOL = 0.5 SOL.
     solido.exchange_rate.sol_balance = Lamports(1_000_000_000);
@@ -158,7 +161,10 @@ async fn test_withdraw_after_st_sol_price_decrease() {
     );
     solido_account_shared.set_rent_epoch(solido_account.rent_epoch);
     solido_account_shared.set_data(solido_account.data);
-    context.solido_context.context.set_account(&context.solido_context.solido.pubkey(), &solido_account_shared);
+    context.solido_context.context.set_account(
+        &context.solido_context.solido.pubkey(),
+        &solido_account_shared,
+    );
 
     assert_eq!(b_sol_balance, BLamports(1_000_000_000));
 

--- a/testlib/src/solido_context.rs
+++ b/testlib/src/solido_context.rs
@@ -27,6 +27,7 @@ use solana_sdk::transport::TransportError;
 use solana_vote_program::vote_instruction;
 use solana_vote_program::vote_state::{VoteInit, VoteState};
 
+use anker::error::AnkerError;
 use lido::account_map::PubkeyAndEntry;
 use lido::processor::StakeType;
 use lido::stake_account::StakeAccount;
@@ -187,6 +188,15 @@ pub async fn send_transaction(
                 err
             ),
             None => println!("This error is not a known Solido error."),
+        }
+        // Even though this is the Solido context, we also check for the Anker error,
+        // because the Anker context builds on this.
+        match AnkerError::from_u32(error_code) {
+            Some(err) => println!(
+                "If this error originated from Anker, it was this variant: {:?}",
+                err,
+            ),
+            None => println!("This error is not a known Anker error."),
         }
     }
 


### PR DESCRIPTION
This adds two tests:

 * Test that deposit fails if you pass in the wrong reserve. (The bug that we had in Solido v0.5 before the audit, and that we added a regression test for there. We should pro-actively test it here.)
 * Test that the program fails if the instance doesn’t live at the right address. For this I modified the `solana-program-test` framework to add the ability to arbitrarily modify accounts, a kind of “god mode” to make it easier to write tests. To use that, override the dependencies so we use our fork instead of the crates.io version.
 * Test that withdraw uses the right exchange rate when the stSOL value goes down.