### PR TITLE
Fix CI tests 🤞 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         tests/airdrop_lamports.sh
 
         tests/test_solido.py
-        kill $validator
+        kill -9 $validator
 
     - name: Run Multisig integration test
       run: |
@@ -119,7 +119,7 @@ jobs:
         # should still be there from the previous run.
 
         tests/test_multisig.py
-        kill $validator
+        kill -9 $validator
 
     - name: Run Anker integration test
       run: |
@@ -130,7 +130,7 @@ jobs:
         # should still be there from the previous run.
 
         tests/test_anker.py
-        kill $validator
+        kill -9 $validator
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Wait 60s instead of 5s for validator to be up.
- Fix solana command to check our own instance for when it's up.
- Kill validator with -9.
- Use different status codes when existing with error.