### PR TITLE
Test Anker `SellRewards` in test script

### DIFF
--- a/cli/src/maintenance.rs
+++ b/cli/src/maintenance.rs
@@ -116,9 +116,11 @@ pub enum MaintenanceOutput {
     UnstakeFromActiveValidator(Unstake),
 
     SellRewards {
+        #[serde(rename = "st_sol_amount_st_lamports")]
         st_sol_amount: StLamports,
     },
     SendRewards {
+        #[serde(rename = "ust_amount_micro_ust")]
         ust_amount: MicroUst,
     },
 }


### PR DESCRIPTION
Extend the Anker test script by:

* Donating 1 stSOL to Anker’s reserve
* Running one maintenance step, which triggers `SellRewards`
* Check that we now have the expected amount of UST in the reserve