### PR TITLE
Limit queries

### DIFF
--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -212,9 +212,7 @@ pub fn get_interval_price_for_period(
             "SELECT MAX(epoch) from exchange_rate where pool = :pool and timestamp < :t",
         )?;
         let epoch = match last_epoch_stmt
-            .query_row([pool.clone(), to_time.to_rfc3339()], |row| {
-                row.get::<usize, u64>(0)
-            })
+            .query_row([pool, to_time.to_rfc3339()], |row| row.get::<usize, u64>(0))
             .ok()
         {
             Some(epoch) => epoch,

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -208,7 +208,7 @@ pub fn get_interval_price_for_period(
             )?
             .next();
 
-        // Get maximum epoch in which timestamp is smaller than `from_time`.
+        // Get maximum epoch in which timestamp is smaller than `to_time`.
         let mut last_epoch_stmt = tx.prepare(
             "SELECT MAX(epoch) from exchange_rate where pool = :pool and timestamp < :t",
         )?;

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -98,7 +98,10 @@ pub fn create_db(conn: &Connection) -> rusqlite::Result<()> {
                 price_lamports_numerator    INTEGER NOT NULL,
                 price_lamports_denominator  INTEGER NOT NULL,
                 CHECK (price_lamports_denominator>0)
-            )",
+            );
+            CREATE INDEX IF NOT EXISTS ix_exchange_rate_timestamp ON exchange_rate (timestamp);
+            CREATE INDEX IF NOT EXISTS ix_exchange_rate_slot ON exchange_rate (slot);
+            ",
         [],
     )?;
     Ok(())


### PR DESCRIPTION
Limit query for `const QUERY_INTERVAL_OFFSET: usize = 200` from the
beginning of the epoch.
This is done so the exchange rate could be updated in time.

Close #516