### PR TITLE
Upgrade Solana to 1.8.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,14 +59,14 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: build-1.7.15-v2-${{ hashFiles('Cargo.lock') }}
-        restore-keys: build-1.7.15-v2
+        key: build-1.8.16-v3-${{ hashFiles('Cargo.lock') }}
+        restore-keys: build-1.8.16-v3
 
     - name: Install development tools
       run: |
         sudo apt update
         sudo apt-get install -y libudev-dev
-        sh -c "$(curl -sSfL https://release.solana.com/v1.7.15/install)"
+        sh -c "$(curl -sSfL https://release.solana.com/v1.8.16/install)"
 
     - name: Run unit tests
       run: |
@@ -155,8 +155,8 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: lint-1.7.15-v1-${{ hashFiles('Cargo.lock') }}
-        restore-keys: lint-1.7.15-v1
+        key: lint-1.8.16-v3-${{ hashFiles('Cargo.lock') }}
+        restore-keys: lint-1.8.16-v3
 
     - name: Install linters
       run: |

--- a/buildimage.sh
+++ b/buildimage.sh
@@ -7,7 +7,7 @@
 VERSION=$(git rev-parse --short HEAD)
 TAG="chorusone/solido:$VERSION"
 BASETAG="chorusone/solido-base"
-SOLIPATH="/root/.local/share/solana/install/releases/1.7.15/solana-release/bin/solido"
+SOLIPATH="/root/.local/share/solana/install/releases/1.8.16/solana-release/bin/solido"
 
 
 # 2. Build container image

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM chorusone/solido-base
 
-ENV SOLVERSION=1.7.15
+ENV SOLVERSION=1.8.16
 ENV SOLINSTALLCHECKSUM=33778e26b0b81133ba3bb4f9e46e84182f2adf72f0bc6e06fc59ad55ddd017d1
 ENV SOLPATH="/root/.local/share/solana/install/active_release/bin"
 ENV SOLIDOBUILDPATH="$SOLPATH/solido-build"


### PR DESCRIPTION
The 1.9.9 and 1.10.0 version broke the `solana validator-info publish` command. I didn't investigate much but I think it's related to the wrong number of bytes or lamports when funding the Info account for it to be rent exempt.

In `solana validator-info publish` we could pass `--info-pubkey` with an already funded account owned by the Config program and with sufficient bytes allocated. However, how could we do this from the Solana client tools 😡? Of course we could write some custom function in Solido, but should we? 😬 

I reverted the upgrade to `1.9.9` until some version fixes this issue. We can upgrade to `1.8.16` so it would download the binaries from Solana's repo.