### PR TITLE
Show Anker instruction that require multisig

### DIFF
--- a/cli/maintainer/src/commands_anker.rs
+++ b/cli/maintainer/src/commands_anker.rs
@@ -246,6 +246,9 @@ struct ShowAnkerOutput {
     #[serde(serialize_with = "serialize_b58")]
     b_sol_mint_authority: Pubkey,
 
+    #[serde(serialize_with = "serialize_b58")]
+    token_swap_pool: Pubkey,
+
     #[serde(serialize_with = "serialize_bech32")]
     terra_rewards_destination: TerraAddress,
 
@@ -354,6 +357,7 @@ fn command_show_anker(
         solido_address: anker.solido,
         solido_program_id: anker.solido_program_id,
 
+        token_swap_pool: anker.token_swap_pool,
         terra_rewards_destination: anker.terra_rewards_destination,
         sell_rewards_min_out_bps: anker.sell_rewards_min_out_bps,
 

--- a/cli/maintainer/src/commands_anker.rs
+++ b/cli/maintainer/src/commands_anker.rs
@@ -287,6 +287,7 @@ impl fmt::Display for ShowAnkerOutput {
             "Rewards destination:   {}",
             self.terra_rewards_destination
         )?;
+        writeln!(f, "Token Swap Pool:       {}", self.token_swap_pool)?;
         if self.sell_rewards_min_out_bps <= 9999 {
             writeln!(f,
                      "Sell rewards min out:  {}.{:>02}% of the expected amount ({}.{:>02}% slippage + fees)",

--- a/cli/maintainer/src/commands_multisig.rs
+++ b/cli/maintainer/src/commands_multisig.rs
@@ -461,6 +461,7 @@ enum SolidoInstruction {
     },
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Serialize)]
 enum AnkerInstruction {
     ChangeTerraRewardsDestination {
@@ -1023,7 +1024,7 @@ fn show_transaction(
             }
         }
     } else if anker_program_id == Some(instr.program_id) {
-        match try_parse_anker_instruction(config, &&instr) {
+        match try_parse_anker_instruction(config, &instr) {
             Ok(instr) => instr,
             Err(SnapshotError::MissingAccount) => return Err(SnapshotError::MissingAccount),
             Err(SnapshotError::MissingValidatorIdentity(addr)) => {

--- a/cli/maintainer/src/commands_multisig.rs
+++ b/cli/maintainer/src/commands_multisig.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use anchor_lang::prelude::{AccountMeta, ToAccountMetas};
 use anchor_lang::{Discriminator, InstructionData};
 use anker::instruction::{
-    ChangeSellRewardsMinBpsAccountsMeta, ChangeTerraRewardsDestinationAccountsMeta,
+    ChangeSellRewardsMinOutBpsAccountsMeta, ChangeTerraRewardsDestinationAccountsMeta,
     ChangeTokenSwapPoolAccountsMeta,
 };
 use anker::wormhole::TerraAddress;
@@ -488,7 +488,7 @@ enum AnkerInstruction {
         #[serde(serialize_with = "serialize_b58")]
         new_token_swap_pool: Pubkey,
     },
-    ChangeSellRewardsMinBps {
+    ChangeSellRewardsMinOutBps {
         #[serde(serialize_with = "serialize_b58")]
         anker_instance: Pubkey,
 
@@ -497,7 +497,7 @@ enum AnkerInstruction {
 
         old_sell_rewards_min_out_bps: u64,
 
-        new_sell_rewards_min_bps: u64,
+        new_sell_rewards_min_out_bps: u64,
     },
 }
 
@@ -748,11 +748,11 @@ impl fmt::Display for ShowTransactionOutput {
                     writeln!(f, "    Old Token Swap Pool: {}", old_token_swap_pool)?;
                     writeln!(f, "    New Token Swap Pool: {}", new_token_swap_pool)?;
                 }
-                AnkerInstruction::ChangeSellRewardsMinBps {
+                AnkerInstruction::ChangeSellRewardsMinOutBps {
                     anker_instance,
                     manager,
-                    old_sell_rewards_min_bps,
-                    new_sell_rewards_min_bps,
+                    old_sell_rewards_min_out_bps,
+                    new_sell_rewards_min_out_bps,
                 } => {
                     writeln!(f, "It changes the sell rewards min bps in Anker")?;
                     writeln!(f, "    Anker instance:           {}", anker_instance)?;
@@ -760,12 +760,12 @@ impl fmt::Display for ShowTransactionOutput {
                     writeln!(
                         f,
                         "    Old sell rewards min bps: {}",
-                        old_sell_rewards_min_bps
+                        old_sell_rewards_min_out_bps
                     )?;
                     writeln!(
                         f,
                         "    New sell rewards min bps: {}",
-                        new_sell_rewards_min_bps
+                        new_sell_rewards_min_out_bps
                     )?;
                 }
             },
@@ -1164,16 +1164,16 @@ fn try_parse_anker_instruction(
                 new_token_swap_pool: accounts.new_token_swap_pool,
             })
         }
-        anker::instruction::AnkerInstruction::ChangeSellRewardsMinBps {
+        anker::instruction::AnkerInstruction::ChangeSellRewardsMinOutBps {
             sell_rewards_min_out_bps,
         } => {
-            let accounts = ChangeSellRewardsMinBpsAccountsMeta::try_from_slice(&instr.accounts)?;
+            let accounts = ChangeSellRewardsMinOutBpsAccountsMeta::try_from_slice(&instr.accounts)?;
             let current_anker = config.client.get_anker(&accounts.anker)?;
-            ParsedInstruction::AnkerInstruction(AnkerInstruction::ChangeSellRewardsMinBps {
+            ParsedInstruction::AnkerInstruction(AnkerInstruction::ChangeSellRewardsMinOutBps {
                 anker_instance: accounts.anker,
                 manager: accounts.manager,
-                old_sell_rewards_min_bps: current_anker.sell_rewards_min_out_bps,
-                new_sell_rewards_min_bps: sell_rewards_min_out_bps,
+                old_sell_rewards_min_out_bps: current_anker.sell_rewards_min_out_bps,
+                new_sell_rewards_min_out_bps: sell_rewards_min_out_bps,
             })
         }
         _ => ParsedInstruction::InvalidAnkerInstruction,

--- a/cli/maintainer/src/commands_multisig.rs
+++ b/cli/maintainer/src/commands_multisig.rs
@@ -7,6 +7,11 @@ use std::str::FromStr;
 
 use anchor_lang::prelude::{AccountMeta, ToAccountMetas};
 use anchor_lang::{Discriminator, InstructionData};
+use anker::instruction::{
+    ChangeSellRewardsMinBpsAccountsMeta, ChangeTerraRewardsDestinationAccountsMeta,
+    ChangeTokenSwapPoolAccountsMeta,
+};
+use anker::wormhole::TerraAddress;
 use borsh::de::BorshDeserialize;
 use borsh::ser::BorshSerialize;
 use clap::Clap;
@@ -132,11 +137,17 @@ pub fn main(config: &mut SnapshotClientConfig, multisig_opts: MultisigOpts) {
         }
         SubCommand::ShowTransaction(cmd_opts) => {
             let result = config.with_snapshot(|config| {
+                let anker_program_id = if cmd_opts.anker_program_id() == &Pubkey::default() {
+                    None
+                } else {
+                    Some(*cmd_opts.anker_program_id())
+                };
                 show_transaction(
                     config,
                     cmd_opts.transaction_address(),
                     cmd_opts.multisig_program_id(),
                     cmd_opts.solido_program_id(),
+                    anker_program_id,
                 )
             });
             let output = result.ok_or_abort_with("Failed to read multisig.");
@@ -384,8 +395,10 @@ enum ParsedInstruction {
         new_owners: Vec<Pubkey>,
     },
     SolidoInstruction(SolidoInstruction),
+    AnkerInstruction(AnkerInstruction),
     TokenInstruction(TokenInstruction),
     InvalidSolidoInstruction,
+    InvalidAnkerInstruction,
     Unrecognized,
 }
 
@@ -445,6 +458,45 @@ enum SolidoInstruction {
         manager: Pubkey,
 
         fee_recipients: FeeRecipients,
+    },
+}
+
+#[derive(Serialize)]
+enum AnkerInstruction {
+    ChangeTerraRewardsDestination {
+        #[serde(serialize_with = "serialize_b58")]
+        anker_instance: Pubkey,
+
+        #[serde(serialize_with = "serialize_b58")]
+        manager: Pubkey,
+
+        old_terra_rewards_destination: TerraAddress,
+
+        new_terra_rewards_destination: TerraAddress,
+    },
+    ChangeTokenSwapPool {
+        #[serde(serialize_with = "serialize_b58")]
+        anker_instance: Pubkey,
+
+        #[serde(serialize_with = "serialize_b58")]
+        manager: Pubkey,
+
+        #[serde(serialize_with = "serialize_b58")]
+        old_token_swap_pool: Pubkey,
+
+        #[serde(serialize_with = "serialize_b58")]
+        new_token_swap_pool: Pubkey,
+    },
+    ChangeSellRewardsMinBps {
+        #[serde(serialize_with = "serialize_b58")]
+        anker_instance: Pubkey,
+
+        #[serde(serialize_with = "serialize_b58")]
+        manager: Pubkey,
+
+        old_sell_rewards_min_bps: u64,
+
+        new_sell_rewards_min_bps: u64,
     },
 }
 
@@ -662,6 +714,66 @@ impl fmt::Display for ShowTransactionOutput {
                     }
                 }
             }
+            ParsedInstruction::AnkerInstruction(anker_instruction) => match anker_instruction {
+                AnkerInstruction::ChangeTerraRewardsDestination {
+                    anker_instance,
+                    manager,
+                    old_terra_rewards_destination,
+                    new_terra_rewards_destination,
+                } => {
+                    writeln!(f, "It changes the Terra rewards destination in Anker")?;
+                    writeln!(f, "    Anker instance:                {}", anker_instance)?;
+                    writeln!(f, "    Manager:                       {}", manager)?;
+                    writeln!(
+                        f,
+                        "    Old Terra rewards destination: {}",
+                        old_terra_rewards_destination
+                    )?;
+                    writeln!(
+                        f,
+                        "    New Terra rewards destination: {}",
+                        new_terra_rewards_destination
+                    )?;
+                }
+                AnkerInstruction::ChangeTokenSwapPool {
+                    anker_instance,
+                    manager,
+                    old_token_swap_pool,
+                    new_token_swap_pool,
+                } => {
+                    writeln!(f, "It changes the Token Swap Pool in Anker")?;
+                    writeln!(f, "    Anker instance:      {}", anker_instance)?;
+                    writeln!(f, "    Manager:             {}", manager)?;
+                    writeln!(f, "    Old Token Swap Pool: {}", old_token_swap_pool)?;
+                    writeln!(f, "    New Token Swap Pool: {}", new_token_swap_pool)?;
+                }
+                AnkerInstruction::ChangeSellRewardsMinBps {
+                    anker_instance,
+                    manager,
+                    old_sell_rewards_min_bps,
+                    new_sell_rewards_min_bps,
+                } => {
+                    writeln!(f, "It changes the sell rewards min bps in Anker")?;
+                    writeln!(f, "    Anker instance:           {}", anker_instance)?;
+                    writeln!(f, "    Manager:                  {}", manager)?;
+                    writeln!(
+                        f,
+                        "    Old sell rewards min bps: {}",
+                        old_sell_rewards_min_bps
+                    )?;
+                    writeln!(
+                        f,
+                        "    New sell rewards min bps: {}",
+                        new_sell_rewards_min_bps
+                    )?;
+                }
+            },
+            ParsedInstruction::InvalidAnkerInstruction => {
+                writeln!(
+                    f,
+                    "  Tried to deserialize an Anker instruction, but failed."
+                )?;
+            }
         }
 
         Ok(())
@@ -811,6 +923,7 @@ fn show_transaction(
     transaction_address: &Pubkey,
     multisig_program_id: &Pubkey,
     solido_program_id: &Pubkey,
+    anker_program_id: Option<Pubkey>,
 ) -> Result<ShowTransactionOutput> {
     let transaction: serum_multisig::Transaction =
         config.client.get_account_deserialize(transaction_address)?;
@@ -907,6 +1020,19 @@ fn show_transaction(
                 println!("Warning: Failed to parse Token instruction.");
                 err.print_pretty();
                 ParsedInstruction::InvalidSolidoInstruction
+            }
+        }
+    } else if anker_program_id == Some(instr.program_id) {
+        match try_parse_anker_instruction(config, &&instr) {
+            Ok(instr) => instr,
+            Err(SnapshotError::MissingAccount) => return Err(SnapshotError::MissingAccount),
+            Err(SnapshotError::MissingValidatorIdentity(addr)) => {
+                return Err(SnapshotError::MissingValidatorIdentity(addr))
+            }
+            Err(SnapshotError::OtherError(err)) => {
+                println!("Warning: Failed to parse Anker instruction.");
+                err.print_pretty();
+                ParsedInstruction::InvalidAnkerInstruction
             }
         }
     } else {
@@ -1006,6 +1132,51 @@ fn try_parse_token_instruction(
             TokenInstruction::Unsupported,
         )),
     }
+}
+
+fn try_parse_anker_instruction(
+    config: &mut SnapshotConfig,
+    instr: &Instruction,
+) -> Result<ParsedInstruction> {
+    let instruction: anker::instruction::AnkerInstruction =
+        BorshDeserialize::deserialize(&mut instr.data.as_slice())?;
+    Ok(match instruction {
+        anker::instruction::AnkerInstruction::ChangeTerraRewardsDestination {
+            terra_rewards_destination,
+        } => {
+            let accounts =
+                ChangeTerraRewardsDestinationAccountsMeta::try_from_slice(&instr.accounts)?;
+            let current_anker = config.client.get_anker(&accounts.anker)?;
+            ParsedInstruction::AnkerInstruction(AnkerInstruction::ChangeTerraRewardsDestination {
+                anker_instance: accounts.anker,
+                manager: accounts.manager,
+                old_terra_rewards_destination: current_anker.terra_rewards_destination,
+                new_terra_rewards_destination: terra_rewards_destination,
+            })
+        }
+        anker::instruction::AnkerInstruction::ChangeTokenSwapPool => {
+            let accounts = ChangeTokenSwapPoolAccountsMeta::try_from_slice(&instr.accounts)?;
+            ParsedInstruction::AnkerInstruction(AnkerInstruction::ChangeTokenSwapPool {
+                anker_instance: accounts.anker,
+                manager: accounts.manager,
+                old_token_swap_pool: accounts.current_token_swap_pool,
+                new_token_swap_pool: accounts.new_token_swap_pool,
+            })
+        }
+        anker::instruction::AnkerInstruction::ChangeSellRewardsMinBps {
+            sell_rewards_min_out_bps,
+        } => {
+            let accounts = ChangeSellRewardsMinBpsAccountsMeta::try_from_slice(&instr.accounts)?;
+            let current_anker = config.client.get_anker(&accounts.anker)?;
+            ParsedInstruction::AnkerInstruction(AnkerInstruction::ChangeSellRewardsMinBps {
+                anker_instance: accounts.anker,
+                manager: accounts.manager,
+                old_sell_rewards_min_bps: current_anker.sell_rewards_min_out_bps,
+                new_sell_rewards_min_bps: sell_rewards_min_out_bps,
+            })
+        }
+        _ => ParsedInstruction::InvalidAnkerInstruction,
+    })
 }
 
 #[derive(Serialize)]
@@ -1333,6 +1504,7 @@ fn approve_transaction_interactive(
             transaction_address,
             opts.multisig_program_id(),
             opts.solido_program_id(),
+            None,
         )?;
         println!("{}", output);
         Ok(())

--- a/cli/maintainer/src/commands_multisig.rs
+++ b/cli/maintainer/src/commands_multisig.rs
@@ -495,7 +495,7 @@ enum AnkerInstruction {
         #[serde(serialize_with = "serialize_b58")]
         manager: Pubkey,
 
-        old_sell_rewards_min_bps: u64,
+        old_sell_rewards_min_out_bps: u64,
 
         new_sell_rewards_min_bps: u64,
     },

--- a/cli/maintainer/src/config.rs
+++ b/cli/maintainer/src/config.rs
@@ -901,7 +901,7 @@ cli_opt_struct! {
         /// New Anker's `sell_rewards_min_out_bps`.
         //
         // See also `anker create --sell-rewards-min-out-bps`.
-        #[clap(value_name = "basis points")]
+        #[clap(long, value_name = "basis points")]
         sell_rewards_min_out_bps: u64,
 
         /// Multisig instance.

--- a/cli/maintainer/src/config.rs
+++ b/cli/maintainer/src/config.rs
@@ -541,6 +541,10 @@ cli_opt_struct! {
         /// Address of the Multisig program.
         #[clap(long)]
         multisig_program_id: Pubkey,
+
+        /// Address of the Anker program.
+        #[clap(long, value_name = "address")]
+        anker_program_id: Pubkey => Pubkey::default(),
     }
 }
 

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -488,7 +488,7 @@ expected_result = {
     'reserve_authority': authorities['reserve_authority'],
     'terra_rewards_destination': new_terra_rewards_destination,
     'token_swap_pool': new_token_pool_address,
-    'sell_rewards_min_out_bps': 10,
+    'sell_rewards_min_out_bps': str(new_min_out_bps),
     'ust_reserve_balance_micro_ust': 500_000,
     'st_sol_reserve_balance_st_lamports': 1_000_000_000,
     'st_sol_reserve_value_lamports': None,

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -227,7 +227,7 @@ print(f'> Created instance at {anker_address}.')
 
 
 print('\nVerifying Anker instance with `solido anker show` ...')
-result = solido('anker', 'show', '--anker-address', anker_address)
+anker_show = solido('anker', 'show', '--anker-address', anker_address)
 
 # Check if `anker show-authorities` got it right.
 expected_result = {
@@ -248,7 +248,7 @@ expected_result = {
     'st_sol_reserve_value_lamports': None,
     'b_sol_supply_b_lamports': 0,
 }
-assert result == expected_result, f'Expected {result} to be {expected_result}'
+assert anker_show == expected_result, f'Expected {anker_show} to be {expected_result}'
 print('> Instance parameters are as expected.')
 
 
@@ -302,8 +302,8 @@ spl_token(
     st_sol_account,
 )
 
-result = solido('anker', 'show', '--anker-address', anker_address)
-assert result['st_sol_reserve_balance_st_lamports'] == 1_000_000_000
+anker_show = solido('anker', 'show', '--anker-address', anker_address)
+assert anker_show['st_sol_reserve_balance_st_lamports'] == 1_000_000_000
 print('> Anker stSOL reserve now contains 1 SOL.')
 
 print('\nPerforming maintenance to swap that stSOL for UST ...')
@@ -314,12 +314,12 @@ assert result == {
     }
 }, f'Expected SellRewards, but got {result}'
 
-result = solido('anker', 'show', '--anker-address', anker_address)
-assert result['st_sol_reserve_balance_st_lamports'] == 0
+anker_show = solido('anker', 'show', '--anker-address', anker_address)
+assert anker_show['st_sol_reserve_balance_st_lamports'] == 0
 # The pool contained 1 stSOL and 1 UST, we doubled the amount of stSOL, so to
 # keep the product constant, there is now 0.5 UST in the pool, and the other
 # 0.5 UST went to Anker.
-assert result['ust_reserve_balance_micro_ust'] == 500_000
+assert anker_show['ust_reserve_balance_micro_ust'] == 500_000
 print('> Anker stSOL reserve now contains 0.5 UST.')
 
 
@@ -385,13 +385,14 @@ st_sol_balance = spl_token_balance(st_sol_account)
 assert st_sol_balance.balance_raw == 1_000_000_000
 print(f'> stSOL balance of {st_sol_account} is now 1.0 stSOL again.')
 
-result = solido('anker', 'show', '--anker-address', anker_address)
-assert result['st_sol_reserve_balance_st_lamports'] == 1_000_000_000
-assert result['b_sol_supply_b_lamports'] == 0
+anker_show = solido('anker', 'show', '--anker-address', anker_address)
+assert anker_show['st_sol_reserve_balance_st_lamports'] == 1_000_000_000
+assert anker_show['b_sol_supply_b_lamports'] == 0
 print(f'> Anker reserve has 1 stSOL, the bSOL mint has a supply of 0 bSOL.')
 
 print('\nTesting manager functions ...')
 print('> Changing Terra rewards destination')
+new_terra_rewards_destination = 'terra14dycr8jm7e5kw88g4studekkzzw5xc5ffnp4hk'
 transaction_result = solido(
     'anker',
     'change-terra-rewards-destination',
@@ -402,7 +403,7 @@ transaction_result = solido(
     '--multisig-program-id',
     multisig_program_id,
     '--terra-rewards-destination',
-    'terra14dycr8jm7e5kw88g4studekkzzw5xc5ffnp4hk',
+    new_terra_rewards_destination,
     keypair_path=test_addrs[0].keypair_path,
 )
 transaction_address = transaction_result['transaction_address']
@@ -453,6 +454,7 @@ transaction_address = transaction_result['transaction_address']
 approve_and_execute(transaction_address)
 
 print('> Changing min out basis points')
+new_min_out_bps = anker_show['sell_rewards_min_out_bps'] + 10
 transaction_result = solido(
     'anker',
     'change-sell-rewards-min-out-bps',
@@ -463,7 +465,7 @@ transaction_result = solido(
     '--multisig-program-id',
     multisig_program_id,
     '--sell-rewards-min-out-bps',
-    '10',
+    str(new_min_out_bps),
     keypair_path=test_addrs[0].keypair_path,
 )
 transaction_address = transaction_result['transaction_address']
@@ -471,7 +473,7 @@ approve_and_execute(transaction_address)
 
 print('\nVerifying Anker instance with `solido anker show` ...')
 # See if `anker show` shows the correct output
-result = solido('anker', 'show', '--anker-address', anker_address)
+anker_show = solido('anker', 'show', '--anker-address', anker_address)
 
 # Check if `anker show-authorities` got it right.
 expected_result = {
@@ -484,7 +486,7 @@ expected_result = {
     'ust_reserve': authorities['ust_reserve_account'],
     'b_sol_mint_authority': authorities['b_sol_mint_authority'],
     'reserve_authority': authorities['reserve_authority'],
-    'terra_rewards_destination': 'terra14dycr8jm7e5kw88g4studekkzzw5xc5ffnp4hk',
+    'terra_rewards_destination': new_terra_rewards_destination,
     'token_swap_pool': new_token_pool_address,
     'sell_rewards_min_out_bps': 10,
     'ust_reserve_balance_micro_ust': 500_000,
@@ -492,5 +494,5 @@ expected_result = {
     'st_sol_reserve_value_lamports': None,
     'b_sol_supply_b_lamports': 0,
 }
-assert result == expected_result, f'Expected {result} to be {expected_result}'
+assert anker_show == expected_result, f'Expected {anker_show} to be {expected_result}'
 print('> Instance parameters are as expected.')

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -451,7 +451,7 @@ transaction_result = solido(
 transaction_address = transaction_result['transaction_address']
 approve_and_execute(transaction_address)
 
-print('> Changing Terra rewards destination')
+print('> Changing min out basis points')
 transaction_result = solido(
     'anker',
     'change-sell-rewards-min-bps',

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -241,6 +241,7 @@ expected_result = {
     'b_sol_mint_authority': authorities['b_sol_mint_authority'],
     'reserve_authority': authorities['reserve_authority'],
     'terra_rewards_destination': terra_rewards_address,
+    'token_swap_pool': token_pool_address,
     'sell_rewards_min_out_bps': 0,
     'ust_reserve_balance_micro_ust': 0,
     'st_sol_reserve_balance_st_lamports': 0,
@@ -454,7 +455,7 @@ approve_and_execute(transaction_address)
 print('> Changing min out basis points')
 transaction_result = solido(
     'anker',
-    'change-sell-rewards-min-bps',
+    'change-sell-rewards-min-out-bps',
     '--anker-address',
     anker_address,
     '--multisig-address',
@@ -467,3 +468,29 @@ transaction_result = solido(
 )
 transaction_address = transaction_result['transaction_address']
 approve_and_execute(transaction_address)
+
+print('\nVerifying Anker instance with `solido anker show` ...')
+# See if `anker show` shows the correct output
+result = solido('anker', 'show', '--anker-address', anker_address)
+
+# Check if `anker show-authorities` got it right.
+expected_result = {
+    'anker_address': authorities['anker_address'],
+    'anker_program_id': anker_program_id,
+    'solido_address': solido_address,
+    'solido_program_id': solido_program_id,
+    'b_sol_mint': b_sol_mint_address.pubkey,
+    'st_sol_reserve': authorities['st_sol_reserve_account'],
+    'ust_reserve': authorities['ust_reserve_account'],
+    'b_sol_mint_authority': authorities['b_sol_mint_authority'],
+    'reserve_authority': authorities['reserve_authority'],
+    'terra_rewards_destination': 'terra14dycr8jm7e5kw88g4studekkzzw5xc5ffnp4hk',
+    'token_swap_pool': new_token_pool_address,
+    'sell_rewards_min_out_bps': 10,
+    'ust_reserve_balance_micro_ust': 500_000,
+    'st_sol_reserve_balance_st_lamports': 1_000_000_000,
+    'st_sol_reserve_value_lamports': None,
+    'b_sol_supply_b_lamports': 0,
+}
+assert result == expected_result, f'Expected {result} to be {expected_result}'
+print('> Instance parameters are as expected.')


### PR DESCRIPTION
Show the following Anker instructions:
- ChangeTerraRewardsDestination
- ChangeTokenSwapPool
- ChangeSellRewardsMinBps

Test management functions