### PR TITLE
Implement fetch pool price in maintainer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,28 +109,29 @@ jobs:
 
         tests/test_solido.py
         kill -9 $validator
+        rm -r test-ledger
 
     - name: Run Multisig integration test
       run: |
         export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
         validator=$(tests/start_test_validator.py)
 
-        # We don't need to run keygen/setup again, the private key and state
-        # should still be there from the previous run.
+        tests/airdrop_lamports.sh
 
         tests/test_multisig.py
         kill -9 $validator
+        rm -r test-ledger
 
     - name: Run Anker integration test
       run: |
         export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
         validator=$(tests/start_test_validator.py)
 
-        # We don't need to run keygen/setup again, the private key and state
-        # should still be there from the previous run.
+        tests/airdrop_lamports.sh
 
         tests/test_anker.py
         kill -9 $validator
+        rm -r test-ledger
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         tests/airdrop_lamports.sh
 
         tests/test_solido.py
-        kill -9 $validator
+        killall -9 solana-test-validator
         rm -r test-ledger
 
     - name: Run Multisig integration test
@@ -119,7 +119,7 @@ jobs:
         tests/airdrop_lamports.sh
 
         tests/test_multisig.py
-        kill -9 $validator
+        killall -9 solana-test-validator
         rm -r test-ledger
 
     - name: Run Anker integration test
@@ -130,7 +130,7 @@ jobs:
         tests/airdrop_lamports.sh
 
         tests/test_anker.py
-        kill -9 $validator
+        killall -9 solana-test-validator
         rm -r test-ledger
 
   lint:

--- a/anker/src/lib.rs
+++ b/anker/src/lib.rs
@@ -3,13 +3,11 @@
 
 use solana_program::pubkey::Pubkey;
 
-mod logic;
-
 #[cfg(not(feature = "no-entrypoint"))]
 pub mod entrypoint;
-
 pub mod error;
 pub mod instruction;
+pub mod logic;
 pub mod metrics;
 pub mod processor;
 pub mod state;

--- a/cli/maintainer/src/anker_state.rs
+++ b/cli/maintainer/src/anker_state.rs
@@ -17,7 +17,7 @@ use solido_cli_common::{
     error::{Error, SerializationError},
     snapshot::SnapshotConfig,
 };
-use spl_token_swap::curve::constant_product::ConstantProductCurve;
+use spl_token_swap::curve::{constant_product::ConstantProductCurve, fees};
 
 #[derive(Default)]
 pub struct AnkerState {
@@ -32,6 +32,7 @@ pub struct AnkerState {
     pub pool_ust_balance: MicroUst,
 
     pub constant_product_calculator: ConstantProductCurve,
+    pub pool_fees: fees::Fees,
     pub ust_mint: Pubkey,
     pub pool_mint: Pubkey,
     pub pool_fee_account: Pubkey,
@@ -97,6 +98,7 @@ impl AnkerState {
             pool_st_sol_balance,
             pool_ust_balance,
             constant_product_calculator: ConstantProductCurve::default(),
+            pool_fees: token_swap.fees,
             ust_mint: ust_account.mint,
             pool_mint: token_swap.pool_mint,
             pool_fee_account: token_swap.pool_fee_account,

--- a/cli/maintainer/src/anker_state.rs
+++ b/cli/maintainer/src/anker_state.rs
@@ -17,6 +17,7 @@ use solido_cli_common::{
     error::{Error, SerializationError},
     snapshot::SnapshotConfig,
 };
+use spl_token_swap::curve::constant_product::ConstantProductCurve;
 
 #[derive(Default)]
 pub struct AnkerState {
@@ -30,6 +31,7 @@ pub struct AnkerState {
     pub pool_st_sol_balance: StLamports,
     pub pool_ust_balance: MicroUst,
 
+    pub constant_product_calculator: ConstantProductCurve,
     pub ust_mint: Pubkey,
     pub pool_mint: Pubkey,
     pub pool_fee_account: Pubkey,
@@ -94,6 +96,7 @@ impl AnkerState {
             pool_ust_account,
             pool_st_sol_balance,
             pool_ust_balance,
+            constant_product_calculator: ConstantProductCurve::default(),
             ust_mint: ust_account.mint,
             pool_mint: token_swap.pool_mint,
             pool_fee_account: token_swap.pool_fee_account,
@@ -101,6 +104,22 @@ impl AnkerState {
             st_sol_reserve_balance,
             token_swap_program_id,
         })
+    }
+
+    pub fn get_fetch_pool_price_instruction(&self, solido_address: Pubkey) -> Instruction {
+        let (anker_instance, _anker_bump_seed) =
+            find_instance_address(&self.anker_program_id, &solido_address);
+
+        anker::instruction::fetch_pool_price(
+            &self.anker_program_id,
+            &anker::instruction::FetchPoolPriceAccountsMeta {
+                anker: anker_instance,
+                solido: solido_address,
+                token_swap_pool: self.anker.token_swap_pool,
+                pool_st_sol_account: self.pool_st_sol_account,
+                pool_ust_account: self.pool_ust_account,
+            },
+        )
     }
 
     pub fn get_sell_rewards_instruction(

--- a/cli/maintainer/src/daemon.rs
+++ b/cli/maintainer/src/daemon.rs
@@ -71,6 +71,9 @@ struct MaintenanceMetrics {
 
     /// Number of times we performed `SendRewards` on the Anker instance.
     transactions_send_rewards: u64,
+
+    /// Number of times we performed `FetchPoolPrice` on the Anker instance.
+    transactions_fetch_pool_price: u64,
 }
 
 impl MaintenanceMetrics {
@@ -121,6 +124,8 @@ impl MaintenanceMetrics {
                         .with_label("operation", "SellRewards".to_string()),
                     Metric::new(self.transactions_send_rewards)
                         .with_label("operation", "SendRewards".to_string()),
+                    Metric::new(self.transactions_fetch_pool_price)
+                        .with_label("operation", "FetchPoolPrice".to_string()),
                 ],
             },
         )?;
@@ -155,6 +160,7 @@ impl MaintenanceMetrics {
             }
             MaintenanceOutput::SellRewards { .. } => self.transactions_sell_rewards += 1,
             MaintenanceOutput::SendRewards { .. } => self.transactions_send_rewards += 1,
+            MaintenanceOutput::FetchPoolPrice { .. } => self.transactions_fetch_pool_price += 1,
         }
     }
 }
@@ -319,6 +325,7 @@ impl<'a, 'b> Daemon<'a, 'b> {
             transactions_unstake_from_active_validator: 0,
             transactions_sell_rewards: 0,
             transactions_send_rewards: 0,
+            transactions_fetch_pool_price: 0,
         };
         Daemon {
             config,

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -807,8 +807,6 @@ impl SolidoState {
 
         // We want at least 0.01 UST out if we are going to do the swap at all.
         let min_proceeds = MicroUst(10_000);
-
-        // We want at least 0.01 UST out if we are going to do the swap at all.
         if expected_proceeds < min_proceeds {
             return None;
         }

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -119,7 +119,7 @@ pub enum MaintenanceOutput {
 
     FetchPoolPrice {
         #[serde(rename = "st_sol_price_in_micro_ust")]
-        st_sol_price_in_ust: MicroUst,
+        expected_st_sol_price_in_ust: MicroUst,
     },
 
     SellRewards {
@@ -263,10 +263,14 @@ impl fmt::Display for MaintenanceOutput {
                 writeln!(f, "  Amount: {}", ust_amount)?;
             }
             MaintenanceOutput::FetchPoolPrice {
-                st_sol_price_in_ust,
+                expected_st_sol_price_in_ust,
             } => {
                 writeln!(f, "Fetch Pool Price")?;
-                writeln!(f, "  Estimated amount per stSOL: {}", st_sol_price_in_ust)?;
+                writeln!(
+                    f,
+                    "  Expected amount per stSOL: {}",
+                    expected_st_sol_price_in_ust
+                )?;
             }
         }
         Ok(())
@@ -804,7 +808,7 @@ impl SolidoState {
         let have_rewards_to_claim = rewards >= min_rewards_to_sell;
 
         if (should_start_fetch || have_rewards_to_claim) && passed_minimum_update_price {
-            let estimated_st_sol_in_ust = get_one_st_sol_for_ust_price_from_pool(
+            let expected_st_sol_price_in_ust = get_one_st_sol_for_ust_price_from_pool(
                 &anker_state.constant_product_calculator,
                 &anker_state.pool_st_sol_account,
                 &anker_state.pool_ust_account,
@@ -815,7 +819,7 @@ impl SolidoState {
             Some(MaintenanceInstruction::new(
                 anker_state.get_fetch_pool_price_instruction(self.solido_address),
                 MaintenanceOutput::FetchPoolPrice {
-                    st_sol_price_in_ust: estimated_st_sol_in_ust,
+                    expected_st_sol_price_in_ust,
                 },
             ))
         } else {

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -7,8 +7,11 @@ use std::fmt;
 use std::io;
 use std::time::SystemTime;
 
-use anker::logic::get_one_st_sol_for_ust_price_from_pool;
-use anker::state::{POOL_PRICE_MAX_SAMPLE_AGE, POOL_PRICE_MIN_SAMPLE_DISTANCE};
+use anker::{
+    logic::get_one_st_sol_for_ust_price_from_pool,
+    state::{POOL_PRICE_MAX_SAMPLE_AGE, POOL_PRICE_MIN_SAMPLE_DISTANCE},
+    token::MicroUst,
+};
 use itertools::izip;
 
 use serde::Serialize;
@@ -32,7 +35,6 @@ use solido_cli_common::{
 };
 use spl_token::state::Mint;
 
-use anker::token::MicroUst;
 use lido::{
     account_map::PubkeyAndEntry,
     processor::StakeType,
@@ -43,7 +45,7 @@ use lido::{
     token::Rational,
     token::StLamports,
     util::serialize_b58,
-    MINIMUM_STAKE_ACCOUNT_BALANCE, MINT_AUTHORITY, STAKE_AUTHORITY,
+    MINIMUM_STAKE_ACCOUNT_BALANCE, MINT_AUTHORITY, REWARDS_WITHDRAW_AUTHORITY, STAKE_AUTHORITY,
 };
 use spl_token_swap::curve::calculator::{CurveCalculator, TradeDirection};
 

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -794,10 +794,17 @@ impl SolidoState {
             return None;
         }
 
+        // Fees as in the `spl_token_swap` `SwapCurve::swap` calculation.
+        let trade_fee = anker_state.pool_fees.trading_fee(rewards.0 as u128)?;
+        let owner_fee = anker_state.pool_fees.owner_trading_fee(rewards.0 as u128)?;
+
+        let total_fees = trade_fee.checked_add(owner_fee)?;
+        let rewards_minus_fees = (rewards.0 as u128).checked_sub(total_fees)?;
+
         let expected_proceeds = anker_state
             .constant_product_calculator
             .swap_without_fees(
-                rewards.0 as u128,
+                rewards_minus_fees,
                 anker_state.pool_st_sol_balance.0 as u128,
                 anker_state.pool_ust_balance.0 as u128,
                 TradeDirection::AtoB,

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -8,48 +8,47 @@ use std::io;
 use std::time::SystemTime;
 
 use anker::logic::get_one_st_sol_for_ust_price_from_pool;
-use anker::state::POOL_PRICE_MAX_SAMPLE_AGE;
-use anker::state::POOL_PRICE_MIN_SAMPLE_DISTANCE;
+use anker::state::{POOL_PRICE_MAX_SAMPLE_AGE, POOL_PRICE_MIN_SAMPLE_DISTANCE};
 use itertools::izip;
 
-use lido::processor::StakeType;
-use lido::token;
-use lido::token::Rational;
-use lido::REWARDS_WITHDRAW_AUTHORITY;
 use serde::Serialize;
-use solana_program::program_pack::Pack;
 use solana_program::{
     clock::{Clock, Slot},
     epoch_schedule::EpochSchedule,
+    program_pack::Pack,
     pubkey::Pubkey,
     rent::Rent,
     stake_history::StakeHistory,
 };
-use solana_sdk::account::ReadableAccount;
-use solana_sdk::fee_calculator::DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE;
-use solana_sdk::signer::{keypair::Keypair, Signer};
-use solana_sdk::{account::Account, instruction::Instruction};
+use solana_sdk::{
+    account::{Account, ReadableAccount},
+    fee_calculator::DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE,
+    instruction::Instruction,
+    signer::{keypair::Keypair, Signer},
+};
 use solana_vote_program::vote_state::VoteState;
-use solido_cli_common::error::MaintenanceError;
-use solido_cli_common::{snapshot::SnapshotConfig, validator_info_utils::ValidatorInfo, Result};
+use solido_cli_common::{
+    error::MaintenanceError, snapshot::SnapshotConfig, validator_info_utils::ValidatorInfo, Result,
+};
 use spl_token::state::Mint;
 
 use anker::token::MicroUst;
-use lido::token::StLamports;
-use lido::{account_map::PubkeyAndEntry, stake_account::StakeAccount, MINT_AUTHORITY};
 use lido::{
+    account_map::PubkeyAndEntry,
+    processor::StakeType,
+    stake_account::StakeAccount,
     stake_account::{deserialize_stake_account, StakeBalance},
-    util::serialize_b58,
-};
-use lido::{
     state::{Lido, Validator},
     token::Lamports,
-    MINIMUM_STAKE_ACCOUNT_BALANCE, STAKE_AUTHORITY,
+    token::Rational,
+    token::StLamports,
+    util::serialize_b58,
+    MINIMUM_STAKE_ACCOUNT_BALANCE, MINT_AUTHORITY, STAKE_AUTHORITY,
 };
+use spl_token_swap::curve::calculator::{CurveCalculator, TradeDirection};
 
 use crate::anker_state::AnkerState;
-use crate::config::PerformMaintenanceOpts;
-use crate::config::StakeTime;
+use crate::config::{PerformMaintenanceOpts, StakeTime};
 
 /// A brief description of the maintenance performed. Not relevant functionally,
 /// but helpful for automated testing, and just for info.

--- a/tests/start_test_validator.py
+++ b/tests/start_test_validator.py
@@ -21,6 +21,7 @@ test_validator = subprocess.Popen(
         'solana-test-validator',
     ],
     stdout=subprocess.DEVNULL,
+    shell=True,
 )
 
 # Wait up to 60 seconds for the validator to be running and processing blocks. We

--- a/tests/start_test_validator.py
+++ b/tests/start_test_validator.py
@@ -21,6 +21,9 @@ test_validator = subprocess.Popen(
         'solana-test-validator',
     ],
     stdout=subprocess.DEVNULL,
+    # Somehow, CI only works if `shell=True`, so this argument is left here on
+    # purpose.
+    shell=True,
 )
 
 # Wait up to 60 seconds for the validator to be running and processing blocks. We

--- a/tests/start_test_validator.py
+++ b/tests/start_test_validator.py
@@ -21,7 +21,6 @@ test_validator = subprocess.Popen(
         'solana-test-validator',
     ],
     stdout=subprocess.DEVNULL,
-    shell=True,
 )
 
 # Wait up to 60 seconds for the validator to be running and processing blocks. We

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -24,6 +24,7 @@ from util import (
     spl_token,
     spl_token_balance,
     create_spl_token_account,
+    wait_for_slots,
 )
 
 print('Creating test accounts ...')
@@ -312,6 +313,22 @@ spl_token(
 anker_show = solido('anker', 'show', '--anker-address', anker_address)
 assert anker_show['st_sol_reserve_balance_st_lamports'] == 1_000_000_000
 print('> Anker stSOL reserve now contains 1 SOL.')
+
+print('\nPerforming 5 maintenance to populate the historical prices ...')
+expected_price_update_result = {'FetchPoolPrice': {'st_sol_price_in_micro_ust': 500000}}
+for i in range(4):
+    result = perform_maintenance()
+    assert (
+        result == expected_price_update_result
+    ), f'Expected {result} to be {expected_price_update_result}'
+
+    print(f'> ({i + 1}/4) Waiting for 100 slots for the next price update ...')
+    wait_for_slots(100)
+result = perform_maintenance()
+assert (
+    result == expected_price_update_result
+), f'Expected {result} to be {expected_price_update_result}'
+
 
 print('\nPerforming maintenance to swap that stSOL for UST ...')
 result = perform_maintenance()

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -518,11 +518,11 @@ expected_result = {
     'st_sol_reserve_value_lamports': None,
     'b_sol_supply_b_lamports': 0,
     'historical_st_sol_price': [
-        {'slot': 0, 'st_sol_price_in_micro_ust': 1000000},
-        {'slot': 0, 'st_sol_price_in_micro_ust': 1000000},
-        {'slot': 0, 'st_sol_price_in_micro_ust': 1000000},
-        {'slot': 0, 'st_sol_price_in_micro_ust': 1000000},
-        {'slot': 0, 'st_sol_price_in_micro_ust': 1000000},
+        {
+            'slot': anker_show['historical_st_sol_price'][i]['slot'],
+            'st_sol_price_in_micro_ust': 500000,
+        }
+        for i in range(5)
     ],
 }
 assert anker_show == expected_result, f'Expected {anker_show} to be {expected_result}'

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -314,7 +314,7 @@ anker_show = solido('anker', 'show', '--anker-address', anker_address)
 assert anker_show['st_sol_reserve_balance_st_lamports'] == 1_000_000_000
 print('> Anker stSOL reserve now contains 1 SOL.')
 
-print('\nPerforming 5 maintenance to populate the historical prices ...')
+print('\nPerforming maintenance 5 times to populate the historical prices ...')
 expected_price_update_result = {'FetchPoolPrice': {'st_sol_price_in_micro_ust': 500000}}
 for i in range(4):
     result = perform_maintenance()

--- a/tests/util.py
+++ b/tests/util.py
@@ -322,3 +322,18 @@ def get_approve_and_execute(
         )
 
     return approve_and_execute
+
+
+def wait_for_slots(slots: int):
+    import time
+
+    """
+    Blocks waiting until `slots` slots have passed.
+    """
+    slots_beginning = int(solana('get-slot'))
+    while True:
+        # Wait 1 second to poll next slot height (around 2 slots)
+        time.sleep(1)
+        elapsed_slots = int(solana('get-slot')) - slots_beginning
+        if elapsed_slots >= slots:
+            break

--- a/tests/util.py
+++ b/tests/util.py
@@ -324,7 +324,7 @@ def get_approve_and_execute(
     return approve_and_execute
 
 
-def wait_for_slots(slots: int):
+def wait_for_slots(slots: int) -> None:
     import time
 
     """


### PR DESCRIPTION
Call `FetchPoolPrice` inside maintainer if the following conditions are met:
- current slot > 1st slot of next epoch - (`POOL_PRICE_MAX_SAMPLE_AGE + POOL_PRICE_MIN_SAMPLE_DISTANCE`) OR `rewards >= min_rewards_to_sell`
- slots elapsed from the last check > `POOL_PRICE_MIN_SAMPLE_DISTANCE`