### PR TITLE
[Anker] Remove ordering restriction for swap tokens.

### DIFF
--- a/anker/src/state.rs
+++ b/anker/src/state.rs
@@ -312,20 +312,28 @@ impl Anker {
             accounts.ust_reserve_account,
         )?;
 
-        // `token_a` should be stSOL.
-        if &token_swap.token_a != accounts.pool_st_sol_account.key {
+        // Pool stSOL and UST token could be swapped.
+        let (pool_st_sol_account, pool_ust_account) =
+            if &token_swap.token_a == accounts.pool_st_sol_account.key {
+                (token_swap.token_a, token_swap.token_b)
+            } else {
+                (token_swap.token_b, token_swap.token_a)
+            };
+
+        // check stSOL token.
+        if &pool_st_sol_account != accounts.pool_st_sol_account.key {
             msg!(
             "Token Swap StSol token is different from what is stored in the instance, expected {}, found {}",
-            token_swap.token_a,
+            pool_st_sol_account,
             accounts.pool_st_sol_account.key
         );
             return Err(AnkerError::WrongSplTokenSwapParameters.into());
         }
         // `token_b` should be UST.
-        if &token_swap.token_b != accounts.pool_ust_account.key {
+        if &pool_ust_account != accounts.pool_ust_account.key {
             msg!(
             "Token Swap UST token is different from what is stored in the instance, expected {}, found {}",
-            token_swap.token_b,
+            pool_ust_account,
             accounts.pool_ust_account.key
         );
             return Err(AnkerError::WrongSplTokenSwapParameters.into());
@@ -339,20 +347,29 @@ impl Anker {
         );
             return Err(AnkerError::WrongSplTokenSwapParameters.into());
         }
+
+        // Get mint from tokens, depending on the order.
+        let (pool_st_sol_mint, pool_ust_mint) =
+            if &token_swap.token_a_mint == accounts.st_sol_mint.key {
+                (token_swap.token_a_mint, token_swap.token_b_mint)
+            } else {
+                (token_swap.token_b_mint, token_swap.token_a_mint)
+            };
+
         // Check stSOL mint.
-        if &token_swap.token_a_mint != accounts.st_sol_mint.key {
+        if &pool_st_sol_mint != accounts.st_sol_mint.key {
             msg!(
             "Token Swap StSol mint is different from what is stored in the instance, expected {}, found {}",
-            token_swap.token_a_mint,
+            pool_st_sol_mint,
             accounts.st_sol_mint.key
         );
             return Err(AnkerError::WrongSplTokenSwapParameters.into());
         }
         // Check UST mint.
-        if &token_swap.token_b_mint != accounts.ust_mint.key {
+        if &pool_ust_mint != accounts.ust_mint.key {
             msg!(
             "Token Swap UST mint is different from what is stored in the instance, expected {}, found {}",
-            token_swap.token_b_mint,
+            pool_ust_mint,
             accounts.ust_mint.key
         );
             return Err(AnkerError::WrongSplTokenSwapParameters.into());

--- a/anker/tests/tests/amm.rs
+++ b/anker/tests/tests/amm.rs
@@ -6,7 +6,8 @@ use testlib::anker_context::Context;
 
 #[tokio::test]
 async fn test_successful_token_swap() {
-    let mut context = Context::new_with_initialized_token_pool().await;
+    let mut context = Context::new().await;
+    context.initialize_token_pool().await;
     let (st_sol_keypair, st_sol_token) = context
         .solido_context
         .deposit(Lamports(10_000_000_000))

--- a/anker/tests/tests/sell_rewards.rs
+++ b/anker/tests/tests/sell_rewards.rs
@@ -2,13 +2,41 @@ use anker::{error::AnkerError, token::MicroUst};
 use lido::token::Lamports;
 use solana_program::pubkey::Pubkey;
 use solana_program_test::tokio;
+use std::mem;
 use testlib::{anker_context::Context, assert_solido_error};
 
 const DEPOSIT_AMOUNT: u64 = 1_000_000_000; // 1e9 units
 
 #[tokio::test]
 async fn test_successful_sell_rewards() {
-    let mut context = Context::new_with_initialized_token_pool().await;
+    let mut context = Context::new_with_token_pool_rewards(Lamports(DEPOSIT_AMOUNT)).await;
+    context.sell_rewards().await;
+
+    let ust_account = context
+        .solido_context
+        .get_account(context.ust_reserve)
+        .await;
+    let ust_spl_account: spl_token::state::Account =
+        spl_token::state::Account::unpack_from_slice(ust_account.data.as_slice()).unwrap();
+
+    // Exchange rate is 12 stSol : 13 Sol
+    // We have 1 stSOL, our rewards were 1 - (1 * 12/13) = 0.076923077
+    // Initially there are 10 StSol and 10 UST in the AMM
+    // We should get 10 - (10*10 / 10.076923077) = 0.07633587793834806 UST
+    assert_eq!(ust_spl_account.amount, 76335877);
+}
+
+// Create a token pool where the token a and b are swapped (what matters is that
+// they are stSOL and UST), the order shouldn't make a difference.
+#[tokio::test]
+async fn test_successful_sell_rewards_pool_a_b_token_swapped() {
+    let mut context = Context::new().await;
+    // Swap the tokens a and b on Token Swap creation.
+    mem::swap(
+        &mut context.token_pool_context.token_a,
+        &mut context.token_pool_context.token_b,
+    );
+    context.initialize_token_pool().await;
     context.deposit(Lamports(DEPOSIT_AMOUNT)).await;
     // Donate something to Solido's reserve so we can see some rewards.
     context
@@ -38,7 +66,8 @@ async fn test_successful_sell_rewards() {
 
 #[tokio::test]
 async fn test_rewards_fail_with_different_reserve() {
-    let mut context = Context::new_with_initialized_token_pool().await;
+    let mut context = Context::new().await;
+    context.initialize_token_pool().await;
     context.deposit(Lamports(DEPOSIT_AMOUNT)).await;
     // Donate something to Solido's reserve so we can see some rewards.
     context

--- a/anker/tests/tests/sell_rewards.rs
+++ b/anker/tests/tests/sell_rewards.rs
@@ -15,9 +15,9 @@ async fn test_successful_sell_rewards() {
     let ust_balance = context.get_ust_balance(context.ust_reserve).await;
     // Exchange rate is 12 stSol : 13 Sol
     // We have 1 stSOL, our rewards were 1 - (1 * 12/13) = 0.076923077
-    // Initially there are 10 StSol and 10 UST in the AMM
-    // We should get 10 - (10*10 / 10.076923077) = 0.07633587793834806 UST
-    assert_eq!(ust_balance, MicroUst(76335877));
+    // Initially there are 10 StSol and 10_000 UST in the AMM
+    // We should get 10000 - (10*10000 / 10.076923077) = 76.33587793834886 UST
+    assert_eq!(ust_balance, MicroUst(76_335_877));
     // Test claiming the reward again fails.
     let result = context.try_sell_rewards().await;
     assert_solido_error!(result, AnkerError::ZeroRewardsToClaim);

--- a/anker/tests/tests/sell_rewards.rs
+++ b/anker/tests/tests/sell_rewards.rs
@@ -9,7 +9,10 @@ const DEPOSIT_AMOUNT: u64 = 1_000_000_000; // 1e9 units
 
 #[tokio::test]
 async fn test_successful_sell_rewards() {
-    let mut context = Context::new_with_token_pool_rewards(Lamports(DEPOSIT_AMOUNT)).await;
+    let mut context = Context::new().await;
+    context
+        .initialize_token_pool_and_deposit(Lamports(DEPOSIT_AMOUNT))
+        .await;
     context.sell_rewards().await;
 
     let ust_balance = context.get_ust_balance(context.ust_reserve).await;
@@ -33,50 +36,21 @@ async fn test_successful_sell_rewards_pool_a_b_token_swapped() {
         &mut context.token_pool_context.token_a,
         &mut context.token_pool_context.token_b,
     );
-    context.initialize_token_pool().await;
-    context.deposit(Lamports(DEPOSIT_AMOUNT)).await;
-    // Donate something to Solido's reserve so we can see some rewards.
     context
-        .solido_context
-        .fund(
-            context.solido_context.reserve_address,
-            Lamports(DEPOSIT_AMOUNT),
-        )
+        .initialize_token_pool_and_deposit(Lamports(DEPOSIT_AMOUNT))
         .await;
-    // Update the exchange rate so we see some rewards.
-    context.solido_context.advance_to_normal_epoch(1);
-    context.solido_context.update_exchange_rate().await;
-
     context.sell_rewards().await;
 
     let ust_balance = context.get_ust_balance(context.ust_reserve).await;
-    // Exchange rate is 12 stSol : 13 Sol
-    // We have 1 stSOL, our rewards were 1 - (1 * 12/13) = 0.076923077
-    // Initially there are 10 StSol and 10_000 UST in the AMM
-    // We should get 10000 - (10*10000 / 10.076923077) = 76.33587793834886 UST
     assert_eq!(ust_balance, MicroUst(76_335_877));
-
-    // Test claiming the reward again fails.
-    let result = context.try_sell_rewards().await;
-    assert_solido_error!(result, AnkerError::ZeroRewardsToClaim);
 }
 
 #[tokio::test]
 async fn test_rewards_fail_with_different_reserve() {
     let mut context = Context::new().await;
-    context.initialize_token_pool().await;
-    context.deposit(Lamports(DEPOSIT_AMOUNT)).await;
-    // Donate something to Solido's reserve so we can see some rewards.
     context
-        .solido_context
-        .fund(
-            context.solido_context.reserve_address,
-            Lamports(DEPOSIT_AMOUNT),
-        )
+        .initialize_token_pool_and_deposit(Lamports(DEPOSIT_AMOUNT))
         .await;
-    // Update the exchange rate so we see some rewards.
-    context.solido_context.advance_to_normal_epoch(1);
-    context.solido_context.update_exchange_rate().await;
 
     context.ust_reserve = Pubkey::new_unique();
 

--- a/testlib/src/anker_context.rs
+++ b/testlib/src/anker_context.rs
@@ -262,19 +262,16 @@ impl Context {
         .expect("Failed to initialize token pool.");
     }
 
-    pub async fn new_with_token_pool_rewards(deposit_amount: Lamports) -> Context {
-        let mut context = Context::new().await;
-        context.initialize_token_pool().await;
-        context.deposit(deposit_amount).await;
+    pub async fn initialize_token_pool_and_deposit(&mut self, deposit_amount: Lamports) {
+        self.initialize_token_pool().await;
+        self.deposit(deposit_amount).await;
         // Donate something to Solido's reserve so we can see some rewards.
-        context
-            .solido_context
-            .fund(context.solido_context.reserve_address, deposit_amount)
+        self.solido_context
+            .fund(self.solido_context.reserve_address, deposit_amount)
             .await;
         // Update the exchange rate so we see some rewards.
-        context.solido_context.advance_to_normal_epoch(1);
-        context.solido_context.update_exchange_rate().await;
-        context
+        self.solido_context.advance_to_normal_epoch(1);
+        self.solido_context.update_exchange_rate().await;
     }
 
     /// Create a new SPL token account holding bSOL, return its address.


### PR DESCRIPTION
The stake pool tokens obeyed a strict ordering,
i.e. `token_a` and `token_b` were tied to stSOL and UST. This order is not necessary and removed.

Test swapping tokens with a stake pool created with swapped `token_a` and `token_b`.

Closes #468