### PR TITLE
Pass empty seeds when withdrawing

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -944,7 +944,7 @@ pub fn process_withdraw(
             stake_program: accounts.stake_program,
         },
         sol_to_withdraw,
-        &[&[]],
+        &[],
     )?;
 
     // Give control of the stake to the user.


### PR DESCRIPTION
`process_withdraw` was failing on recent tests, we passed a slice of one element before `&[&[]]` to `invoke_signed`, probably Solido was trying to call a signed instruction with the empty slice as a bump seed, in fact we should have passed an empty slice `&[]` so it just ignores it. `invoke` calls `inkove_signed` with an empty slice.