### PR TITLE
Return message when no data point could be calculated

### DIFF
--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -536,7 +536,7 @@ fn get_interval_price_request(
                 get_success_response(interval_prices)
             } else {
                 // No interval price could be calculated, probably because of few data points.
-                get_error_response(ResponseError::BadRequest(
+                get_error_response(ResponseError::NotFound(
                     "No data points for calculating the price interval.",
                 ))
             }


### PR DESCRIPTION
As @ruuda pointed out in #515, we shouldn't return an error when no data points are present for calculating the APY. We instead should return a message with 404 status code. 