### PR TITLE
Add test for `solido anker show`

### DIFF
--- a/cli/src/commands_anker.rs
+++ b/cli/src/commands_anker.rs
@@ -210,9 +210,16 @@ struct ShowAnkerOutput {
     #[serde(serialize_with = "serialize_b58")]
     ust_reserve: Pubkey,
 
+    #[serde(rename = "ust_reserve_balance_micro_ust")]
     ust_reserve_balance: MicroUst,
+
+    #[serde(rename = "st_sol_reserve_balance_st_lamports")]
     st_sol_reserve_balance: StLamports,
+
+    #[serde(rename = "st_sol_reserve_value_lamports")]
     st_sol_reserve_value: Option<Lamports>,
+
+    #[serde(rename = "b_sol_supply_b_lamports")]
     b_sol_supply: BLamports,
 }
 

--- a/cli/src/commands_multisig.rs
+++ b/cli/src/commands_multisig.rs
@@ -52,12 +52,6 @@ pub struct MultisigOpts {
     subcommand: SubCommand,
 }
 
-#[derive(Clap, Debug)]
-pub struct TokenOpts {
-    #[clap(subcommand)]
-    subcommand: TokenSubCommand,
-}
-
 impl MultisigOpts {
     pub fn merge_with_config_and_environment(&mut self, config_file: Option<&ConfigFile>) {
         match &mut self.subcommand {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -947,7 +947,13 @@ pub fn process_withdraw(
     }
 
     // Reduce validator's balance
-    let sol_to_withdraw = lido.exchange_rate.exchange_st_sol(amount)?;
+    let sol_to_withdraw = match lido.exchange_rate.exchange_st_sol(amount) {
+        Ok(amount) => amount,
+        Err(err) => {
+            msg!("Cannot exchange stSOL for SOL, because no stSTOL has been minted.");
+            return Err(err.into());
+        }
+    };
     let provided_validator = lido
         .validators
         .get_mut(accounts.validator_vote_account.key)?;

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -165,7 +165,6 @@ impl ExchangeRate {
     pub fn exchange_st_sol(&self, amount: StLamports) -> Result<Lamports, LidoError> {
         // If there is no stSOL in existence, it cannot be exchanged.
         if self.st_sol_supply == StLamports(0) {
-            msg!("Cannot exchange stSOL for SOL, because no stSTOL has been minted.");
             return Err(LidoError::InvalidAmount);
         }
 

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -166,6 +166,7 @@ token_pool_address = result['pool_address']
 print(f'> Created instance at {token_pool_address}.')
 
 print('\nCreating Anker instance ...')
+terra_rewards_address = 'terra18aqm668ygwppxnmkmjn4wrtgdweq5ay7rs42ch'
 result = solido(
     'anker',
     'create',
@@ -186,7 +187,7 @@ result = solido(
     # Wormhole's testnet address. TODO: Replace with a new localhost program instance.
     'DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe',
     '--terra-rewards-address',
-    'terra18aqm668ygwppxnmkmjn4wrtgdweq5ay7rs42ch',
+    terra_rewards_address,
 )
 # TODO: Also provide --mint-address, we need to be sure that that one works.
 anker_address = result['anker_address']
@@ -194,3 +195,35 @@ anker_st_sol_reserve_account = result['st_sol_reserve_account']
 anker_ust_reserve_account = result['ust_reserve_account']
 b_sol_mint_address = result['b_sol_mint_address']
 print(f'> Created instance at {anker_address}.')
+
+
+print('\nVerifying Anker instance with `solido anker show` ...')
+result = solido(
+    'anker',
+    'show',
+    '--anker-address', anker_address
+)
+
+# Some addresses are generated and it's tedious here in this test to know what
+# they are ahead of time, so we don't check those against a reference, instead
+# we store them so we can use them later in this test.
+reserve_authority = result.pop('reserve_authority')
+b_sol_mint_authority = result.pop('b_sol_mint_authority')
+st_sol_reserve = result.pop('st_sol_reserve')
+ust_reserve = result.pop('ust_reserve')
+
+# We do check the remaining fields.
+expected_result = {
+    'anker_address': anker_address,
+    'anker_program_id': anker_program_id,
+    'solido_address': solido_address,
+    'solido_program_id': solido_program_id,
+    'b_sol_mint': b_sol_mint_address,
+    'terra_rewards_destination': terra_rewards_address,
+    'ust_reserve_balance_micro_ust': 0,
+    'st_sol_reserve_balance_st_lamports': 0,
+    'st_sol_reserve_value_lamports': None,
+    'b_sol_supply_b_lamports': 0,
+}
+assert result == expected_result, f'Expected {result} to be {expected_result}'
+print('> Instance parameters are as expected.')

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -209,8 +209,6 @@ result = solido(
 # we store them so we can use them later in this test.
 reserve_authority = result.pop('reserve_authority')
 b_sol_mint_authority = result.pop('b_sol_mint_authority')
-st_sol_reserve = result.pop('st_sol_reserve')
-ust_reserve = result.pop('ust_reserve')
 
 # We do check the remaining fields.
 expected_result = {
@@ -219,6 +217,8 @@ expected_result = {
     'solido_address': solido_address,
     'solido_program_id': solido_program_id,
     'b_sol_mint': b_sol_mint_address,
+    'st_sol_reserve': anker_st_sol_reserve_account,
+    'ust_reserve': anker_ust_reserve_account,
     'terra_rewards_destination': terra_rewards_address,
     'ust_reserve_balance_micro_ust': 0,
     'st_sol_reserve_balance_st_lamports': 0,

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -198,11 +198,7 @@ print(f'> Created instance at {anker_address}.')
 
 
 print('\nVerifying Anker instance with `solido anker show` ...')
-result = solido(
-    'anker',
-    'show',
-    '--anker-address', anker_address
-)
+result = solido('anker', 'show', '--anker-address', anker_address)
 
 # Some addresses are generated and it's tedious here in this test to know what
 # they are ahead of time, so we don't check those against a reference, instead


### PR DESCRIPTION
This extends the test script to call `solido anker show`, which acts two-fold:

* It tests that `solido anker show` works.
* We can use it in the remainder of the test to confirm that the instance looks as expected.

This is also the final step for #456, so closes #456.