### PR TITLE
Fix stack overflow in `Anker::SendRewards`

### DIFF
--- a/anker/src/processor.rs
+++ b/anker/src/processor.rs
@@ -563,7 +563,7 @@ fn process_send_rewards(
     accounts_raw: &[AccountInfo],
     wormhole_nonce: u32,
 ) -> ProgramResult {
-    let accounts = SendRewardsAccountsInfo::try_from_slice(accounts_raw)?;
+    let accounts = Box::new(SendRewardsAccountsInfo::try_from_slice(accounts_raw)?);
     let anker = deserialize_anker(program_id, accounts.anker, accounts.solido)?.1;
     anker.check_ust_reserve_address(
         program_id,
@@ -622,11 +622,11 @@ fn process_send_rewards(
         )?;
     }
 
-    let payload = crate::wormhole::Payload::new(
+    let payload = Box::new(crate::wormhole::Payload::new(
         wormhole_nonce,
         reserve_ust_amount,
         anker.terra_rewards_destination.to_foreign(),
-    );
+    ));
 
     // For the order and meaning of the accounts, see also
     // https://github.com/certusone/wormhole/blob/537d56b37aa041a585f2c90515fa3a7ffa5898b5/solana/modules/token_bridge/program/src/instructions.rs#L328-L390.

--- a/anker/tests/tests/mod.rs
+++ b/anker/tests/tests/mod.rs
@@ -8,4 +8,5 @@ pub mod deposit;
 pub mod fetch_pool_price;
 pub mod manager;
 pub mod sell_rewards;
+pub mod send_rewards;
 pub mod withdraw;

--- a/anker/tests/tests/sell_rewards.rs
+++ b/anker/tests/tests/sell_rewards.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Chorus One AG
+// SPDX-License-Identifier: GPL-3.0
+
 use anker::{
     error::AnkerError,
     state::{POOL_PRICE_MIN_SAMPLE_DISTANCE, POOL_PRICE_NUM_SAMPLES},

--- a/anker/tests/tests/send_rewards.rs
+++ b/anker/tests/tests/send_rewards.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2022 Chorus One AG
+// SPDX-License-Identifier: GPL-3.0
+
+use solana_program::instruction::InstructionError;
+use std::mem;
+
+use solana_program::pubkey::Pubkey;
+use solana_program_test::tokio;
+use solana_sdk::transaction::TransactionError;
+use solana_sdk::transport::TransportError;
+
+use anker::{
+    error::AnkerError,
+    state::{POOL_PRICE_MIN_SAMPLE_DISTANCE, POOL_PRICE_NUM_SAMPLES},
+    token::MicroUst,
+};
+use lido::token::{Lamports, StLamports};
+use testlib::{anker_context::Context, assert_solido_error};
+
+const DEPOSIT_AMOUNT: u64 = 1_000_000_000; // 1e9 units
+
+#[tokio::test]
+async fn test_send_rewards_does_not_overflow_stack() {
+    let mut context = Context::new().await;
+    context
+        .initialize_token_pool_and_deposit(Lamports(DEPOSIT_AMOUNT))
+        .await;
+    context.fill_historical_st_sol_price_array().await;
+    context.sell_rewards().await;
+
+    let result = context.try_send_rewards().await;
+
+    match result {
+        Err(TransportError::TransactionError(TransactionError::InstructionError(
+            0,
+            InstructionError::ProgramFailedToComplete,
+        ))) => panic!("Did the program overflow the stack?"),
+        Ok(()) => panic!("This should not have passed without the Wormhole program present."),
+        Err(err) => {
+            println!("Unexpected error: {:?}", err);
+        } // TODO: Add a case for the expected error after resolving the stack overflow.
+    }
+}

--- a/anker/tests/tests/send_rewards.rs
+++ b/anker/tests/tests/send_rewards.rs
@@ -2,20 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
 use solana_program::instruction::InstructionError;
-use std::mem;
-
-use solana_program::pubkey::Pubkey;
 use solana_program_test::tokio;
 use solana_sdk::transaction::TransactionError;
 use solana_sdk::transport::TransportError;
 
-use anker::{
-    error::AnkerError,
-    state::{POOL_PRICE_MIN_SAMPLE_DISTANCE, POOL_PRICE_NUM_SAMPLES},
-    token::MicroUst,
-};
-use lido::token::{Lamports, StLamports};
-use testlib::{anker_context::Context, assert_solido_error};
+use lido::token::Lamports;
+use testlib::anker_context::Context;
 
 const DEPOSIT_AMOUNT: u64 = 1_000_000_000; // 1e9 units
 
@@ -31,13 +23,27 @@ async fn test_send_rewards_does_not_overflow_stack() {
     let result = context.try_send_rewards().await;
 
     match result {
+        // An access violation caused by a stack overflow results in this error.
         Err(TransportError::TransactionError(TransactionError::InstructionError(
             0,
             InstructionError::ProgramFailedToComplete,
-        ))) => panic!("Did the program overflow the stack?"),
+        ))) => {
+            panic!("Did the program overflow the stack?")
+        }
+        Err(TransportError::TransactionError(TransactionError::InstructionError(
+            0,
+            InstructionError::AccountNotExecutable,
+        ))) => {
+            // This error is expected, we try to call a dummy address where the
+            // Wormhole program is supposed to live, but that dummy address is
+            // not executable. If we get here, it means we executed the entire
+            // `SendRewards` instruction aside from the final call to the
+            // Wormhole progrma. In particular we know that we didn't overflow
+            // the stack.
+        }
         Ok(()) => panic!("This should not have passed without the Wormhole program present."),
         Err(err) => {
-            println!("Unexpected error: {:?}", err);
-        } // TODO: Add a case for the expected error after resolving the stack overflow.
+            panic!("Unexpected error: {:?}", err);
+        }
     }
 }


### PR DESCRIPTION
## Problem

Currently, our maintainer is failing to call `SendRewards` on mainnet:

```
Error while performing maintenance.
Solana RPC client returned an error:

  Request:    Some(SendTransaction)
  Kind:       RPC response error
  Error code: -32002
  Message:    Transaction simulation failed: Error processing Instruction 0: Program failed to complete
  Reason:     Transaction preflight failure
  Error:     

    Raw:      InstructionError(0, ProgramFailedToComplete)
    Display:  Error processing Instruction 0: Program failed to complete


  Logs:      

    Program BNVB8pd4coHpY7MVcrtiHLCLst7fyDGzMtPmfJqFAhwj invoke [1]
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
    Program log: Instruction: Approve
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 2026 of 153383 compute units
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
    Program BNVB8pd4coHpY7MVcrtiHLCLst7fyDGzMtPmfJqFAhwj consumed 52383 of 200000 compute units
    Program failed to complete: Access violation in stack frame 3 at address 0x200003fe8 of size 8 by instruction #19763
    Program BNVB8pd4coHpY7MVcrtiHLCLst7fyDGzMtPmfJqFAhwj failed: Program failed to complete
```

We saw this access violation before, it is caused by a stack overflow. We ran into this in `SendRewards` previously and we already optimized it to reduce stack usage, but I suspect the late addition of some metrics increased the size of the Anker struct which pushed it over the edge again.

## Changes

* Add a test that reproduces the stack overflow and fails in case it happens. The test calls `SendRewards` which will fail either way in our test context because we don’t have the Wormhole program and all its dependent accounts available there. (Setting up a token swap instance was hard enough, I don’t think it is feasible to get a working Wormhole instance in the test context.) But we can tell apart the failure due to stack overflow from the failure due to trying to call a non-existing program.
* Make the test pass by boxing a few more things to free up stack space.