### PR TITLE
Enforce minimum distance between last price sample and `SellRewards`

### DIFF
--- a/anker/src/error.rs
+++ b/anker/src/error.rs
@@ -63,6 +63,9 @@ pub enum AnkerError {
 
     /// Value of `sell_rewards_min_out_bps` is greater than 100% (1_000_000).
     InvalidSellRewardsMinOutBps = 4016,
+
+    /// The most recent price sample is too recent, we can’t call `SellRewards` yet.
+    SellRewardsTooEarly = 4017,
 }
 
 // Just reuse the generated Debug impl for Display. It shows the variant names.

--- a/anker/src/state.rs
+++ b/anker/src/state.rs
@@ -201,7 +201,7 @@ pub struct Anker {
     /// median of the recent price samples times a factor alpha. In other words,
     /// this factor alpha is `1 - max_slippage`. Alpha is defined as
     /// `sell_rewards_min_out_bps / 1e4`. The `bps` here means "basis points".
-    /// A basis point is 0.01% = 1e-4.)
+    /// A basis point is 0.01% = 1e-4.
     pub sell_rewards_min_out_bps: u64,
 
     /// Metrics for informational purposes.

--- a/tests/test_anker.py
+++ b/tests/test_anker.py
@@ -316,19 +316,14 @@ print('> Anker stSOL reserve now contains 1 SOL.')
 
 print('\nPerforming maintenance 5 times to populate the historical prices ...')
 expected_price_update_result = {'FetchPoolPrice': {'st_sol_price_in_micro_ust': 500000}}
-for i in range(4):
+for i in range(5):
     result = perform_maintenance()
     assert (
         result == expected_price_update_result
     ), f'Expected {result} to be {expected_price_update_result}'
 
-    print(f'> ({i + 1}/4) Waiting for 100 slots for the next price update ...')
+    print(f'> ({i + 1}/5) Waiting for 100 slots for the next price update ...')
     wait_for_slots(100)
-result = perform_maintenance()
-assert (
-    result == expected_price_update_result
-), f'Expected {result} to be {expected_price_update_result}'
-
 
 print('\nPerforming maintenance to swap that stSOL for UST ...')
 result = perform_maintenance()


### PR DESCRIPTION
Addresses https://github.com/ChorusOne/solido/pull/511/files#r839805004. Without this, you can put the final fetch in the same transaction as the sale, and sandwich the final sale by sandwiching two additional fetches (so you control 3 of the 5 price samples, so you control the median). With this added check, you need to sandwich one additional fetch before you can sandwich the final sale.