### PR TITLE
Test pre existing mint

### DIFF
--- a/cli/maintainer/src/commands_anker.rs
+++ b/cli/maintainer/src/commands_anker.rs
@@ -20,7 +20,7 @@ use spl_token_swap::curve::constant_product::ConstantProductCurve;
 
 use crate::config::{
     AnkerDepositOpts, AnkerWithdrawOpts, ConfigFile, CreateAnkerOpts, CreateTokenPoolOpts,
-    ShowAnkerOpts,
+    ShowAnkerAuthoritiesOpts, ShowAnkerOpts,
 };
 use crate::print_output;
 use crate::serialization_utils::serialize_bech32;
@@ -30,6 +30,9 @@ use crate::spl_token_utils::{push_create_spl_token_account, push_create_spl_toke
 enum SubCommand {
     /// Create a new Anker instance.
     Create(Box<CreateAnkerOpts>),
+
+    /// Show Anker authorities.
+    ShowAuthorities(ShowAnkerAuthoritiesOpts),
 
     /// Display the details of an Anker instance.
     Show(ShowAnkerOpts),
@@ -60,6 +63,9 @@ impl AnkerOpts {
             }
             SubCommand::Deposit(opts) => opts.merge_with_config_and_environment(config_file),
             SubCommand::Withdraw(opts) => opts.merge_with_config_and_environment(config_file),
+            SubCommand::ShowAuthorities(opts) => {
+                opts.merge_with_config_and_environment(config_file)
+            }
         }
     }
 }
@@ -89,6 +95,11 @@ pub fn main(config: &mut SnapshotClientConfig, anker_opts: &AnkerOpts) {
         SubCommand::Withdraw(opts) => {
             let result = config.with_snapshot(|config| command_withdraw(config, opts));
             let output = result.ok_or_abort_with("Failed to withdraw from Anker.");
+            print_output(config.output_mode, &output);
+        }
+        SubCommand::ShowAuthorities(opts) => {
+            let result = config.with_snapshot(|_| command_show_anker_authorities(opts));
+            let output = result.ok_or_abort_with("Failed to show Anker authorities.");
             print_output(config.output_mode, &output);
         }
     }
@@ -651,4 +662,57 @@ fn command_withdraw(
         to_st_sol_account: recipient,
     };
     Ok(result)
+}
+
+#[derive(Serialize)]
+pub struct ShowAnkerAuthoritiesOutput {
+    #[serde(serialize_with = "serialize_b58")]
+    pub anker_address: Pubkey,
+
+    #[serde(serialize_with = "serialize_b58")]
+    pub b_sol_mint_authority: Pubkey,
+
+    #[serde(serialize_with = "serialize_b58")]
+    pub st_sol_reserve_account: Pubkey,
+
+    #[serde(serialize_with = "serialize_b58")]
+    pub ust_reserve_account: Pubkey,
+
+    #[serde(serialize_with = "serialize_b58")]
+    pub reserve_authority: Pubkey,
+}
+
+impl fmt::Display for ShowAnkerAuthoritiesOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Anker address:         {}", self.anker_address,)?;
+        writeln!(f, "bSOL Mint authority:   {}", self.b_sol_mint_authority)?;
+        writeln!(f, "stSOL reserve account: {}", self.st_sol_reserve_account)?;
+        writeln!(f, "UST reserve account:   {}", self.ust_reserve_account)?;
+        writeln!(f, "Reserve authority:     {}", self.reserve_authority,)?;
+        Ok(())
+    }
+}
+
+/// Show Anker address derived for its Solido instance and Anker authorities.
+pub fn command_show_anker_authorities(
+    opts: &ShowAnkerAuthoritiesOpts,
+) -> solido_cli_common::Result<ShowAnkerAuthoritiesOutput> {
+    let (anker_address, _) =
+        anker::find_instance_address(opts.anker_program_id(), opts.solido_address());
+    let (b_sol_mint_authority, _) =
+        anker::find_mint_authority(opts.anker_program_id(), &anker_address);
+    let (reserve_authority, _) =
+        anker::find_reserve_authority(opts.anker_program_id(), &anker_address);
+    let (st_sol_reserve_account, _) =
+        anker::find_st_sol_reserve_account(opts.anker_program_id(), &anker_address);
+    let (ust_reserve_account, _) =
+        anker::find_ust_reserve_account(opts.anker_program_id(), &anker_address);
+
+    Ok(ShowAnkerAuthoritiesOutput {
+        anker_address,
+        b_sol_mint_authority,
+        st_sol_reserve_account,
+        ust_reserve_account,
+        reserve_authority,
+    })
 }

--- a/cli/maintainer/src/commands_solido.rs
+++ b/cli/maintainer/src/commands_solido.rs
@@ -616,7 +616,7 @@ pub fn command_show_solido(
 }
 
 #[derive(Serialize)]
-pub struct ShowSolidoAuthorities {
+pub struct ShowSolidoAuthoritiesOutput {
     #[serde(serialize_with = "serialize_b58")]
     pub solido_program_id: Pubkey,
 
@@ -636,7 +636,7 @@ pub struct ShowSolidoAuthorities {
     pub rewards_withdraw_authority: Pubkey,
 }
 
-impl fmt::Display for ShowSolidoAuthorities {
+impl fmt::Display for ShowSolidoAuthoritiesOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "Stake authority:            {}", self.stake_authority,)?;
         writeln!(f, "Mint authority:             {}", self.mint_authority)?;
@@ -652,7 +652,7 @@ impl fmt::Display for ShowSolidoAuthorities {
 
 pub fn command_show_solido_authorities(
     opts: &ShowSolidoAuthoritiesOpts,
-) -> solido_cli_common::Result<ShowSolidoAuthorities> {
+) -> solido_cli_common::Result<ShowSolidoAuthoritiesOutput> {
     let (reserve_account, _) = find_authority_program_address(
         opts.solido_program_id(),
         opts.solido_address(),
@@ -673,7 +673,7 @@ pub fn command_show_solido_authorities(
         opts.solido_address(),
         REWARDS_WITHDRAW_AUTHORITY,
     );
-    Ok(ShowSolidoAuthorities {
+    Ok(ShowSolidoAuthoritiesOutput {
         solido_program_id: *opts.solido_program_id(),
         solido_address: *opts.solido_address(),
         reserve_account,

--- a/cli/maintainer/src/config.rs
+++ b/cli/maintainer/src/config.rs
@@ -412,12 +412,25 @@ cli_opt_struct! {
 
 cli_opt_struct! {
     ShowSolidoAuthoritiesOpts {
-        /// The solido instance to show authorities.
+        /// The Solido instance to show authorities.
         #[clap(long, value_name = "address")]
         solido_address: Pubkey,
+
         /// Address of the Solido program.
         #[clap(long, value_name = "address")]
         solido_program_id: Pubkey,
+   }
+}
+
+cli_opt_struct! {
+    ShowAnkerAuthoritiesOpts {
+        /// The Solido instance, used to derive the Anker instance.
+        #[clap(long, value_name = "address")]
+        solido_address: Pubkey,
+
+        /// Address of the Anker program.
+        #[clap(long, value_name = "address")]
+        anker_program_id: Pubkey,
    }
 }
 

--- a/cli/maintainer/src/config.rs
+++ b/cli/maintainer/src/config.rs
@@ -730,7 +730,7 @@ cli_opt_struct! {
 
         /// Optionally the bSOL mint address. If not passed a random one will be created.
         #[clap(long, value_name = "address")]
-        b_sol_mint_address: Pubkey => Pubkey::default(),
+        b_sol_mint_address: Pubkey,
 
         /// The UST mint address.
         ///


### PR DESCRIPTION
`anker show-authorities` shows Anker's instance public key and authorities associated with it.
This PR is useful so we can set the b_sol mint with the correct mint authority.
Create some tests so we pass the `bSOL` mint as a parameter when creating Anker.
Closes #518