### PR TITLE
Allow Anker deposits during initial Solido epoch

### DIFF
--- a/anker/tests/tests/deposit.rs
+++ b/anker/tests/tests/deposit.rs
@@ -13,7 +13,24 @@ use testlib::assert_solido_error;
 const TEST_DEPOSIT_AMOUNT: StLamports = StLamports(1_000_000_000);
 
 #[tokio::test]
-async fn test_successful_deposit() {
+async fn test_successful_deposit_during_first_epoch() {
+    let mut context = Context::new_with_undefined_exchange_rate().await;
+    let (_owner, recipient) = context.deposit(Lamports(TEST_DEPOSIT_AMOUNT.0)).await;
+
+    let reserve_balance = context
+        .solido_context
+        .get_st_sol_balance(context.st_sol_reserve)
+        .await;
+    let recipient_balance = context.get_b_sol_balance(recipient).await;
+
+    // If there is no deposit yet, the exchange rate is defined to be 1:1,
+    // so the amounts in SOL, stSOL, and bSOL are all equal.
+    assert_eq!(reserve_balance, TEST_DEPOSIT_AMOUNT);
+    assert_eq!(recipient_balance, BLamports(TEST_DEPOSIT_AMOUNT.0));
+}
+
+#[tokio::test]
+async fn test_successful_deposit_after_first_epoch() {
     let mut context = Context::new().await;
     let (_owner, recipient) = context.deposit(Lamports(TEST_DEPOSIT_AMOUNT.0)).await;
 

--- a/testlib/src/anker_context.rs
+++ b/testlib/src/anker_context.rs
@@ -193,7 +193,7 @@ pub struct Context {
 const INITIAL_DEPOSIT: Lamports = Lamports(1_000_000_000);
 
 impl Context {
-    pub async fn new() -> Self {
+    pub async fn new_with_undefined_exchange_rate() -> Self {
         let mut solido_context = solido_context::Context::new_with_maintainer().await;
         let (anker, _seed) = anker::find_instance_address(&id(), &solido_context.solido.pubkey());
 
@@ -237,10 +237,6 @@ impl Context {
         .await
         .expect("Failed to initialize Anker instance.");
 
-        solido_context.deposit(INITIAL_DEPOSIT).await;
-        solido_context.advance_to_normal_epoch(0);
-        solido_context.update_exchange_rate().await;
-
         Self {
             solido_context,
             anker,
@@ -253,6 +249,18 @@ impl Context {
             terra_rewards_destination,
             reserve_authority,
         }
+    }
+
+    /// Create a new test context, where Solido has some balance, and the exchange
+    /// rate has been updated once.
+    pub async fn new() -> Self {
+        let mut ctx = Context::new_with_undefined_exchange_rate().await;
+
+        ctx.solido_context.deposit(INITIAL_DEPOSIT).await;
+        ctx.solido_context.advance_to_normal_epoch(0);
+        ctx.solido_context.update_exchange_rate().await;
+
+        ctx
     }
 
     // Start a new Anker context with `amount` Lamports donated to Solido's


### PR DESCRIPTION
On mainnet this will not happen, but in local testing, it might happen that you set up a Solido instance with zero balance (0 SOL, 0 stSOL), and therefore its exchange rate from the balances is undefined. Then if you try to do an Anker deposit in that initial epoch, previously that would fail. This is not a concern on mainnet, but for testing this is annoying, so do allow deposits during the initial epoch, by defining the exchange rate to be 1 stSOL = 1 bSOL, just like Solido defines 1 stSOL =1 SOL if it has zero balance.