### PR TITLE
Improve validator name sanitizer

### DIFF
--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -420,6 +420,8 @@ fn sanitize_validator_name(name: &str) -> String {
     // adds no information, strip it here to leave more space for graphs in
     // dashboards, and not waste so much space on the redundant part of the name.
     match name.strip_prefix("Lido / ") {
+        // Negated range.contains syntax only makes things more cryptic below.
+        #[allow(clippy::manual_range_contains)]
         // I don't want distracting emojis in my Grafana dashboards.
         Some(suffix) => suffix
             .chars()

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -420,13 +420,22 @@ fn sanitize_validator_name(name: &str) -> String {
     // adds no information, strip it here to leave more space for graphs in
     // dashboards, and not waste so much space on the redundant part of the name.
     match name.strip_prefix("Lido / ") {
-        // I don't want distracting emojis in my Grafana dashboards, so remove
-        // code points in the Supplementary Multilingual Plane and beyond. This
-        // strips emojis and dingbats while leaving letters and punctuation of
-        // all contemporary languages.
+        // I don't want distracting emojis in my Grafana dashboards.
         Some(suffix) => suffix
             .chars()
-            .filter(|&ch| ch < '\u{10000}')
+            .filter(|&ch|
+                // Remove code points in the Supplementary Multilingual Plane and
+                // beyond. This strips most emojis and dingbats while leaving
+                // letters and punctuation of all contemporary languages.
+                ch < '\u{10000}'
+                // Remove variation selectors. These can be used to make code
+                // points that are traditionally not emoji, render as emoji.
+                && (ch < '\u{fe00}' || ch > '\u{fe0f}')
+                // Remove code points from the Miscellaneous Symbols block,
+                // which contains dingbats that predate emoji, but nowadays
+                // are usually rendered with colored emoji font instead of an
+                // outline glyph.
+                && (ch < '\u{2600}' || ch > '\u{26ff}'))
             .collect::<String>()
             .trim()
             .to_string(),


### PR DESCRIPTION
One of the validators in the last onboarding wave has U+26A1 HIGH VOLTAGE SIGN and U+FE0F VARIATION SELECTOR-16 in its name. In my terminal and also in Grafana in my browser, these render as a lightning bolt using an emoji font.

Also, due to the way we render labels when rendering the metrics, the variation selector turns into the literal text "\u{fe0f}" (so a
backslash and hex between curly brackets, not an U+FE0F itself).

Strip code points from both blocks to fix this.