### PR TITLE
Add `Expires` header to query response.

### DIFF
--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -592,7 +592,7 @@ fn get_expires_header(
         now + chrono::Duration::milliseconds(ms_diff as i64)
     } else {
         // 1 year duration if the end is in the past.
-        now + chrono::Duration::days(365)
+        now + chrono::Duration::weeks(1)
     };
     Header::from_bytes(&b"Expires"[..], &expires_date.to_rfc2822()[..])
         .expect("Static header value, does not fail at runtime.")
@@ -1100,7 +1100,7 @@ mod test {
             expiration_header.field,
             HeaderField::from_str("Expires").unwrap()
         );
-        let next_year_expiration = begin_epoch_293_datetime + chrono::Duration::days(365);
+        let next_year_expiration = begin_epoch_293_datetime + chrono::Duration::weeks(1);
         assert_eq!(expiration_header.value, next_year_expiration.to_rfc2822());
     }
 

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -628,10 +628,10 @@ fn get_expires_header(
         // From the past, set expiration to 1 week from now.
         DateRequestType::Fixed => now + chrono::Duration::weeks(1),
         DateRequestType::MovingTarget => {
-            // We don't have information about the current clock, default to 1hr
-            // cache.
+            // We don't have information about the current clock, default to 5
+            // minutes cache.
             match current_clock {
-                None => now + chrono::Duration::hours(1),
+                None => now + chrono::Duration::minutes(5),
                 Some(clock) => {
                     let epoch_sched = EpochSchedule::without_warmup();
                     let first_slot_next_epoch =
@@ -659,8 +659,8 @@ fn get_expires_header(
         }
     };
 
-    // Set minimum expiration time to 1 hour.
-    let expires_date = expires_date.max(now + chrono::Duration::hours(1));
+    // Set minimum expiration time to 5 minutes.
+    let expires_date = expires_date.max(now + chrono::Duration::minutes(5));
     Header::from_bytes(&b"Expires"[..], &expires_date.to_rfc2822()[..])
         .expect("Static header value, does not fail at runtime.")
 }
@@ -1273,7 +1273,7 @@ mod test {
             HeaderField::from_str("Expires").unwrap()
         );
 
-        let expected_time = epoch_293_minus_1m_datetime + chrono::Duration::hours(1);
+        let expected_time = epoch_293_minus_1m_datetime + chrono::Duration::minutes(5);
         assert_eq!(expiration_header.value, expected_time.to_rfc2822());
     }
 }

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -699,12 +699,12 @@ fn serve_request(
             // Take the current snapshot. This only holds the lock briefly, and does
             // not prevent other threads from updating the snapshot while this request
             // handler is running.
-            let metrics = metrics_mutex.lock().unwrap().clone();
+            let snapshot = metrics_mutex.lock().unwrap().clone();
 
             // We don't even look at the request, for now we always serve the metrics.
 
             let mut out: Vec<u8> = Vec::new();
-            metrics.write_prometheus(&mut out).expect(
+            snapshot.metrics.write_prometheus(&mut out).expect(
                 "We must handle the error because of io::Write, but writing to a Vec does not fail.",
             );
 

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -1181,8 +1181,8 @@ mod test {
             expiration_header.field,
             HeaderField::from_str("Expires").unwrap()
         );
-        let next_year_expiration = begin_epoch_293_datetime + chrono::Duration::weeks(1);
-        assert_eq!(expiration_header.value, next_year_expiration.to_rfc2822());
+        let next_week_expiration = begin_epoch_293_datetime + chrono::Duration::weeks(1);
+        assert_eq!(expiration_header.value, next_week_expiration.to_rfc2822());
     }
 
     #[test]

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -640,6 +640,8 @@ fn get_expires_header(
                             / interval_prices.duration_epochs() as i32;
                         let slot_duration = epoch_duration
                             / epoch_sched.get_slots_in_epoch(interval_prices.end_epoch) as i32;
+                        // Cache until we estimate that 80% of the current epoch will be complete,
+                        // so that we don’t cache for too long if the epoch suddenly ends faster than expected.
                         now + slot_duration * (slots_diff * 8 / 10) as i32
                     } else {
                         // We can't estimate the epoch duration, use Solana's

--- a/cli/listener/src/main.rs
+++ b/cli/listener/src/main.rs
@@ -468,7 +468,7 @@ struct ResponseInterval {
 
 #[derive(Debug, PartialEq)]
 enum DateRequestType {
-    Past,
+    Fixed,
     MovingTarget,
 }
 
@@ -484,7 +484,7 @@ fn get_date_params<'a, I: IntoIterator<Item = (Cow<'a, str>, Cow<'a, str>)>>(
 ) -> Result<DateRequest, ResponseError> {
     let mut begin_vec: Vec<chrono::DateTime<chrono::Utc>> = vec![];
     let mut end_vec: Vec<chrono::DateTime<chrono::Utc>> = vec![];
-    let mut request_date_type = DateRequestType::Past;
+    let mut request_date_type = DateRequestType::Fixed;
 
     for (k, v) in query_params {
         match k.as_ref() {
@@ -497,7 +497,7 @@ fn get_date_params<'a, I: IntoIterator<Item = (Cow<'a, str>, Cow<'a, str>)>>(
                 })?;
 
                 begin_vec.push(t);
-                request_date_type = DateRequestType::Past;
+                request_date_type = DateRequestType::Fixed;
             }
             "end" => {
                 let t = parse_utc_iso8601(&v).map_err(|_| {
@@ -508,7 +508,7 @@ fn get_date_params<'a, I: IntoIterator<Item = (Cow<'a, str>, Cow<'a, str>)>>(
                 })?;
 
                 end_vec.push(t);
-                request_date_type = DateRequestType::Past;
+                request_date_type = DateRequestType::Fixed;
             }
             "days" => {
                 let days = v.parse::<i64>().map_err(|_| {
@@ -623,7 +623,7 @@ fn get_expires_header(
 ) -> Header {
     let expires_date = match date_request_type {
         // From the past, set expiration to 1 week from now.
-        DateRequestType::Past => now + chrono::Duration::weeks(1),
+        DateRequestType::Fixed => now + chrono::Duration::weeks(1),
         DateRequestType::MovingTarget => {
             // We don't have information about the current clock, default to 1hr
             // cache.
@@ -1018,7 +1018,7 @@ mod test {
             Ok(DateRequest {
                 date_range: parse_utc_iso8601("2022-02-04T11:40:02.683960+00:00").unwrap()
                     ..parse_utc_iso8601("2022-02-07T14:22:08.826526+00:00").unwrap(),
-                request_type: DateRequestType::Past
+                request_type: DateRequestType::Fixed
             })
         );
     }
@@ -1172,7 +1172,7 @@ mod test {
             begin_epoch_293_datetime,
             &interval_prices,
             Some(current_clock),
-            &DateRequestType::Past,
+            &DateRequestType::Fixed,
         );
         assert_eq!(
             expiration_header.field,


### PR DESCRIPTION
If queries are from the past, set the `Expires` header to `now` + 1 year, otherwise, if we are in the same epoch as the query's end slot, we set the `Expires` to the approximate time until the next epoch.
Closes #526