### PR TITLE
Apy daemon query params

### DIFF
--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -6,6 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use chrono::TimeZone;
 use clap::Clap;
 use lido::token::Rational;
 use rand::{rngs::ThreadRng, Rng};
@@ -468,6 +469,13 @@ fn get_date_params<'a, I: IntoIterator<Item = (Cow<'a, str>, Cow<'a, str>)>>(
                     Expected e.g. '30'.",
                         )
                     })?;
+                begin_opt = Some(begin);
+                end_opt = Some(end);
+            }
+            "since_launch" => {
+                let begin = chrono::Utc.ymd(2021, 09, 01).and_hms(00, 00, 00); // Solido Launch Date
+                let end = chrono::Utc::now();
+
                 begin_opt = Some(begin);
                 end_opt = Some(end);
             }

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -452,6 +452,25 @@ fn get_date_params<'a, I: IntoIterator<Item = (Cow<'a, str>, Cow<'a, str>)>>(
                 })?;
                 end_opt = Some(t);
             }
+            "days" => {
+                let days = v.parse::<i64>().map_err(|_| {
+                    ResponseError::BadRequest(
+                        "Invalid number of days in 'days' query parameter. \
+                    Expected e.g. '30'.",
+                    )
+                })?;
+                let end = chrono::Utc::now();
+                let begin = end
+                    .checked_sub_signed(chrono::Duration::days(days))
+                    .ok_or_else(|| {
+                        ResponseError::BadRequest(
+                            "Invalid number of days in 'days' query parameter. \
+                    Expected e.g. '30'.",
+                        )
+                    })?;
+                begin_opt = Some(begin);
+                end_opt = Some(end);
+            }
             _ => continue,
         }
     }


### PR DESCRIPTION
**Changes:**
- Added 2 query params to add support for queries like `/apy?days=5` and `/apy?since_launch`.

**Question:**
Currently the program loops over all the query parameters and overrides the `begin_opt` and `end_opt` on the way.
So if I do `/apy?days=2&since_launch`, it will consider begin and end values based on `since_launch` parameter.

Is this expected behaviour, or should we break out of the loop once we have valid `begin_opt` and `end_opt` values?