### PR TITLE
Add `solido anker deposit` command, use it in Anker test

### DIFF
--- a/cli/src/commands_anker.rs
+++ b/cli/src/commands_anker.rs
@@ -16,7 +16,9 @@ use solana_sdk::signer::Signer;
 use spl_token_swap::curve::base::{CurveType, SwapCurve};
 use spl_token_swap::curve::constant_product::ConstantProductCurve;
 
-use crate::config::{ConfigFile, CreateAnkerOpts, CreateTokenPoolOpts, ShowAnkerOpts};
+use crate::config::{
+    AnkerDepositOpts, ConfigFile, CreateAnkerOpts, CreateTokenPoolOpts, ShowAnkerOpts,
+};
 use crate::error::Abort;
 use crate::serialization_utils::serialize_bech32;
 use crate::snapshot::Result;
@@ -33,6 +35,9 @@ enum SubCommand {
 
     /// Create an SPL token swap pool for testing purposes.
     CreateTokenPool(CreateTokenPoolOpts),
+
+    /// Deposit stSOL to Anker to obtain bSOL.
+    Deposit(AnkerDepositOpts),
 }
 
 #[derive(Clap, Debug)]
@@ -49,6 +54,7 @@ impl AnkerOpts {
             SubCommand::CreateTokenPool(opts) => {
                 opts.merge_with_config_and_environment(config_file)
             }
+            SubCommand::Deposit(opts) => opts.merge_with_config_and_environment(config_file),
         }
     }
 }
@@ -68,6 +74,11 @@ pub fn main(config: &mut SnapshotClientConfig, anker_opts: &AnkerOpts) {
         SubCommand::CreateTokenPool(opts) => {
             let result = config.with_snapshot(|config| command_create_token_pool(config, opts));
             let output = result.ok_or_abort_with("Failed to create Token Pool instance.");
+            print_output(config.output_mode, &output);
+        }
+        SubCommand::Deposit(opts) => {
+            let result = command_deposit(config, opts);
+            let output = result.ok_or_abort_with("Failed to deposit.");
             print_output(config.output_mode, &output);
         }
     }
@@ -433,4 +444,90 @@ fn command_create_token_pool(
         pool_address: token_pool_account.pubkey(),
         pool_authority: authority_pubkey,
     })
+}
+
+#[derive(Serialize)]
+struct DepositOutput {
+    /// Recipient account that holds the bSOL.
+    #[serde(serialize_with = "serialize_b58")]
+    pub b_sol_account: Pubkey,
+
+    /// Whether we had to create the associated bSOL account. False if one existed already.
+    pub created_associated_b_sol_account: bool,
+}
+
+impl fmt::Display for DepositOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.created_associated_b_sol_account {
+            writeln!(f, "Created recipient bSOL account, it did not yet exist.")?;
+        } else {
+            writeln!(f, "Recipient bSOL account existed already before deposit.")?;
+        }
+        writeln!(f, "Recipient bSOL account: {}", self.b_sol_account)?;
+        Ok(())
+    }
+}
+
+fn command_deposit(
+    config: &mut SnapshotClientConfig,
+    opts: &AnkerDepositOpts,
+) -> std::result::Result<DepositOutput, crate::error::Error> {
+    let (recipient, created_recipient) = config.with_snapshot(|config| {
+        let client = &mut config.client;
+        let anker = client.get_anker(opts.anker_address())?;
+
+        let recipient = spl_associated_token_account::get_associated_token_address(
+            &config.signer.pubkey(),
+            &anker.b_sol_mint,
+        );
+
+        if !config.client.account_exists(&recipient)? {
+            let instr = spl_associated_token_account::create_associated_token_account(
+                &config.signer.pubkey(),
+                &config.signer.pubkey(),
+                &anker.b_sol_mint,
+            );
+
+            config.sign_and_send_transaction(&[instr], &[config.signer])?;
+
+            Ok((recipient, true))
+        } else {
+            Ok((recipient, false))
+        }
+    })?;
+
+    config.with_snapshot(|config| {
+        let client = &mut config.client;
+        let anker_account = client.get_account(opts.anker_address())?;
+        let anker_program_id = anker_account.owner;
+        let anker = client.get_anker(opts.anker_address())?;
+
+        let (st_sol_reserve_account, _bump_seed) =
+            anker::find_st_sol_reserve_account(&anker_program_id, opts.anker_address());
+        let (b_sol_mint_authority, _bump_seed) =
+            anker::find_mint_authority(&anker_program_id, opts.anker_address());
+
+        let instr = anker::instruction::deposit(
+            &anker_program_id,
+            &anker::instruction::DepositAccountsMeta {
+                anker: *opts.anker_address(),
+                solido: anker.solido,
+                from_account: config.signer.pubkey(),
+                user_authority: config.signer.pubkey(),
+                to_reserve_account: st_sol_reserve_account,
+                b_sol_user_account: recipient,
+                b_sol_mint: anker.b_sol_mint,
+                b_sol_mint_authority,
+            },
+            *opts.amount_st_sol(),
+        );
+
+        config.sign_and_send_transaction(&[instr], &[config.signer])
+    })?;
+
+    let result = DepositOutput {
+        created_associated_b_sol_account: created_recipient,
+        b_sol_account: recipient,
+    };
+    Ok(result)
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -794,8 +794,15 @@ cli_opt_struct! {
         #[clap(long, value_name = "address")]
         anker_address: Pubkey,
 
+        /// stSOL SPL token account to send from.
+        ///
+        /// By default, the stSOL associated token account of the signer is used.
+        /// In any case, the signer must own this account.
+        #[clap(long, value_name = "address")]
+        from_st_sol_address: Pubkey => Pubkey::default(),
+
         /// Amount to deposit, in stSOL, using . as decimal separator.
-        #[clap(long, value_name = "sol")]
+        #[clap(long, value_name = "amount")]
         amount_st_sol: StLamports,
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -787,3 +787,15 @@ cli_opt_struct! {
         ust_account: Pubkey,
     }
 }
+
+cli_opt_struct! {
+    AnkerDepositOpts {
+        /// Address of the Anker instance.
+        #[clap(long, value_name = "address")]
+        anker_address: Pubkey,
+
+        /// Amount to deposit, in stSOL, using . as decimal separator.
+        #[clap(long, value_name = "sol")]
+        amount_st_sol: StLamports,
+    }
+}

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -316,3 +316,8 @@ assert result['created_associated_b_sol_account'] == True
 b_sol_balance = spl_token_balance(b_sol_account)
 assert b_sol_balance.balance_raw == 1_000_000_000
 print(f'> We now have 1 bSOL in account {b_sol_account}.')
+
+result = solido('anker', 'show', '--anker-address', anker_address)
+assert result['st_sol_reserve_balance_st_lamports'] == 1_000_000_000
+assert result['b_sol_supply_b_lamports'] == 1_000_000_000
+print(f'> Anker reserve has 1 stSOL, the bSOL mint has a supply of 1 bSOL.')

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -228,7 +228,7 @@ print('> Instance parameters are as expected.')
 
 
 def perform_maintenance() -> Optional[Dict[str, Any]]:
-    return solido(
+    result: Optional[Dict[str, Any]] = solido(
         'perform-maintenance',
         '--solido-program-id',
         solido_program_id,
@@ -239,6 +239,7 @@ def perform_maintenance() -> Optional[Dict[str, Any]]:
         '--stake-time',
         'anytime',
     )
+    return result
 
 
 # There shouldn't be any maintenance to perform at this point.

--- a/tests/util.py
+++ b/tests/util.py
@@ -107,6 +107,34 @@ def spl_token(*args: str) -> str:
     return run('spl-token', '--url', get_network(), *args)
 
 
+class SplTokenBalance(NamedTuple):
+    # The raw amount is the amount in the smallest denomination of the token
+    # (i.e. the number of Lamports for wrapped SOL), the UI amount is a float
+    # of `amount_raw` divided by `10^num_decimals`.
+    balance_raw: int
+    balance_ui: float
+
+
+def spl_token_balance(address: str) -> SplTokenBalance:
+    """
+    Run 'spl_token' against network.
+    """
+    result = run(
+        'spl-token',
+        '--url',
+        get_network(),
+        'balance',
+        '--address',
+        address,
+        '--output',
+        'json',
+    )
+    data = json.loads(result)
+    amount_raw = int(data['amount'])
+    amount_ui = data('uiAmount')
+    return SplTokenBalance(amount_raw, amount_ui)
+
+
 def solana_program_deploy(fname: str) -> str:
     """
     Deploy a .so file, return its program id.

--- a/tests/util.py
+++ b/tests/util.py
@@ -117,7 +117,7 @@ class SplTokenBalance(NamedTuple):
 
 def spl_token_balance(address: str) -> SplTokenBalance:
     """
-    Run 'spl_token' against network.
+    Return the balance of an SPL token account.
     """
     result = run(
         'spl-token',

--- a/tests/util.py
+++ b/tests/util.py
@@ -129,9 +129,9 @@ def spl_token_balance(address: str) -> SplTokenBalance:
         '--output',
         'json',
     )
-    data = json.loads(result)
+    data: Dict[str, Any] = json.loads(result)
     amount_raw = int(data['amount'])
-    amount_ui = data('uiAmount')
+    amount_ui: float = data['uiAmount']
     return SplTokenBalance(amount_raw, amount_ui)
 
 


### PR DESCRIPTION
* Add a new command to the CLI, `solido anker deposit`, to make a deposit. The recipient is the associated token account of the signer, and this account will be created if it doesn’t exist.
* (In hindsight, the `solido deposit` command for Solido deposits can be simplified to not take multiple snapshots, but let’s not do that right now.)
* Use this to extend the Anker test.