### PR TITLE
Stop calling `Anker::SendRewards` in maintainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.3.3
+
+Released 2022-07-08.
+
+The on-chain Solido program remains functionally unchanged since v1.0.0. The
+Anker program remains unchanged since v1.3.0.
+
+Changes:
+
+* Do not try to call `Anker::SendRewards` from the maintenance daemon.
+
 ## v1.3.2
 
 Released 2022-05-04.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "anker"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "bech32",
  "borsh 0.9.1",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "lido"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "bincode",
  "borsh 0.9.1",
@@ -1963,7 +1963,7 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "listener"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "solido-cli"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anchor-lang",
  "anker",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "solido-cli-common"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anchor-lang",
  "anker",

--- a/anker/Cargo.toml
+++ b/anker/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chorus One <techops@chorus.one>"]
 license = "GPL-3.0"
 edition = "2018"
 name = "anker"
-version = "1.3.2"
+version = "1.3.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cli/common/Cargo.toml
+++ b/cli/common/Cargo.toml
@@ -4,7 +4,7 @@ description = "Solido common client implementation"
 license = "GPL-3.0"
 edition = "2018"
 name = "solido-cli-common"
-version = "1.3.2"
+version = "1.3.3"
 
 [dependencies]
 anchor-lang = "0.13.2"

--- a/cli/listener/Cargo.toml
+++ b/cli/listener/Cargo.toml
@@ -4,7 +4,7 @@ description = "Solido utility for indexing price data"
 license = "GPL-3.0"
 edition = "2018"
 name = "listener"
-version = "1.3.2"
+version = "1.3.3"
 
 [dependencies]
 rusqlite = "0.26.3"

--- a/cli/listener/fuzz/Cargo.lock
+++ b/cli/listener/fuzz/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "anker"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "bech32",
  "borsh 0.9.3",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "lido"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "borsh 0.9.3",
  "num-derive",
@@ -1847,7 +1847,7 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "listener"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "chrono",
  "clap 3.1.6",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "solido-cli-common"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anchor-lang",
  "anker",

--- a/cli/maintainer/Cargo.toml
+++ b/cli/maintainer/Cargo.toml
@@ -4,7 +4,7 @@ description = "Solido Command-line Utility"
 license = "GPL-3.0"
 edition = "2018"
 name = "solido-cli"
-version = "1.3.2"
+version = "1.3.3"
 
 [dependencies]
 anchor-lang = "0.13.2"

--- a/cli/maintainer/src/anker_state.rs
+++ b/cli/maintainer/src/anker_state.rs
@@ -11,8 +11,6 @@ use lido::{state::Lido, token::StLamports};
 use solana_program::{instruction::Instruction, program_pack::Pack};
 use solana_sdk::account::ReadableAccount;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signer::keypair::Keypair;
-use solana_sdk::signer::Signer;
 use solido_cli_common::{
     error::{Error, SerializationError},
     snapshot::SnapshotConfig,
@@ -165,73 +163,5 @@ impl AnkerState {
                 token_swap_program_id: self.token_swap_program_id,
             },
         )
-    }
-
-    /// Build the instruction to send rewards through Wormhole.
-    ///
-    /// Returns the instruction and one additional signer.
-    pub fn get_send_rewards_instruction(
-        &self,
-        solido_address: Pubkey,
-        maintainer_address: Pubkey,
-        wormhole_nonce: u32,
-    ) -> (Instruction, Keypair) {
-        // In our test transaction [1], before the call to Wormhole,
-        // there is a transfer of 0.000_000_010 SOL to _some_ account ... but
-        // then the Wormhole call also transfers that amount. So it seems the
-        // first one is a kind of tip? Can we skip it?
-        // TODO(#489): // Also, we shouldn't transfer out of an account which may have more
-        // balance than we need to spend, because Wormhole may steal it.
-        // [1]: https://explorer.solana.com/tx/5tSRA1CYLd51sjf7Dd2ZRkLspcqiR8NH51oTd3K34sNc3PZG9uF7euE2AHE95KurrcfKYf2sCQqsEbSRmzQq8oDg?cluster=devnet
-        let (anker_instance, _anker_bump_seed) =
-            find_instance_address(&self.anker_program_id, &solido_address);
-
-        let (ust_reserve_account, _ust_reserve_bump_seed) =
-            find_ust_reserve_account(&self.anker_program_id, &anker_instance);
-
-        let (reserve_authority, _reserve_authority_bump_seed) =
-            find_reserve_authority(&self.anker_program_id, &anker_instance);
-
-        // Wormhole requires allocating a new "message" account for every
-        // Wormhole transaction.
-        let message = Keypair::new();
-
-        // The maintainer who is submitting this transaction pays for the Wormhole fees.
-        let payer = maintainer_address;
-
-        let transfer_args = anker::wormhole::WormholeTransferArgs::new(
-            self.anker.wormhole_parameters.token_bridge_program_id,
-            self.anker.wormhole_parameters.core_bridge_program_id,
-            self.ust_mint,
-            payer,
-            ust_reserve_account,
-            reserve_authority,
-            message.pubkey(),
-        );
-
-        let instruction = anker::instruction::send_rewards(
-            &self.anker_program_id,
-            &anker::instruction::SendRewardsAccountsMeta {
-                anker: anker_instance,
-                solido: solido_address,
-                reserve_authority,
-                wormhole_token_bridge_program_id: transfer_args.token_bridge_program_id,
-                wormhole_core_bridge_program_id: transfer_args.core_bridge_program_id,
-                payer: transfer_args.payer,
-                config_key: transfer_args.config_key,
-                ust_reserve_account,
-                wrapped_meta_key: transfer_args.wrapped_meta_key,
-                ust_mint: self.ust_mint,
-                authority_signer_key: transfer_args.authority_signer_key,
-                bridge_config: transfer_args.bridge_config,
-                message: message.pubkey(),
-                emitter_key: transfer_args.emitter_key,
-                sequence_key: transfer_args.sequence_key,
-                fee_collector_key: transfer_args.fee_collector_key,
-            },
-            wormhole_nonce,
-        );
-
-        (instruction, message)
     }
 }

--- a/cli/maintainer/src/daemon.rs
+++ b/cli/maintainer/src/daemon.rs
@@ -69,9 +69,6 @@ struct MaintenanceMetrics {
     /// Number of times we performed `SellRewards` on the Anker instance.
     transactions_sell_rewards: u64,
 
-    /// Number of times we performed `SendRewards` on the Anker instance.
-    transactions_send_rewards: u64,
-
     /// Number of times we performed `FetchPoolPrice` on the Anker instance.
     transactions_fetch_pool_price: u64,
 }
@@ -122,8 +119,6 @@ impl MaintenanceMetrics {
                         .with_label("operation", "UnstakeFromActiveValidator".to_string()),
                     Metric::new(self.transactions_sell_rewards)
                         .with_label("operation", "SellRewards".to_string()),
-                    Metric::new(self.transactions_send_rewards)
-                        .with_label("operation", "SendRewards".to_string()),
                     Metric::new(self.transactions_fetch_pool_price)
                         .with_label("operation", "FetchPoolPrice".to_string()),
                 ],
@@ -159,7 +154,6 @@ impl MaintenanceMetrics {
                 self.transactions_unstake_from_active_validator += 1
             }
             MaintenanceOutput::SellRewards { .. } => self.transactions_sell_rewards += 1,
-            MaintenanceOutput::SendRewards { .. } => self.transactions_send_rewards += 1,
             MaintenanceOutput::FetchPoolPrice { .. } => self.transactions_fetch_pool_price += 1,
         }
     }
@@ -324,7 +318,6 @@ impl<'a, 'b> Daemon<'a, 'b> {
             transactions_remove_validator: 0,
             transactions_unstake_from_active_validator: 0,
             transactions_sell_rewards: 0,
-            transactions_send_rewards: 0,
             transactions_fetch_pool_price: 0,
         };
         Daemon {

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -127,10 +127,6 @@ pub enum MaintenanceOutput {
         #[serde(rename = "st_sol_amount_st_lamports")]
         st_sol_amount: StLamports,
     },
-    SendRewards {
-        #[serde(rename = "ust_amount_micro_ust")]
-        ust_amount: MicroUst,
-    },
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -258,10 +254,6 @@ impl fmt::Display for MaintenanceOutput {
             MaintenanceOutput::SellRewards { st_sol_amount } => {
                 writeln!(f, "Sell stSOL rewards")?;
                 writeln!(f, "  Amount:               {}", st_sol_amount)?;
-            }
-            MaintenanceOutput::SendRewards { ust_amount } => {
-                writeln!(f, "Sent Anker UST rewards through Wormhole.")?;
-                writeln!(f, "  Amount: {}", ust_amount)?;
             }
             MaintenanceOutput::FetchPoolPrice {
                 expected_st_sol_price_in_ust,
@@ -870,41 +862,6 @@ impl SolidoState {
                 },
             ))
         }
-    }
-
-    pub fn try_send_anker_rewards(&self) -> Option<MaintenanceInstruction> {
-        let anker_state = self.anker_state.as_ref()?;
-
-        // If there are no rewards to send, or if there are some, but it's less
-        // than 10 cent, then don't send the rewards, because the transaction
-        // cost would be significant with respect to the amount we send.
-        if anker_state.ust_reserve_balance < MicroUst(100_000) {
-            return None;
-        }
-
-        // Use the low 32 bits of the current slot as the nonce. This ensures
-        // that we don't repeat the nonce for at least 2^32 slots, which is 327
-        // years even if the block times were 100ms, but in practice block times
-        // are 600-700ms, so it’s even longer. Do we never send multiple
-        // transactions based on the same slot though? If we do, then the state
-        // we observe should also be identical, and only one of the transactions
-        // should succeed.
-        let wormhole_nonce = (self.clock.slot & 0xffff_ffff) as u32;
-
-        let (instruction, additional_signer) = anker_state.get_send_rewards_instruction(
-            self.solido_address,
-            self.maintainer_address,
-            wormhole_nonce,
-        );
-
-        let ust_amount = anker_state.ust_reserve_balance;
-        let output = MaintenanceOutput::SendRewards { ust_amount };
-        let mut maintenance_instruction = MaintenanceInstruction::new(instruction, output);
-        maintenance_instruction
-            .additional_signers
-            .push(additional_signer);
-
-        Some(maintenance_instruction)
     }
 
     /// Get an instruction to merge accounts.
@@ -1714,8 +1671,7 @@ pub fn try_perform_maintenance(
         .or_else(|| state.try_unstake_from_active_validators())
         .or_else(|| state.try_claim_validator_fee())
         .or_else(|| state.try_remove_validator())
-        .or_else(|| state.try_sell_anker_rewards())
-        .or_else(|| state.try_send_anker_rewards());
+        .or_else(|| state.try_sell_anker_rewards());
 
     match instruction_output {
         Some(maintenance_instruction) => {

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chorus One <techops@chorus.one>"]
 license = "GPL-3.0"
 edition = "2018"
 name = "lido"
-version = "1.3.2"
+version = "1.3.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The maintenance daemons are still trying to call `Anker::SendRewards`, and generating an error most of their duty time. It’s not really harmful, but it would be nice if they didn’t error so we can see when there is actually a problem.

We can make this a small 1.3.3 release just for the maintainer daemon, independent of the v2 stuff that @kkonevets is working on. Nobody is required to update, but I would like to update ours.