### PR TITLE
Anker: Check the token swap program id before we call it

### DIFF
--- a/anker/src/error.rs
+++ b/anker/src/error.rs
@@ -34,7 +34,7 @@ pub enum AnkerError {
     /// An account is not owned by the expected owner.
     InvalidOwner = 4006,
 
-    /// Wrong SPL Token Swap instance.
+    /// Wrong SPL Token Swap instance or program.
     WrongSplTokenSwap = 4007,
 
     /// Wrong parameters for the SPL Token Swap instruction.

--- a/anker/src/error.rs
+++ b/anker/src/error.rs
@@ -48,6 +48,9 @@ pub enum AnkerError {
 
     /// Arguments/Accounts for SendRewards are wrong.
     InvalidSendRewardsParameters = 4011,
+
+    /// After swapping, we are left with less stSOL than we intended.
+    TokenSwapAmountInvalid = 4012,
 }
 
 // Just reuse the generated Debug impl for Display. It shows the variant names.

--- a/anker/src/lib.rs
+++ b/anker/src/lib.rs
@@ -37,6 +37,15 @@ pub mod orca_token_swap_v2 {
     declare_id!("9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP");
 }
 
+/// A different address that will also contain a deployment of the token swap program.
+///
+/// This is used to test that attackers who upload their own (modified) copy of
+/// the token swap program would not be able to call it.
+pub mod orca_token_swap_v2_fake {
+    use solana_program::declare_id;
+    declare_id!("hackRN3Era2mH2ByBLzGo1EqiGEXFTCAnrJTNxhzU6i");
+}
+
 /// Return the address at which the Anker instance should live that belongs to
 /// the given Solido instance.
 pub fn find_instance_address(anker_program_id: &Pubkey, solido_instance: &Pubkey) -> (Pubkey, u8) {

--- a/anker/src/processor.rs
+++ b/anker/src/processor.rs
@@ -250,10 +250,10 @@ fn process_sell_rewards(program_id: &Pubkey, accounts_raw: &[AccountInfo]) -> Pr
         StLamports(Anker::get_token_amount(accounts.st_sol_reserve_account)?);
 
     // Get StLamports corresponding to the amount of b_sol minted.
-    let st_sol_amount = solido.exchange_rate.exchange_sol(Lamports(b_sol_supply))?;
+    let b_sol_supply_value_in_st_sol = solido.exchange_rate.exchange_sol(Lamports(b_sol_supply))?;
 
-    // If `reserve_st_sol` < `st_sol_amount` something went wrong, and we abort the transaction.
-    let rewards = (reserve_st_sol_before - st_sol_amount)?;
+    // If this underflows, something went wrong, and we abort the transaction.
+    let rewards = (reserve_st_sol_before - b_sol_supply_value_in_st_sol)?;
 
     // Get the amount of UST that we had.
     let ust_before = MicroUst(Anker::get_token_amount(accounts.ust_reserve_account)?);

--- a/anker/src/processor.rs
+++ b/anker/src/processor.rs
@@ -246,26 +246,42 @@ fn process_sell_rewards(program_id: &Pubkey, accounts_raw: &[AccountInfo]) -> Pr
         spl_token::state::Mint::unpack_from_slice(&accounts.b_sol_mint.data.borrow())?;
     let b_sol_supply = token_mint_state.supply;
 
-    let reserve_st_sol = StLamports(Anker::get_token_amount(accounts.st_sol_reserve_account)?);
+    let reserve_st_sol_before =
+        StLamports(Anker::get_token_amount(accounts.st_sol_reserve_account)?);
 
     // Get StLamports corresponding to the amount of b_sol minted.
     let st_sol_amount = solido.exchange_rate.exchange_sol(Lamports(b_sol_supply))?;
 
     // If `reserve_st_sol` < `st_sol_amount` something went wrong, and we abort the transaction.
-    let rewards = (reserve_st_sol - st_sol_amount)?;
+    let rewards = (reserve_st_sol_before - st_sol_amount)?;
 
     // Get the amount of UST that we had.
     let ust_before = MicroUst(Anker::get_token_amount(accounts.ust_reserve_account)?);
     swap_rewards(program_id, rewards, &anker, &accounts)?;
     // Get new UST amount.
     let ust_after = MicroUst(Anker::get_token_amount(accounts.ust_reserve_account)?);
+    let reserve_st_sol_after =
+        StLamports(Anker::get_token_amount(accounts.st_sol_reserve_account)?);
     let swapped_ust = (ust_after - ust_before)?;
+    let swapped_st_sol = (reserve_st_sol_before - reserve_st_sol_after)?;
 
-    msg!("Swapped {} for {}.", st_sol_amount, swapped_ust);
+    // The token swap program should not take more stSOL than we told it to swap.
+    // As an extra line of defense, confirm this after the swap is done, and abort
+    // if some stSOL went missing.
+    if swapped_st_sol > rewards {
+        msg!(
+            "Called the token swap program to swap {}, but {} was removed from the reserve!",
+            rewards,
+            swapped_st_sol,
+        );
+        return Err(AnkerError::TokenSwapAmountInvalid.into());
+    }
+
+    msg!("Swapped {} for {}.", swapped_st_sol, swapped_ust);
 
     anker
         .metrics
-        .observe_token_swap(st_sol_amount, swapped_ust)?;
+        .observe_token_swap(swapped_st_sol, swapped_ust)?;
     anker.save(accounts.anker)
 }
 

--- a/anker/src/processor.rs
+++ b/anker/src/processor.rs
@@ -388,12 +388,19 @@ fn process_change_token_swap_pool(
     let (solido, mut anker) = deserialize_anker(program_id, accounts.anker, accounts.solido)?;
     solido.check_manager(accounts.manager)?;
 
-    let current_token_swap = anker.get_token_swap_instance(accounts.current_token_swap_pool)?;
+    let current_token_swap_program_id = accounts.current_token_swap_pool.owner;
+    let current_token_swap = anker.get_token_swap_instance(
+        accounts.current_token_swap_pool,
+        current_token_swap_program_id,
+    )?;
+
     // `get_token_swap_instance` compares the account to the one stored in
     // `anker.token_swap_pool`. We assign first so we have the correct value to
     // compare. If the check fails, the transaction will revert.
     anker.token_swap_pool = *accounts.new_token_swap_pool.key;
-    let new_token_swap = anker.get_token_swap_instance(accounts.new_token_swap_pool)?;
+    let new_token_swap_program_id = accounts.new_token_swap_pool.owner;
+    let new_token_swap =
+        anker.get_token_swap_instance(accounts.new_token_swap_pool, new_token_swap_program_id)?;
 
     anker.check_change_token_swap_pool(&solido, current_token_swap, new_token_swap)?;
     anker.save(accounts.anker)

--- a/anker/tests/tests/sell_rewards.rs
+++ b/anker/tests/tests/sell_rewards.rs
@@ -59,7 +59,7 @@ async fn test_successful_sell_rewards_pool_a_b_token_swapped() {
 }
 
 #[tokio::test]
-async fn test_rewards_fail_with_different_reserve() {
+async fn test_sell_rewards_fails_with_different_reserve() {
     let mut context = Context::new().await;
     context
         .initialize_token_pool_and_deposit(Lamports(DEPOSIT_AMOUNT))
@@ -69,4 +69,19 @@ async fn test_rewards_fail_with_different_reserve() {
 
     let result = context.try_sell_rewards().await;
     assert_solido_error!(result, AnkerError::InvalidDerivedAccount);
+}
+
+#[tokio::test]
+async fn test_sell_rewards_fails_with_different_token_swap_program() {
+    let mut context = Context::new().await;
+    context
+        .initialize_token_pool_and_deposit(Lamports(DEPOSIT_AMOUNT))
+        .await;
+
+    // If we try to call `SellRewards`, but the swap program is not the owner of
+    // the pool, that should fail.
+    context.token_swap_program_id = anker::orca_token_swap_v2_fake::id();
+    let result = context.try_sell_rewards().await;
+
+    assert_solido_error!(result, AnkerError::WrongSplTokenSwap);
 }

--- a/anker/tests/tests/sell_rewards.rs
+++ b/anker/tests/tests/sell_rewards.rs
@@ -20,11 +20,20 @@ async fn test_successful_sell_rewards() {
     assert_eq!(
         anker_after.metrics.swapped_rewards_st_sol_total
             - anker_before.metrics.swapped_rewards_st_sol_total,
-        Ok(StLamports(0_923_076_923))
+        // Solido got initialized with 1 SOL. Then it got 10 stLamports for
+        // initializing the swap pool. Then we deposited 1 more SOL for use with
+        // Anker, and we donated 1 SOL to change the exchange rate.
+        // That would mean we have 13 SOL = 12 stSOL, and that would mean Anker's
+        // excess value is 1/12 = 0.0833 SOL. Converting that to stSOL yields
+        // 1/12 * 12/13 = 1/13 = 0.0769 stSOL.
+        Ok(StLamports(76_923_077))
     );
     assert_eq!(
         anker_after.metrics.swapped_rewards_ust_total
             - anker_before.metrics.swapped_rewards_ust_total,
+        // We started out the constant product pool with 10 stSOL = 10 UST,
+        // and we swapped a relatively small amount, so the amount we got out
+        // here in UST should be close to the amount in stSOL above.
         Ok(MicroUst(76_335_877))
     );
 

--- a/testlib/src/anker_context.rs
+++ b/testlib/src/anker_context.rs
@@ -188,6 +188,8 @@ pub struct Context {
     pub rewards_owner: Keypair,
     pub terra_rewards_destination: TerraAddress,
     pub reserve_authority: Pubkey,
+
+    pub token_swap_program_id: Pubkey,
 }
 
 const INITIAL_DEPOSIT: Lamports = Lamports(1_000_000_000);
@@ -248,6 +250,7 @@ impl Context {
             rewards_owner,
             terra_rewards_destination,
             reserve_authority,
+            token_swap_program_id: anker::orca_token_swap_v2::id(),
         }
     }
 
@@ -429,7 +432,7 @@ impl Context {
             .get_ust_stsol_addresses(&mut self.solido_context)
             .await;
         let swap_instruction = spl_token_swap::instruction::swap(
-            &anker::orca_token_swap_v2::id(),
+            &self.token_swap_program_id,
             &spl_token::id(),
             &self.token_pool_context.swap_account.pubkey(),
             &self.token_pool_context.get_token_pool_authority().0,
@@ -496,7 +499,7 @@ impl Context {
                     token_swap_authority,
                     reserve_authority,
                     ust_reserve_account: self.ust_reserve,
-                    token_swap_program_id: anker::orca_token_swap_v2::id(),
+                    token_swap_program_id: self.token_swap_program_id,
                 },
             )],
             vec![],

--- a/testlib/src/solido_context.rs
+++ b/testlib/src/solido_context.rs
@@ -268,6 +268,11 @@ impl Context {
         // If we don't have it locally, download it from the chain.
         crate::util::ensure_orca_program_exists();
         program_test.add_program("orca_token_swap_v2", anker::orca_token_swap_v2::id(), None);
+        program_test.add_program(
+            "orca_token_swap_v2",
+            anker::orca_token_swap_v2_fake::id(),
+            None,
+        );
 
         let mut result = Self {
             context: program_test.start_with_context().await,


### PR DESCRIPTION
This fixes a critical issue identified by Neodyme: we never checked the program id of the token swap program before calling it with `invoke_signed` in `SellRewards`. An attacker could call `SellRewards` and pass in their own patched version of the token swap program, which would then be able to steal the full stSOL reserve.

* Add a regression test that would have caught the missing check.
* Fix the bug by checking that the token swap program passed in to the call is the owner of the token swap pool stored in the Anker instance. The token swap pool can only be set by the manager, who we trust to set the right pool that is owned by the right token swap program.
* Add an additional check in `SellRewards` that checks that we don’t lose more stSOL than we intended to sell. If the owner check were not in place, this check would not have prevented an attacker from stealing some stSOL, but it would at least have limited the damage to stealing only the excess stSOL that we intended to sell, not the full stSOL reserve.