### PR TITLE
Add script to print details of past multisig LDO transfers

### DIFF
--- a/scripts/print_incentive_history.py
+++ b/scripts/print_incentive_history.py
@@ -175,9 +175,7 @@ def main() -> None:
         assert (
             details.amount / 1e8 == entry.amount_ldo
         ), f'Expected amount in script to match transaction for {entry}'
-        assert (
-            details.did_execute
-        ), f'Expected transaction to be executed for {entry}'
+        assert details.did_execute, f'Expected transaction to be executed for {entry}'
 
         if prev_date != entry.date:
             print(f'\n### {entry.date}')

--- a/scripts/print_incentive_history.py
+++ b/scripts/print_incentive_history.py
@@ -24,11 +24,20 @@ class Entry(NamedTuple):
 
 # fmt: off
 entries = [
+    # October 20201
     Entry('2021-10-06', 'Mercurial', 'stSOL-SOL',      75_000, '7ymsoHodgC9ES6NJsWmt6aA7csJmkFvhsC4nBsTY67gF'),
     Entry('2021-10-06', 'Orca',      'stSOL-wstETH',  125_000, '5V1gUNKBgFPpVmH2qoNfyhB3PjpmyZbJ6VHfeVxWKkfY'),
     Entry('2021-10-06', 'Raydium',   'stSOL-USDC',    125_000, '6q6QgB2eAdhg9KLZCRTty8MDwFL9xqUa7v1FRDusTfyk'),
+
+    # November 2021
     Entry('2021-11-07', 'Mercurial', 'stSOL-SOL',      75_000, '6a1K1eF6k6oXp5PYKnUqGm2Y3uJxfBkGn1JDdiXgsud7'),
     Entry('2021-11-07', 'Orca',      'stSOL-wstETH',  125_000, 'Dmfp4UuFRqBJ5TU2U21JhPaTjv4HcLzZQgWBvj6DadZS'),
     Entry('2021-11-07', 'Raydium',   'stSOL-USDC',    125_000, 'ByJAsTdHzrabU8aihvZCtmLRorhtgVsXLBCF31P2PgUz'),
+
+    # December 2021
+    Entry('2021-12-15', 'Mercurial', 'stSOL-SOL',      40_000, 'FuoT4Yi2YMYwEyuFkBaQ36FARYDNVwjPp8dymB6mAizJ'),
+    Entry('2021-12-15', 'Orca',      'stSOL-USDC',     60_000, 'JB92vLZuRj7t9cYRi2j4TnKoRPjdJNHJZepiFd7GQHD3'),
+    Entry('2021-12-15', 'Orca',      'stSOL-wstETH',   10_000, 'FJTfrRt6xfYyR8mx4aQEQ3raBPi2vwcuyKtvSRLZBhxH'),
+    Entry('2021-12-15', 'Raydium',   'stSOL-USDC',     60_000, '2UtYtZ4cydPJRv969ASqB3bqR9MDzDoWAs8gM42PkPtc'),
 ]
 # fmt: on

--- a/scripts/print_incentive_history.py
+++ b/scripts/print_incentive_history.py
@@ -29,6 +29,7 @@ class Entry(NamedTuple):
 # fmt: off
 entries = [
     # December 2021
+    Entry('2021-12-17', 'Saber',     'stSOL-SOL',      40_000, '3ccNd9MxfroqQ9gmaGQFTt1U65yRsUyiJi1oJhGwaz8E'),
     Entry('2021-12-15', 'Mercurial', 'stSOL-SOL',      40_000, 'FuoT4Yi2YMYwEyuFkBaQ36FARYDNVwjPp8dymB6mAizJ'),
     Entry('2021-12-15', 'Orca',      'stSOL-USDC',     60_000, 'JB92vLZuRj7t9cYRi2j4TnKoRPjdJNHJZepiFd7GQHD3'),
     Entry('2021-12-15', 'Orca',      'stSOL-wstETH',   10_000, 'FJTfrRt6xfYyR8mx4aQEQ3raBPi2vwcuyKtvSRLZBhxH'),

--- a/scripts/print_incentive_history.py
+++ b/scripts/print_incentive_history.py
@@ -28,21 +28,21 @@ class Entry(NamedTuple):
 
 # fmt: off
 entries = [
-    # October 20201
-    Entry('2021-10-06', 'Mercurial', 'stSOL-SOL',      75_000, '7ymsoHodgC9ES6NJsWmt6aA7csJmkFvhsC4nBsTY67gF'),
-    Entry('2021-10-06', 'Orca',      'stSOL-wstETH',  125_000, '5V1gUNKBgFPpVmH2qoNfyhB3PjpmyZbJ6VHfeVxWKkfY'),
-    Entry('2021-10-06', 'Raydium',   'stSOL-USDC',    125_000, '6q6QgB2eAdhg9KLZCRTty8MDwFL9xqUa7v1FRDusTfyk'),
+    # December 2021
+    Entry('2021-12-15', 'Mercurial', 'stSOL-SOL',      40_000, 'FuoT4Yi2YMYwEyuFkBaQ36FARYDNVwjPp8dymB6mAizJ'),
+    Entry('2021-12-15', 'Orca',      'stSOL-USDC',     60_000, 'JB92vLZuRj7t9cYRi2j4TnKoRPjdJNHJZepiFd7GQHD3'),
+    Entry('2021-12-15', 'Orca',      'stSOL-wstETH',   10_000, 'FJTfrRt6xfYyR8mx4aQEQ3raBPi2vwcuyKtvSRLZBhxH'),
+    Entry('2021-12-15', 'Raydium',   'stSOL-USDC',     60_000, '2UtYtZ4cydPJRv969ASqB3bqR9MDzDoWAs8gM42PkPtc'),
 
     # November 2021
     Entry('2021-11-07', 'Mercurial', 'stSOL-SOL',      75_000, '6a1K1eF6k6oXp5PYKnUqGm2Y3uJxfBkGn1JDdiXgsud7'),
     Entry('2021-11-07', 'Orca',      'stSOL-wstETH',  125_000, 'Dmfp4UuFRqBJ5TU2U21JhPaTjv4HcLzZQgWBvj6DadZS'),
     Entry('2021-11-07', 'Raydium',   'stSOL-USDC',    125_000, 'ByJAsTdHzrabU8aihvZCtmLRorhtgVsXLBCF31P2PgUz'),
 
-    # December 2021
-    Entry('2021-12-15', 'Mercurial', 'stSOL-SOL',      40_000, 'FuoT4Yi2YMYwEyuFkBaQ36FARYDNVwjPp8dymB6mAizJ'),
-    Entry('2021-12-15', 'Orca',      'stSOL-USDC',     60_000, 'JB92vLZuRj7t9cYRi2j4TnKoRPjdJNHJZepiFd7GQHD3'),
-    Entry('2021-12-15', 'Orca',      'stSOL-wstETH',   10_000, 'FJTfrRt6xfYyR8mx4aQEQ3raBPi2vwcuyKtvSRLZBhxH'),
-    Entry('2021-12-15', 'Raydium',   'stSOL-USDC',     60_000, '2UtYtZ4cydPJRv969ASqB3bqR9MDzDoWAs8gM42PkPtc'),
+    # October 20201
+    Entry('2021-10-06', 'Mercurial', 'stSOL-SOL',     75_000, '7ymsoHodgC9ES6NJsWmt6aA7csJmkFvhsC4nBsTY67gF'),
+    Entry('2021-10-06', 'Orca',      'stSOL-wstETH', 125_000, '5V1gUNKBgFPpVmH2qoNfyhB3PjpmyZbJ6VHfeVxWKkfY'),
+    Entry('2021-10-06', 'Raydium',   'stSOL-USDC',   125_000, '6q6QgB2eAdhg9KLZCRTty8MDwFL9xqUa7v1FRDusTfyk'),
 ]
 # fmt: on
 
@@ -53,7 +53,7 @@ def format_address_as_link(addr: str) -> str:
     """
     href = f'https://solscan.io/account/{addr}'
     name = f'{addr[:6]}…{addr[-6:]}'
-    return f"[`{name}`]({href} '{addr}')"
+    return f"[{name}]({href} '{addr}')"
 
 
 class Details(NamedTuple):
@@ -95,25 +95,21 @@ class Details(NamedTuple):
         Return table headers and alignment.
         """
         return [
-            ('Date', ':--'),
             ('Name', ':--'),
             ('Amount (wLDO)', '--:'),
             ('Recipient stSOL account', ':--'),
             ('Recipient owner account', ':--'),
             ('Multisig transaction', ':--'),
-            ('Executed', ':--'),
         ]
 
     def to_table_row(self, entry: Entry) -> List[str]:
         return [
-            entry.date,
             f'{entry.name} {entry.pool}',
             # wLDO has 8 decimals, so divide by 1e8.
             f'{self.amount / 1e8:,.0f}',
             format_address_as_link(self.to_address),
             format_address_as_link(self.get_to_owner()),
             format_address_as_link(entry.multisig_tx),
-            'yes' if self.did_execute else 'not yet',
         ]
 
 
@@ -156,15 +152,20 @@ def get_multisig_transaction_details(addr: str) -> Details:
     )
 
 
-def main() -> None:
+def print_table_header() -> None:
     headers = Details.get_table_headers()
     row0 = [col[0] for col in headers]
     row1 = [col[1] for col in headers]
     print('| ' + ' | '.join(row0) + ' |')
     print('|' + '|'.join(row1) + '|')
 
+
+def main() -> None:
+    prev_date = ''
+
     for entry in entries:
         details = get_multisig_transaction_details(entry.multisig_tx)
+
         assert (
             details.token_address == 'HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p'
         ), f'Expected token to be wLDO for {entry}'
@@ -174,6 +175,15 @@ def main() -> None:
         assert (
             details.amount / 1e8 == entry.amount_ldo
         ), f'Expected amount in script to match transaction for {entry}'
+        assert (
+            details.did_execute
+        ), f'Expected transaction to be executed for {entry}'
+
+        if prev_date != entry.date:
+            print(f'\n### {entry.date}')
+            print_table_header()
+            prev_date = entry.date
+
         print('| ' + ' | '.join(details.to_table_row(entry)) + ' |')
 
 

--- a/scripts/print_incentive_history.py
+++ b/scripts/print_incentive_history.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 Chorus One AG
+# SPDX-License-Identifier: GPL-3.0
+
+"""
+This script prints past multisig transactions for LDO incentive distribution as a Markdown table.
+
+Usage:
+
+    scripts/print_incentive_history.py
+"""
+
+from typing import NamedTuple
+
+
+class Entry(NamedTuple):
+    date: str
+    name: str
+    pool: str
+    amount_ldo: int
+    multisig_tx: str
+
+
+# fmt: off
+entries = [
+    Entry('2021-10-06', 'Mercurial', 'stSOL-SOL',      75_000, '7ymsoHodgC9ES6NJsWmt6aA7csJmkFvhsC4nBsTY67gF'),
+    Entry('2021-10-06', 'Orca',      'stSOL-wstETH',  125_000, '5V1gUNKBgFPpVmH2qoNfyhB3PjpmyZbJ6VHfeVxWKkfY'),
+    Entry('2021-10-06', 'Raydium',   'stSOL-USDC',    125_000, '6q6QgB2eAdhg9KLZCRTty8MDwFL9xqUa7v1FRDusTfyk'),
+    Entry('2021-11-07', 'Mercurial', 'stSOL-SOL',      75_000, '6a1K1eF6k6oXp5PYKnUqGm2Y3uJxfBkGn1JDdiXgsud7'),
+    Entry('2021-11-07', 'Orca',      'stSOL-wstETH',  125_000, 'Dmfp4UuFRqBJ5TU2U21JhPaTjv4HcLzZQgWBvj6DadZS'),
+    Entry('2021-11-07', 'Raydium',   'stSOL-USDC',    125_000, 'ByJAsTdHzrabU8aihvZCtmLRorhtgVsXLBCF31P2PgUz'),
+]
+# fmt: on

--- a/scripts/print_incentive_history.py
+++ b/scripts/print_incentive_history.py
@@ -97,7 +97,7 @@ class Details(NamedTuple):
         return [
             ('Name', ':--'),
             ('Amount (wLDO)', '--:'),
-            ('Recipient stSOL account', ':--'),
+            ('Recipient wLDO account', ':--'),
             ('Recipient owner account', ':--'),
             ('Multisig transaction', ':--'),
         ]

--- a/scripts/print_incentive_history.py
+++ b/scripts/print_incentive_history.py
@@ -73,8 +73,10 @@ class Details(NamedTuple):
         result = subprocess.run(
             [
                 'spl-token',
-                '--url', 'https://lido.rpcpool.com',
-                '--output', 'json',
+                '--url',
+                'https://lido.rpcpool.com',
+                '--output',
+                'json',
                 'account-info',
                 '--address',
                 self.to_address,
@@ -125,14 +127,24 @@ def get_multisig_transaction_details(addr: str) -> Details:
         'SOLIDO_SOLIDO_ADDRESS': '49Yi1TKkNyYjPAFdR9LBvoHcUjuPX4Df5T5yv39w2XTn',
     }
     result = subprocess.run(
-        ['target/debug/solido', '--output', 'json', 'multisig', 'show-transaction', '--transaction-address', addr],
+        [
+            'target/debug/solido',
+            '--output',
+            'json',
+            'multisig',
+            'show-transaction',
+            '--transaction-address',
+            addr,
+        ],
         env=config,
         check=True,
         capture_output=True,
         encoding='utf-8',
     )
     raw_details: Dict[str, Any] = json.loads(result.stdout)
-    transfer_details: Dict[str, Any] = raw_details['parsed_instruction']['TokenInstruction']['Transfer']
+    transfer_details: Dict[str, Any] = raw_details['parsed_instruction'][
+        'TokenInstruction'
+    ]['Transfer']
     signer_details: Dict[str, Any]
 
     return Details(
@@ -153,9 +165,15 @@ def main() -> None:
 
     for entry in entries:
         details = get_multisig_transaction_details(entry.multisig_tx)
-        assert details.token_address == 'HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p', f'Expected token to be wLDO for {entry}'
-        assert details.from_address == 'T7VpKriUL68aQAKXFyfG3jJjvPHnxaC95XsjaZKSZ7b', f'Expected from address to be the Multisig wLDO account for {entry}'
-        assert details.amount / 1e8 == entry.amount_ldo, f'Expected amount in script to match transaction for {entry}'
+        assert (
+            details.token_address == 'HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p'
+        ), f'Expected token to be wLDO for {entry}'
+        assert (
+            details.from_address == 'T7VpKriUL68aQAKXFyfG3jJjvPHnxaC95XsjaZKSZ7b'
+        ), f'Expected from address to be the Multisig wLDO account for {entry}'
+        assert (
+            details.amount / 1e8 == entry.amount_ldo
+        ), f'Expected amount in script to match transaction for {entry}'
         print('| ' + ' | '.join(details.to_table_row(entry)) + ' |')
 
 


### PR DESCRIPTION
We funded incentive programs three times now, and it is becoming a bit of a mess to see what happened, to find transactions, and to check if addresses match previous addresses.

I tried putting the transactions in a table in Notion, but doing all of that manually is a big hassle and very prone to human error.

To address this, I made a script that prints a Markdown table with all transaction details. We can then put this table in the docs.