### PR TITLE
Add preliminary v1.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.2.0
 
-Released 2022-01-10.
+Released 2022-01-11.
 
 There are no functional changes to the on-chain Solido program in this release.
 The on-chain Solido program remains functionally unchanged since v1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v1.2.0 (unreleased)
+## v1.2.0
+
+Released 2022-01-10.
 
 There are no functional changes to the on-chain Solido program in this release.
 The on-chain Solido program remains functionally unchanged since v1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v1.2.0 (unreleased)
+
+There are no functional changes to the on-chain Solido program in this release.
+The on-chain Solido program remains functionally unchanged since v1.0.0.
+
+**Compatibility**:
+
+ * The interface of the Solido program remains unchanged.
+ * This version of the `solido` program is backwards compatible, only new
+   options were added.
+
+New features:
+
+ * `solido multisig show-transaction` now recognizes wLDO token transfers and
+   will display them in a more readable manner.
+
+Feature previews:
+
+ * Add the Anker program, which implements integration with the Anchor protocol
+   on the Terra blockchain, and is responsible for minting bSOL.
+ * This release is an internal milestone intended to aid auditing.
+ * The `solido` CLI program gained an `anker` subcommand for interacting with
+   the Anker program.
+
 ## v1.1.0
 
 Released 2021-10-06.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "anker"
-version = "0.0.1"
+version = "1.2.0"
 dependencies = [
  "bech32",
  "borsh 0.9.1",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "lido"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bincode",
  "borsh 0.9.1",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "solido-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anchor-lang",
  "anker",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anker",
  "borsh 0.9.1",

--- a/anker/Cargo.toml
+++ b/anker/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chorus One <techops@chorus.one>"]
 license = "GPL-3.0"
 edition = "2018"
 name = "anker"
-version = "0.0.1"
+version = "1.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ description = "Solido Command-line Utility"
 license = "GPL-3.0"
 edition = "2018"
 name = "solido-cli"
-version = "1.1.0"
+version = "1.2.0"
 
 [dependencies]
 anchor-lang = "0.13.2"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chorus One <techops@chorus.one>"]
 license = "GPL-3.0"
 edition = "2018"
 name = "lido"
-version = "1.1.0"
+version = "1.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/testlib/Cargo.toml
+++ b/testlib/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chorus One <techops@chorus.one>"]
 license = "GPL-3.0"
 edition = "2018"
 name = "testlib"
-version = "1.1.0"
+version = "1.2.0"
 
 [dependencies]
 anker = { path = "../anker" }


### PR DESCRIPTION
I want to tag v1.2.0 later this week in preparation for the Anker program audit.